### PR TITLE
Add rate limiting data to responses

### DIFF
--- a/src/main/java/org/stellar/sdk/requests/AccountsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/AccountsRequestBuilder.java
@@ -52,6 +52,7 @@ public class AccountsRequestBuilder extends RequestBuilder {
    * Requests specific <code>uri</code> and returns {@link Page} of {@link AccountResponse}.
    * This method is helpful for getting the next set of results.
    * @return {@link Page} of {@link AccountResponse}
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
   public static Page<AccountResponse> execute(URI uri) throws IOException {
@@ -90,6 +91,7 @@ public class AccountsRequestBuilder extends RequestBuilder {
   /**
    * Build and execute request. <strong>Warning!</strong> {@link AccountResponse}s in {@link Page} will contain only <code>keypair</code> field.
    * @return {@link Page} of {@link AccountResponse}
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
   public Page<AccountResponse> execute() throws IOException {

--- a/src/main/java/org/stellar/sdk/requests/AccountsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/AccountsRequestBuilder.java
@@ -55,7 +55,7 @@ public class AccountsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<AccountResponse> execute(URI uri) throws IOException {
+  public static Page<AccountResponse> execute(URI uri) throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<AccountResponse>>() {};
     ResponseHandler<Page<AccountResponse>> responseHandler = new ResponseHandler<Page<AccountResponse>>(type);
     return (Page<AccountResponse>) Request.Get(uri).execute().handleResponse(responseHandler);
@@ -94,7 +94,7 @@ public class AccountsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public Page<AccountResponse> execute() throws IOException {
+  public Page<AccountResponse> execute() throws IOException, TooManyRequestsException {
     return this.execute(this.buildUri());
   }
 

--- a/src/main/java/org/stellar/sdk/requests/EffectsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/EffectsRequestBuilder.java
@@ -74,6 +74,7 @@ public class EffectsRequestBuilder extends RequestBuilder {
    * Requests specific <code>uri</code> and returns {@link Page} of {@link EffectResponse}.
    * This method is helpful for getting the next set of results.
    * @return {@link Page} of {@link EffectResponse}
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
   public static Page<EffectResponse> execute(URI uri) throws IOException {
@@ -112,6 +113,7 @@ public class EffectsRequestBuilder extends RequestBuilder {
   /**
    * Build and execute request.
    * @return {@link Page} of {@link EffectResponse}
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
   public Page<EffectResponse> execute() throws IOException {

--- a/src/main/java/org/stellar/sdk/requests/EffectsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/EffectsRequestBuilder.java
@@ -77,7 +77,7 @@ public class EffectsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<EffectResponse> execute(URI uri) throws IOException {
+  public static Page<EffectResponse> execute(URI uri) throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<EffectResponse>>() {};
     ResponseHandler<Page<EffectResponse>> responseHandler = new ResponseHandler<Page<EffectResponse>>(type);
     return (Page<EffectResponse>) Request.Get(uri).execute().handleResponse(responseHandler);
@@ -116,7 +116,7 @@ public class EffectsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public Page<EffectResponse> execute() throws IOException {
+  public Page<EffectResponse> execute() throws IOException, TooManyRequestsException {
     return this.execute(this.buildUri());
   }
 

--- a/src/main/java/org/stellar/sdk/requests/LedgersRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/LedgersRequestBuilder.java
@@ -51,6 +51,7 @@ public class LedgersRequestBuilder extends RequestBuilder {
    * Requests specific <code>uri</code> and returns {@link Page} of {@link LedgerResponse}.
    * This method is helpful for getting the next set of results.
    * @return {@link Page} of {@link LedgerResponse}
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
   public static Page<LedgerResponse> execute(URI uri) throws IOException {
@@ -89,6 +90,7 @@ public class LedgersRequestBuilder extends RequestBuilder {
   /**
    * Build and execute request.
    * @return {@link Page} of {@link LedgerResponse}
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
   public Page<LedgerResponse> execute() throws IOException {

--- a/src/main/java/org/stellar/sdk/requests/LedgersRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/LedgersRequestBuilder.java
@@ -54,7 +54,7 @@ public class LedgersRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<LedgerResponse> execute(URI uri) throws IOException {
+  public static Page<LedgerResponse> execute(URI uri) throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<LedgerResponse>>() {};
     ResponseHandler<Page<LedgerResponse>> responseHandler = new ResponseHandler<Page<LedgerResponse>>(type);
     return (Page<LedgerResponse>) Request.Get(uri).execute().handleResponse(responseHandler);
@@ -93,7 +93,7 @@ public class LedgersRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public Page<LedgerResponse> execute() throws IOException {
+  public Page<LedgerResponse> execute() throws IOException, TooManyRequestsException {
     return this.execute(this.buildUri());
   }
 

--- a/src/main/java/org/stellar/sdk/requests/OperationsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/OperationsRequestBuilder.java
@@ -78,6 +78,7 @@ public class OperationsRequestBuilder extends RequestBuilder {
    * Requests specific <code>uri</code> and returns {@link Page} of {@link OperationResponse}.
    * This method is helpful for getting the next set of results.
    * @return {@link Page} of {@link OperationResponse}
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
   public static Page<OperationResponse> execute(URI uri) throws IOException {
@@ -89,6 +90,7 @@ public class OperationsRequestBuilder extends RequestBuilder {
   /**
    * Build and execute request.
    * @return {@link Page} of {@link OperationResponse}
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
   public Page<OperationResponse> execute() throws IOException {

--- a/src/main/java/org/stellar/sdk/requests/OperationsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/OperationsRequestBuilder.java
@@ -81,7 +81,7 @@ public class OperationsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<OperationResponse> execute(URI uri) throws IOException {
+  public static Page<OperationResponse> execute(URI uri) throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<OperationResponse>>() {};
     ResponseHandler<Page<OperationResponse>> responseHandler = new ResponseHandler<Page<OperationResponse>>(type);
     return (Page<OperationResponse>) Request.Get(uri).execute().handleResponse(responseHandler);
@@ -93,7 +93,7 @@ public class OperationsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public Page<OperationResponse> execute() throws IOException {
+  public Page<OperationResponse> execute() throws IOException, TooManyRequestsException {
     return this.execute(this.buildUri());
   }
 

--- a/src/main/java/org/stellar/sdk/requests/PathsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/PathsRequestBuilder.java
@@ -45,12 +45,20 @@ public class PathsRequestBuilder extends RequestBuilder {
     return this;
   }
 
+  /**
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
+   * @throws IOException
+   */
   public static Page<PathResponse> execute(URI uri) throws IOException {
     TypeToken type = new TypeToken<Page<PathResponse>>() {};
     ResponseHandler<Page<PathResponse>> responseHandler = new ResponseHandler<Page<PathResponse>>(type);
     return (Page<PathResponse>) Request.Get(uri).execute().handleResponse(responseHandler);
   }
 
+  /**
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
+   * @throws IOException
+   */
   public Page<PathResponse> execute() throws IOException {
     return this.execute(this.buildUri());
   }

--- a/src/main/java/org/stellar/sdk/requests/PathsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/PathsRequestBuilder.java
@@ -49,7 +49,7 @@ public class PathsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<PathResponse> execute(URI uri) throws IOException {
+  public static Page<PathResponse> execute(URI uri) throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<PathResponse>>() {};
     ResponseHandler<Page<PathResponse>> responseHandler = new ResponseHandler<Page<PathResponse>>(type);
     return (Page<PathResponse>) Request.Get(uri).execute().handleResponse(responseHandler);
@@ -59,7 +59,7 @@ public class PathsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public Page<PathResponse> execute() throws IOException {
+  public Page<PathResponse> execute() throws IOException, TooManyRequestsException {
     return this.execute(this.buildUri());
   }
 }

--- a/src/main/java/org/stellar/sdk/requests/PaymentsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/PaymentsRequestBuilder.java
@@ -64,6 +64,7 @@ public class PaymentsRequestBuilder extends RequestBuilder {
    * Requests specific <code>uri</code> and returns {@link Page} of {@link OperationResponse}.
    * This method is helpful for getting the next set of results.
    * @return {@link Page} of {@link OperationResponse}
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
   public static Page<OperationResponse> execute(URI uri) throws IOException {
@@ -102,6 +103,7 @@ public class PaymentsRequestBuilder extends RequestBuilder {
   /**
    * Build and execute request.
    * @return {@link Page} of {@link OperationResponse}
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
   public Page<OperationResponse> execute() throws IOException {

--- a/src/main/java/org/stellar/sdk/requests/PaymentsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/PaymentsRequestBuilder.java
@@ -67,7 +67,7 @@ public class PaymentsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<OperationResponse> execute(URI uri) throws IOException {
+  public static Page<OperationResponse> execute(URI uri) throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<OperationResponse>>() {};
     ResponseHandler<Page<OperationResponse>> responseHandler = new ResponseHandler<Page<OperationResponse>>(type);
     return (Page<OperationResponse>) Request.Get(uri).execute().handleResponse(responseHandler);
@@ -106,7 +106,7 @@ public class PaymentsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public Page<OperationResponse> execute() throws IOException {
+  public Page<OperationResponse> execute() throws IOException, TooManyRequestsException {
     return this.execute(this.buildUri());
   }
 

--- a/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
+++ b/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
@@ -30,7 +30,7 @@ public class ResponseHandler<T> implements org.apache.http.client.ResponseHandle
     this.type = type;
   }
 
-  public T handleResponse(final HttpResponse response) throws IOException {
+  public T handleResponse(final HttpResponse response) throws IOException, TooManyRequestsException {
     StatusLine statusLine = response.getStatusLine();
     HttpEntity entity = response.getEntity();
 

--- a/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
+++ b/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
@@ -3,12 +3,14 @@ package org.stellar.sdk.requests;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpResponseException;
 import org.stellar.sdk.responses.GsonSingleton;
+import org.stellar.sdk.responses.Response;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -31,9 +33,17 @@ public class ResponseHandler<T> implements org.apache.http.client.ResponseHandle
   public T handleResponse(final HttpResponse response) throws IOException {
     StatusLine statusLine = response.getStatusLine();
     HttpEntity entity = response.getEntity();
+
+    // Too Many Requests
+    if (statusLine.getStatusCode() == 429) {
+      int retryAfter = Integer.parseInt(response.getFirstHeader("Retry-After").getValue());
+      throw new TooManyRequestsException(retryAfter);
+    }
+    // Other errors
     if (statusLine.getStatusCode() >= 300) {
       throw new HttpResponseException(statusLine.getStatusCode(), statusLine.getReasonPhrase());
     }
+    // No content
     if (entity == null) {
       throw new ClientProtocolException("Response contains no content");
     }
@@ -42,6 +52,14 @@ public class ResponseHandler<T> implements org.apache.http.client.ResponseHandle
     IOUtils.copy(entity.getContent(), writer);
     String content = writer.toString();
 
-    return GsonSingleton.getInstance().fromJson(content, type.getType());
+    T object = GsonSingleton.getInstance().fromJson(content, type.getType());
+    if (object instanceof Response) {
+      ((Response) object).setHeaders(
+              response.getFirstHeader("X-Ratelimit-Limit"),
+              response.getFirstHeader("X-Ratelimit-Remaining"),
+              response.getFirstHeader("X-Ratelimit-Reset")
+      );
+    }
+    return object;
   }
 }

--- a/src/main/java/org/stellar/sdk/requests/TooManyRequestsException.java
+++ b/src/main/java/org/stellar/sdk/requests/TooManyRequestsException.java
@@ -1,0 +1,22 @@
+package org.stellar.sdk.requests;
+
+/**
+ * Exception thrown when too many requests were sent to the Horizon server.
+ * @see <a href="https://www.stellar.org/developers/horizon/learn/rate-limiting.html" target="_blank">Rate Limiting</a>
+ */
+public class TooManyRequestsException extends RuntimeException {
+  private int retryAfter;
+
+  public TooManyRequestsException(int retryAfter) {
+    super("The rate limit for the requesting IP address is over its alloted limit.");
+    this.retryAfter = retryAfter;
+  }
+
+  /**
+   * Returns number of seconds a client should wait before sending requests again.
+   * @return
+   */
+  public int getRetryAfter() {
+    return retryAfter;
+  }
+}

--- a/src/main/java/org/stellar/sdk/requests/TransactionsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/TransactionsRequestBuilder.java
@@ -75,6 +75,7 @@ public class TransactionsRequestBuilder extends RequestBuilder {
    * Requests specific <code>uri</code> and returns {@link Page} of {@link TransactionResponse}.
    * This method is helpful for getting the next set of results.
    * @return {@link Page} of {@link TransactionResponse}
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
   public static Page<TransactionResponse> execute(URI uri) throws IOException {
@@ -113,6 +114,7 @@ public class TransactionsRequestBuilder extends RequestBuilder {
   /**
    * Build and execute request.
    * @return {@link Page} of {@link TransactionResponse}
+   * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
   public Page<TransactionResponse> execute() throws IOException {

--- a/src/main/java/org/stellar/sdk/requests/TransactionsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/TransactionsRequestBuilder.java
@@ -78,7 +78,7 @@ public class TransactionsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<TransactionResponse> execute(URI uri) throws IOException {
+  public static Page<TransactionResponse> execute(URI uri) throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<TransactionResponse>>() {};
     ResponseHandler<Page<TransactionResponse>> responseHandler = new ResponseHandler<Page<TransactionResponse>>(type);
     return (Page<TransactionResponse>) Request.Get(uri).execute().handleResponse(responseHandler);
@@ -117,7 +117,7 @@ public class TransactionsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public Page<TransactionResponse> execute() throws IOException {
+  public Page<TransactionResponse> execute() throws IOException, TooManyRequestsException {
     return this.execute(this.buildUri());
   }
 

--- a/src/main/java/org/stellar/sdk/responses/AccountResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/AccountResponse.java
@@ -12,7 +12,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @see org.stellar.sdk.requests.AccountsRequestBuilder
  * @see org.stellar.sdk.Server#accounts()
  */
-public class AccountResponse implements org.stellar.sdk.TransactionBuilderAccount {
+public class AccountResponse extends Response implements org.stellar.sdk.TransactionBuilderAccount {
   @SerializedName("account_id") /* KeyPairTypeAdapter used */
   private KeyPair keypair;
   @SerializedName("sequence")

--- a/src/main/java/org/stellar/sdk/responses/LedgerResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/LedgerResponse.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * @see org.stellar.sdk.requests.LedgersRequestBuilder
  * @see org.stellar.sdk.Server#ledgers()
  */
-public class LedgerResponse {
+public class LedgerResponse extends Response {
   @SerializedName("sequence")
   private final Long sequence;
   @SerializedName("hash")

--- a/src/main/java/org/stellar/sdk/responses/Page.java
+++ b/src/main/java/org/stellar/sdk/responses/Page.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
  * Represents page of objects.
  * @see <a href="https://www.stellar.org/developers/horizon/reference/resources/page.html" target="_blank">Page documentation</a>
  */
-public class Page<T> {
+public class Page<T> extends Response {
   @SerializedName("records")
   private ArrayList<T> records;
   @SerializedName("links")

--- a/src/main/java/org/stellar/sdk/responses/PathResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/PathResponse.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
  * @see org.stellar.sdk.requests.PathsRequestBuilder
  * @see org.stellar.sdk.Server#paths()
  */
-public class PathResponse {
+public class PathResponse extends Response {
   @SerializedName("destination_amount")
   private final String destinationAmount;
   @SerializedName("destination_asset_type")

--- a/src/main/java/org/stellar/sdk/responses/Response.java
+++ b/src/main/java/org/stellar/sdk/responses/Response.java
@@ -1,0 +1,42 @@
+package org.stellar.sdk.responses;
+
+import org.apache.http.Header;
+
+public abstract class Response {
+  protected int rateLimitLimit;
+  protected int rateLimitRemaining;
+  protected int rateLimitReset;
+
+  public void setHeaders(Header limit, Header remaining, Header reset) {
+    this.rateLimitLimit = Integer.parseInt(limit.getValue());
+    this.rateLimitRemaining = Integer.parseInt(remaining.getValue());
+    this.rateLimitReset = Integer.parseInt(reset.getValue());
+  }
+
+  /**
+   * Returns X-RateLimit-Limit header from the response.
+   * This number represents the he maximum number of requests that the current client can
+   * make in one hour.
+   * @see <a href="https://www.stellar.org/developers/horizon/learn/rate-limiting.html" target="_blank">Rate Limiting</a>
+   */
+  public int getRateLimitLimit() {
+    return rateLimitLimit;
+  }
+
+  /**
+   * Returns X-RateLimit-Remaining header from the response.
+   * The number of remaining requests for the current window.
+   * @see <a href="https://www.stellar.org/developers/horizon/learn/rate-limiting.html" target="_blank">Rate Limiting</a>
+   */
+  public int getRateLimitRemaining() {
+    return rateLimitRemaining;
+  }
+
+  /**
+   * Returns X-RateLimit-Reset header from the response. Seconds until a new window starts.
+   * @see <a href="https://www.stellar.org/developers/horizon/learn/rate-limiting.html" target="_blank">Rate Limiting</a>
+   */
+  public int getRateLimitReset() {
+    return rateLimitReset;
+  }
+}

--- a/src/main/java/org/stellar/sdk/responses/SubmitTransactionResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/SubmitTransactionResponse.java
@@ -8,7 +8,7 @@ import org.stellar.sdk.Server;
  * Represents server response after submitting transaction.
  * @see Server#submitTransaction(org.stellar.sdk.Transaction)
  */
-public class SubmitTransactionResponse {
+public class SubmitTransactionResponse extends Response {
     @SerializedName("hash")
     private final String hash;
     @SerializedName("ledger")

--- a/src/main/java/org/stellar/sdk/responses/TransactionResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/TransactionResponse.java
@@ -13,7 +13,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @see org.stellar.sdk.requests.TransactionsRequestBuilder
  * @see org.stellar.sdk.Server#transactions()
  */
-public class TransactionResponse {
+public class TransactionResponse extends Response {
   @SerializedName("hash")
   private final String hash;
   @SerializedName("ledger")

--- a/src/main/java/org/stellar/sdk/responses/effects/EffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/EffectResponse.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.responses.Link;
+import org.stellar.sdk.responses.Response;
 
 /**
  * Abstract class for effect responses.
@@ -11,7 +12,7 @@ import org.stellar.sdk.responses.Link;
  * @see org.stellar.sdk.requests.EffectsRequestBuilder
  * @see org.stellar.sdk.Server#effects()
  */
-public abstract class EffectResponse {
+public abstract class EffectResponse extends Response {
   @SerializedName("id")
   protected String id;
   @SerializedName("account")

--- a/src/main/java/org/stellar/sdk/responses/operations/OperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/OperationResponse.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.responses.Link;
+import org.stellar.sdk.responses.Response;
 
 /**
  * Abstract class for operation responses.
@@ -11,7 +12,7 @@ import org.stellar.sdk.responses.Link;
  * @see org.stellar.sdk.requests.OperationsRequestBuilder
  * @see org.stellar.sdk.Server#operations()
  */
-public abstract class OperationResponse {
+public abstract class OperationResponse extends Response {
   @SerializedName("id")
   protected Long id;
   @SerializedName("source_account")


### PR DESCRIPTION
This PR includes Horizon [rate limiting](https://www.stellar.org/developers/horizon/learn/rate-limiting.html) headers in response classes:
* Added `org.stellar.sdk.responses.Response` abstract class that contains rate limitting headers.
* All response classes now extend `Response` class.
* When the client is being throttled `org.stellar.sdk.requests.TooManyRequestsException` will be thrown by `execute()` methods in request classes. This exception contains `Retry-After` header value which is the number of seconds until a new window starts.

Close https://github.com/stellar/java-stellar-sdk/issues/24