### PR TITLE
Fixes exception thrown from ManageOfferOperation.fromXDR for certain offers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
+## 0.2.0
+
+* Java SDK now works in Android!
+* `Price` constructor is now public.
+* Added support for new endpoints and fields added in Horizon v0.12.0.
+
+## 0.1.14
+
+* Fixed `pad()` method in `XdrInputStream`.
+* Added utf8 string support for `XdrDataInputStream` and `XdrDataOutputStream`.
+* Fixed `AllowTrustOperation.Builder` for `ASSET_TYPE_CREDIT_ALPHANUM12` assets.
+
+## 0.1.13
+
+* `KeyPair.sign` now throws `RuntimeException` when `KeyPair` object does not contain a secret key.
+* `SubmitTransactionResponse.getOfferIdFromResult` if offer was taken and `tx_result` does not contain offer ID.
+
+## 0.1.12
+
+- Regenerated XDR classes:
+  - `XdrDataOutputStream` class is now padding opaque data.
+  - `XdrDataInputStream` class is now throwing an IOException when padding
+  bytes are not zeros.
+  - Made methods that shouldn't be used outside of `XdrDataOutputStream`
+  and `XdrDataInputStream` classes private.
+  - Removed unused imports and variables.
+
+## 0.1.11
+
+* Added ability to set TimeBounds using Transaction.Builder
+* Implemented `/order_book` and `/order_book/trades` requests.
+
+## 0.1.10
+
+* Fixed a bug in `AssetDeserializer`.
+* Fixed a bug in `TransactionResponse`.
+
 ## 0.1.9
 
 * Support for new signer types: `sha256Hash`, `preAuthTx`.

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,4 @@ dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
     testCompile 'com.squareup.okhttp3:mockwebserver:3.9.1'
     testCompile group: 'junit', name: 'junit', version: '4.11'
-    
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'ivy-publish'
 
 sourceCompatibility = 1.6
-version = '0.1.14'
+version = '0.2.0'
 group = 'stellar'
 
 jar {

--- a/src/main/java/org/stellar/sdk/requests/RequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/RequestBuilder.java
@@ -13,7 +13,6 @@ public abstract class RequestBuilder {
   protected OkHttpClient httpClient;
   private ArrayList<String> segments;
   private boolean segmentsAdded;
-  private String originalPath;
 
   RequestBuilder(OkHttpClient httpClient, HttpUrl serverURI, String defaultSegment) {
     this.httpClient = httpClient;

--- a/src/test/java/org/stellar/sdk/OperationTest.java
+++ b/src/test/java/org/stellar/sdk/OperationTest.java
@@ -436,11 +436,10 @@ public class OperationTest {
 
     ManageOfferOperation manageOfferOperation = (ManageOfferOperation)Operation.fromXdr(xdrTransaction.getOperations()[0]);
 
-    Price priceExpected = new Price(74915, 1585546269);
-    Price priceObtained = Price.fromString(manageOfferOperation.getPrice());
+    Price priceObtained = manageOfferOperation.getPriceR();
 
-    assertEquals(priceExpected, priceObtained);
-
+    assertEquals(74915, priceObtained.getNumerator());
+    assertEquals(1585546269, priceObtained.getDenominator());
 
   }
   


### PR DESCRIPTION
The following valid XDR throws an ArithmeticException exception when attempting to decode:

```
@Test
    public void testManageOfferOperationPrice() throws IOException, FormatException {

        String transactionEnvelopeXdr = "AAAAACq1Ixcw1fchtF5aLTSw1zaYAYjb3WbBRd4jqYJKThB9AAAAZAA8tDoAAAAaAAAAAAAAAAAAAAABAAAAAAAAAAMAAAAAAAAAAUJUQwAAAAAAmyMegjdqwy59ijGMyd+sKLgoCfagDexhF17wyd36y2oAAAAABfXhAAABJKNegYQdAAAAAAAAAAAAAAAAAAAAAA==";

        BaseEncoding base64Encoding = BaseEncoding.base64();
        byte[] bytes = base64Encoding.decode(transactionEnvelopeXdr);

        org.stellar.sdk.xdr.TransactionEnvelope transactionEnvelope = TransactionEnvelope.decode(new XdrDataInputStream(new ByteArrayInputStream(bytes)));
        org.stellar.sdk.xdr.Transaction xdrTransaction = transactionEnvelope.getTx();     
        
        ManageOfferOperation manageOfferOperation = (ManageOfferOperation)Operation.fromXdr(xdrTransaction.getOperations()[0]); //Arithmetic exception thrown here.
        
        Price priceExpected = new Price(74915, 1585546269);
        Price priceObtained = Price.fromString(manageOfferOperation.getPrice());
        
        assertEquals(priceExpected, priceObtained);
       
        
    }
```

This is principally because https://github.com/stellar/java-stellar-sdk/blob/master/src/main/java/org/stellar/sdk/ManageOfferOperation.java#L115 throws the following exception:


**ArithmeticException: "Non-terminating decimal expansion; no exact representable decimal result" **

This pull request fixes the issue, and also changes the type of the price field member in  ManageOfferOperation from string to Price. This is necessary for projects that demand a more accurate representation of an offer's price.
