### PR TITLE
hashCode method for Asset classes

### DIFF
--- a/src/main/java/org/stellar/sdk/AssetTypeCreditAlphaNum.java
+++ b/src/main/java/org/stellar/sdk/AssetTypeCreditAlphaNum.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import java.util.Arrays;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -11,22 +13,29 @@ public abstract class AssetTypeCreditAlphaNum extends Asset {
     protected final KeyPair mIssuer;
 
     public AssetTypeCreditAlphaNum(String code, KeyPair issuer) {
-        mCode = checkNotNull(code, "code cannot be null");
-        mIssuer = checkNotNull(issuer, "issuer cannot be null");
+        checkNotNull(code, "code cannot be null");
+        checkNotNull(issuer, "issuer cannot be null");
+        mCode = new String(code);
+        mIssuer = KeyPair.fromAccountId(issuer.getAccountId());
     }
 
     /**
      * Returns asset code
      */
     public String getCode() {
-        return mCode;
+        return new String(mCode);
     }
 
     /**
      * Returns asset issuer
      */
     public KeyPair getIssuer() {
-        return mIssuer;
+        return KeyPair.fromAccountId(mIssuer.getAccountId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(new Object[]{this.getCode(), this.getIssuer().getAccountId()});
     }
 
     @Override

--- a/src/main/java/org/stellar/sdk/AssetTypeCreditAlphaNum12.java
+++ b/src/main/java/org/stellar/sdk/AssetTypeCreditAlphaNum12.java
@@ -7,7 +7,7 @@ import org.stellar.sdk.xdr.AssetType;
  * Represents all assets with codes 5-12 characters long.
  * @see <a href="https://www.stellar.org/developers/learn/concepts/assets.html" target="_blank">Assets</a>
  */
-public class AssetTypeCreditAlphaNum12 extends AssetTypeCreditAlphaNum {
+public final class AssetTypeCreditAlphaNum12 extends AssetTypeCreditAlphaNum {
 
   /**
    * Class constructor

--- a/src/main/java/org/stellar/sdk/AssetTypeCreditAlphaNum4.java
+++ b/src/main/java/org/stellar/sdk/AssetTypeCreditAlphaNum4.java
@@ -7,7 +7,7 @@ import org.stellar.sdk.xdr.AssetType;
  * Represents all assets with codes 1-4 characters long.
  * @see <a href="https://www.stellar.org/developers/learn/concepts/assets.html" target="_blank">Assets</a>
  */
-public class AssetTypeCreditAlphaNum4 extends AssetTypeCreditAlphaNum {
+public final class AssetTypeCreditAlphaNum4 extends AssetTypeCreditAlphaNum {
 
   /**
    * Class constructor

--- a/src/main/java/org/stellar/sdk/AssetTypeNative.java
+++ b/src/main/java/org/stellar/sdk/AssetTypeNative.java
@@ -6,7 +6,7 @@ import org.stellar.sdk.xdr.AssetType;
  * Represents Stellar native asset - <a href="https://www.stellar.org/developers/learn/concepts/assets.html" target="_blank">lumens (XLM)</a>
  * @see <a href="https://www.stellar.org/developers/learn/concepts/assets.html" target="_blank">Assets</a>
  */
-public class AssetTypeNative extends Asset {
+public final class AssetTypeNative extends Asset {
 
   public AssetTypeNative() {}
 
@@ -18,6 +18,11 @@ public class AssetTypeNative extends Asset {
   @Override
   public boolean equals(Object object) {
     return this.getClass().equals(object.getClass());
+  }
+
+  @Override
+  public int hashCode() {
+    return 0;
   }
 
   @Override

--- a/src/test/java/org/stellar/sdk/AssetTest.java
+++ b/src/test/java/org/stellar/sdk/AssetTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -39,6 +40,27 @@ public class AssetTest {
     AssetTypeCreditAlphaNum12 parsedAsset = (AssetTypeCreditAlphaNum12) Asset.fromXdr(xdr);
     assertEquals(code, asset.getCode());
     assertEquals(issuer.getAccountId(), parsedAsset.getIssuer().getAccountId());
+  }
+
+  @Test
+  public void testHashCode() {
+    KeyPair issuer1 = KeyPair.random();
+    KeyPair issuer2 = KeyPair.random();
+
+    // Equal
+    assertEquals(new AssetTypeNative().hashCode(), new AssetTypeNative().hashCode());
+    assertEquals(new AssetTypeCreditAlphaNum4("USD", issuer1).hashCode(), new AssetTypeCreditAlphaNum4("USD", issuer1).hashCode());
+    assertEquals(new AssetTypeCreditAlphaNum12("ABCDE", issuer1).hashCode(), new AssetTypeCreditAlphaNum12("ABCDE", issuer1).hashCode());
+
+    // Not equal
+    assertNotEquals(new AssetTypeNative().hashCode(), new AssetTypeCreditAlphaNum4("USD", issuer1).hashCode());
+    assertNotEquals(new AssetTypeNative().hashCode(), new AssetTypeCreditAlphaNum12("ABCDE", issuer1).hashCode());
+    assertNotEquals(new AssetTypeCreditAlphaNum4("EUR", issuer1).hashCode(), new AssetTypeCreditAlphaNum4("USD", issuer1).hashCode());
+    assertNotEquals(new AssetTypeCreditAlphaNum4("EUR", issuer1).hashCode(), new AssetTypeCreditAlphaNum4("EUR", issuer2).hashCode());
+    assertNotEquals(new AssetTypeCreditAlphaNum4("EUR", issuer1).hashCode(), new AssetTypeCreditAlphaNum12("EUROPE", issuer1).hashCode());
+    assertNotEquals(new AssetTypeCreditAlphaNum4("EUR", issuer1).hashCode(), new AssetTypeCreditAlphaNum12("EUROPE", issuer2).hashCode());
+    assertNotEquals(new AssetTypeCreditAlphaNum12("ABCDE", issuer1).hashCode(), new AssetTypeCreditAlphaNum12("EDCBA", issuer1).hashCode());
+    assertNotEquals(new AssetTypeCreditAlphaNum12("ABCDE", issuer1).hashCode(), new AssetTypeCreditAlphaNum12("ABCDE", issuer2).hashCode());
   }
 
   @Test


### PR DESCRIPTION
This PR also makes `AssetTypeNative`, `AssetTypeCreditAlphaNum4` and `AssetTypeCreditAlphaNum12` classes immutable.

Close #23.