### PR TITLE
No default network

### DIFF
--- a/src/main/java/org/stellar/sdk/Network.java
+++ b/src/main/java/org/stellar/sdk/Network.java
@@ -8,12 +8,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Network class is used to specify which Stellar network you want to use.
  * Each network has a <code>networkPassphrase</code> which is hashed to
  * every transaction id.
- * Default network is <a href="https://www.stellar.org/developers/learn/get-started/test-net.html" target="_blank">Test Network</a>.
+ * There is no default network. You need to specify network when initializing your app by calling
+ * {@link Network#use(Network)}, {@link Network#usePublicNetwork()} or {@link Network#useTestNetwork()}.
  */
 public class Network {
     private final static String PUBLIC = "Public Global Stellar Network ; September 2015";
     private final static String TESTNET = "Test SDF Network ; September 2015";
-    private static Network current = new Network(TESTNET);
+    private static Network current;
 
     private final String networkPassphrase;
 
@@ -51,7 +52,6 @@ public class Network {
      * @param network Network object to set as current network
      */
     public static void use(Network network) {
-        checkNotNull(network, "network cannot be null");
         current = network;
     }
 

--- a/src/main/java/org/stellar/sdk/NoNetworkSelectedException.java
+++ b/src/main/java/org/stellar/sdk/NoNetworkSelectedException.java
@@ -1,0 +1,10 @@
+package org.stellar.sdk;
+
+/**
+ * Indicates that no network was selected.
+ */
+public class NoNetworkSelectedException extends RuntimeException {
+  public NoNetworkSelectedException() {
+    super("No network selected. Use `Network.use`, `Network.usePublicNetwork` or `Network.useTestNetwork` helper methods to select network.");
+  }
+}

--- a/src/main/java/org/stellar/sdk/Transaction.java
+++ b/src/main/java/org/stellar/sdk/Transaction.java
@@ -59,6 +59,10 @@ public class Transaction {
    * Returns signature base.
    */
   public byte[] signatureBase() {
+    if (Network.current() == null) {
+      throw new NoNetworkSelectedException();
+    }
+
     try {
       ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
       // Hashed NetworkID

--- a/src/test/java/org/stellar/sdk/NetworkTest.java
+++ b/src/test/java/org/stellar/sdk/NetworkTest.java
@@ -1,17 +1,25 @@
 package org.stellar.sdk;
 
+import org.junit.After;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class NetworkTest {
-
-    public void tearDown() {
-        Network.useTestNetwork();
+    @After
+    public void resetNetwork() {
+        Network.use(null);
     }
 
     @Test
-    public void testDefaultTestNetwork() {
+    public void testNoDefaultNetwork() {
+        assertNull(Network.current());
+    }
+
+    @Test
+    public void testSwitchToTestNetwork() {
+        Network.useTestNetwork();
         assertEquals("Test SDF Network ; September 2015", Network.current().getNetworkPassphrase());
     }
 
@@ -19,6 +27,5 @@ public class NetworkTest {
     public void testSwitchToPublicNetwork() {
         Network.usePublicNetwork();
         assertEquals("Public Global Stellar Network ; September 2015", Network.current().getNetworkPassphrase());
-        Network.useTestNetwork();
     }
 }

--- a/src/test/java/org/stellar/sdk/ServerTest.java
+++ b/src/test/java/org/stellar/sdk/ServerTest.java
@@ -10,6 +10,8 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicStatusLine;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -69,13 +71,21 @@ public class ServerTest extends TestCase {
 
     private Server server;
 
+    @Before
     public void setUp() throws URISyntaxException, IOException {
+        Network.useTestNetwork();
+
         MockitoAnnotations.initMocks(this);
         server = new Server("https://horizon.stellar.org");
         server.setHttpClient(mockClient);
 
         when(mockResponse.getEntity()).thenReturn(mockEntity);
         when(mockClient.execute((HttpPost) any())).thenReturn(mockResponse);
+    }
+
+    @After
+    public void resetNetwork() {
+        Network.use(null);
     }
 
     Transaction buildTransaction() throws IOException {

--- a/src/test/java/org/stellar/sdk/TransactionTest.java
+++ b/src/test/java/org/stellar/sdk/TransactionTest.java
@@ -1,6 +1,7 @@
 package org.stellar.sdk;
 
 import org.apache.commons.codec.binary.Base64;
+import org.junit.Before;
 import org.junit.Test;
 import org.stellar.sdk.xdr.TransactionEnvelope;
 import org.stellar.sdk.xdr.XdrDataInputStream;
@@ -16,7 +17,8 @@ import static org.junit.Assert.fail;
 
 public class TransactionTest {
 
-  public void tearDown() {
+  @Before
+  public void setupNetwork() {
     Network.useTestNetwork();
   }
 

--- a/src/test/java/org/stellar/sdk/federation/FederationServerTest.java
+++ b/src/test/java/org/stellar/sdk/federation/FederationServerTest.java
@@ -13,6 +13,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.message.BasicStatusLine;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -49,6 +50,7 @@ public class FederationServerTest extends TestCase {
   private final String stellarToml =
           "FEDERATION_SERVER = \"https://api.stellar.org/federation\"";
 
+  @Before
   public void setUp() throws URISyntaxException, IOException {
     MockitoAnnotations.initMocks(this);
     server = new FederationServer(

--- a/src/test/java/org/stellar/sdk/federation/FederationTest.java
+++ b/src/test/java/org/stellar/sdk/federation/FederationTest.java
@@ -11,6 +11,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.message.BasicStatusLine;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -38,6 +39,7 @@ public class FederationTest extends TestCase {
   private final String successResponse =
           "{\"stellar_address\":\"bob*stellar.org\",\"account_id\":\"GCW667JUHCOP5Y7KY6KGDHNPHFM4CS3FCBQ7QWDUALXTX3PGXLSOEALY\"}";
 
+  @Before
   public void setUp() throws URISyntaxException, IOException {
     MockitoAnnotations.initMocks(this);
     FederationServer.setHttpClient(mockClient);


### PR DESCRIPTION
Some users forget to switch to public network (by executing `Network.usePublicNetwork()`) before deploying apps because right now test network is a default choice, selected automatically. This PR changes `Network` module to not select a default network.
