### PR TITLE
Removing .toString on a byte array in AllowTrustOperation Builder Class

### DIFF
--- a/src/main/java/org/stellar/sdk/AllowTrustOperation.java
+++ b/src/main/java/org/stellar/sdk/AllowTrustOperation.java
@@ -89,7 +89,7 @@ public class AllowTrustOperation extends Operation {
           assetCode = new String(op.getAsset().getAssetCode4());
           break;
         case ASSET_TYPE_CREDIT_ALPHANUM12:
-          assetCode = new String(op.getAsset().getAssetCode12().toString());
+          assetCode = new String(op.getAsset().getAssetCode12());
           break;
         default:
           throw new RuntimeException("Unknown asset code");


### PR DESCRIPTION
Executing a .toString() on a byte[] will result in a string representation of that byte[]'s memory address. This will cause the assetCode of an AllowTrustOperation that has an asset of asset type ASSET_TYPE_CREDIT_ALPHANUM12 to have an assetCode of some random address. This most certainly was not intended.