### PR TITLE
AccountFlag enum

### DIFF
--- a/src/main/java/org/stellar/sdk/AccountFlag.java
+++ b/src/main/java/org/stellar/sdk/AccountFlag.java
@@ -1,0 +1,32 @@
+package org.stellar.sdk;
+
+import org.stellar.sdk.xdr.AccountFlags;
+
+/**
+ * AccountFlag is the <code>enum</code> that can be used in {@link SetOptionsOperation}.
+ * @see <a href="https://www.stellar.org/developers/guides/concepts/accounts.html#flags" target="_blank">Account Flags</a>
+ */
+public enum AccountFlag {
+  /**
+   * Authorization required (0x1): Requires the issuing account to give other accounts permission before they can hold the issuing account’s credit.
+   */
+  AUTH_REQUIRED_FLAG(AccountFlags.AUTH_REQUIRED_FLAG.getValue()),
+  /**
+   * Authorization revocable (0x2): Allows the issuing account to revoke its credit held by other accounts.
+   */
+  AUTH_REVOCABLE_FLAG(AccountFlags.AUTH_REVOCABLE_FLAG.getValue()),
+  /**
+   * Authorization immutable (0x4): If this is set then none of the authorization flags can be set and the account can never be deleted.
+   */
+  AUTH_IMMUTABLE_FLAG(AccountFlags.AUTH_IMMUTABLE_FLAG.getValue()),
+  ;
+
+  private final int value;
+  AccountFlag(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+}

--- a/src/main/java/org/stellar/sdk/SetOptionsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetOptionsOperation.java
@@ -48,6 +48,7 @@ public class SetOptionsOperation extends Operation {
 
   /**
    * Indicates which flags to clear. For details about the flags, please refer to the <a href="https://www.stellar.org/developers/learn/concepts/accounts.html" target="_blank">accounts doc</a>.
+   * You can also use {@link AccountFlag} enum.
    */
   public Integer getClearFlags() {
     return clearFlags;
@@ -55,6 +56,7 @@ public class SetOptionsOperation extends Operation {
 
   /**
    * Indicates which flags to set. For details about the flags, please refer to the <a href="https://www.stellar.org/developers/learn/concepts/accounts.html" target="_blank">accounts doc</a>.
+   * You can also use {@link AccountFlag} enum.
    */
   public Integer getSetFlags() {
     return setFlags;

--- a/src/test/java/org/stellar/sdk/AccountFlagTest.java
+++ b/src/test/java/org/stellar/sdk/AccountFlagTest.java
@@ -1,0 +1,14 @@
+package org.stellar.sdk;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AccountFlagTest {
+  @Test
+  public void testValues() {
+    assertEquals(1, AccountFlag.AUTH_REQUIRED_FLAG.getValue());
+    assertEquals(2, AccountFlag.AUTH_REVOCABLE_FLAG.getValue());
+    assertEquals(4, AccountFlag.AUTH_IMMUTABLE_FLAG.getValue());
+  }
+}


### PR DESCRIPTION
This PR introduces `AccountFlag` enum that exposes account flags.

Close https://github.com/stellar/java-stellar-sdk/issues/31