### PR TITLE
resolves #66 preserve type information for generic response types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@
 .idea/
 /local.properties
 
+# Eclipse project files
+.settings
+.classpath
+.project 
+
 # Gradle
 .gradle
 build

--- a/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
+++ b/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
@@ -2,11 +2,12 @@ package org.stellar.sdk.requests;
 
 import com.google.gson.reflect.TypeToken;
 
-import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.stellar.sdk.responses.GsonSingleton;
+import org.stellar.sdk.responses.TypedResponse;
 
 import java.io.IOException;
+
+import okhttp3.Response;
 
 public class ResponseHandler<T> {
 
@@ -41,6 +42,9 @@ public class ResponseHandler<T> {
       T object = GsonSingleton.getInstance().fromJson(content, type.getType());
       if (object instanceof org.stellar.sdk.responses.Response) {
         ((org.stellar.sdk.responses.Response) object).setHeaders(response.headers());
+      }
+      if(object instanceof TypedResponse) {
+    	  	((TypedResponse) object).setType(type);
       }
       return object;
     } finally {

--- a/src/main/java/org/stellar/sdk/responses/Page.java
+++ b/src/main/java/org/stellar/sdk/responses/Page.java
@@ -1,27 +1,31 @@
 package org.stellar.sdk.responses;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 
-import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
 import org.stellar.sdk.requests.ResponseHandler;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 
 /**
  * Represents page of objects.
  * @see <a href="https://www.stellar.org/developers/horizon/reference/resources/page.html" target="_blank">Page documentation</a>
  */
-public class Page<T> extends Response {
+public class Page<T> extends Response implements TypedResponse<Page<T>> {
+
   @SerializedName("records")
   private ArrayList<T> records;
   @SerializedName("links")
   private Links links;
+
+  private TypeToken<Page<T>> type;
 
   Page() {}
 
@@ -42,7 +46,7 @@ public class Page<T> extends Response {
     if (this.getLinks().getNext() == null) {
       return null;
     }
-    TypeToken type = new TypeToken<Page<T>>() {};
+    TypeToken<Page<T>> type = requireNonNull(this.type, "type cannot be null, is it being correctly set after the creation of this " + getClass().getSimpleName() + "?");
     ResponseHandler<Page<T>> responseHandler = new ResponseHandler<Page<T>>(type);
     String url = this.getLinks().getNext().getHref();
 
@@ -50,6 +54,11 @@ public class Page<T> extends Response {
     okhttp3.Response response = httpClient.newCall(request).execute();
 
     return responseHandler.handleResponse(response);
+  }
+
+  @Override
+  public void setType(TypeToken<Page<T>> type) {
+	this.type = type;
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/responses/TypedResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/TypedResponse.java
@@ -1,0 +1,14 @@
+package org.stellar.sdk.responses;
+
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * Indicates a generic container that requires type information to be provided after initialisation.
+ *
+ * @param <T> the type of the objects in this response container.
+ */
+public interface TypedResponse<T> {
+
+  void setType(TypeToken<T> type);
+
+}


### PR DESCRIPTION
Fixes the `Page.getNextPage` method by using a new `TypedResponse` interface to allow the `ResponseHandler` to preserve the `TypeToken` on the original response `Page`, so it is present for subsequent page requests.

Also includes an update to the typing of `ResponseHandler`, which was missing the type information on the implemented `org.apache.http.client.ResponseHandler`.  This removes the need for the casts being done wherever `ResponseHandler` is used.

Added some common eclipse ignore settings.

This PR gets `Page.getNextPage` into a functional state but I see two main improvements that could be made here:

1. It doesn't fix the underlying issue that `Page` objects are being requested in different ways from different places.  It's easy for one of the ways to be broken compared to the others while this is the case.  If `Page` building were factored out somewhere common it would make sure that the same mechanism was used each time.
2. It's untested.  The current Response object tests cover deserialization, but that's not the issue here.  To cover this case would require a slightly broader test that included covering the behaviour we expect from `ResponseHandler`.  At the moment this would be difficult to achieve due to the static http utility used.  Addressing point 1. above would likely make this easier as the bulk of the logic would be moved.  As long as that class were covered the overall test coverage would be more comprehensive.

A further improvement I'd like to raise (on the topic of the static http utility being used fairly extensively) is that while it simplifies things initially I generally find the being able to control the http client configuration for sdk that I'm using ends up being a must.  There's a readily available `httpClient` instance in the `Server`, and allowing that to be provided in a constructor would give the user of the sdk full control over the client being used.  
My suggestion would involve then propagating this instance through the various request builders, so the same httpClient is used throughout, and easily injectable in one place.  I can see there are some static request methods on some of the builders, so some thought would need to go into what would happen with them.  And it is a pretty extensive change to the current design.  Ultimately I think users of the sdk would thank you when they come to needing to apply non-default configuration to the http client used.