### PR TITLE
recommit #108  

### DIFF
--- a/src/main/java/org/stellar/sdk/CreatePassiveOfferOperation.java
+++ b/src/main/java/org/stellar/sdk/CreatePassiveOfferOperation.java
@@ -16,9 +16,9 @@ public class CreatePassiveOfferOperation extends Operation {
   private final Asset selling;
   private final Asset buying;
   private final String amount;
-  private final String price;
+  private final Price price;
 
-  private CreatePassiveOfferOperation(Asset selling, Asset buying, String amount, String price) {
+  private CreatePassiveOfferOperation(Asset selling, Asset buying, String amount, Price price) {
     this.selling = checkNotNull(selling, "selling cannot be null");
     this.buying = checkNotNull(buying, "buying cannot be null");
     this.amount = checkNotNull(amount, "amount cannot be null");
@@ -50,6 +50,13 @@ public class CreatePassiveOfferOperation extends Operation {
    * Price of 1 unit of selling in terms of buying.
    */
   public String getPrice() {
+    return new BigDecimal(price.getNumerator()).divide(new BigDecimal(price.getDenominator())).toString();
+  }
+
+  /**
+   * Price of 1 unit of selling in terms of buying.
+   */
+  public Price getPriceObject() {
     return price;
   }
 
@@ -61,8 +68,7 @@ public class CreatePassiveOfferOperation extends Operation {
     Int64 amount = new Int64();
     amount.setInt64(Operation.toXdrAmount(this.amount));
     op.setAmount(amount);
-    Price price = Price.fromString(this.price);
-    op.setPrice(price.toXdr());
+    op.setPrice(this.price.toXdr());
 
     org.stellar.sdk.xdr.Operation.OperationBody body = new org.stellar.sdk.xdr.Operation.OperationBody();
     body.setDiscriminant(OperationType.CREATE_PASSIVE_OFFER);
@@ -80,7 +86,7 @@ public class CreatePassiveOfferOperation extends Operation {
     private final Asset selling;
     private final Asset buying;
     private final String amount;
-    private final String price;
+    private final Price price;
 
     private KeyPair mSourceAccount;
 
@@ -94,7 +100,7 @@ public class CreatePassiveOfferOperation extends Operation {
       amount = Operation.fromXdrAmount(op.getAmount().getInt64().longValue());
       int n = op.getPrice().getN().getInt32().intValue();
       int d = op.getPrice().getD().getInt32().intValue();
-      price = new BigDecimal(n).divide(new BigDecimal(d)).toString();
+      price = new Price(n,d);
     }
 
     /**
@@ -106,6 +112,21 @@ public class CreatePassiveOfferOperation extends Operation {
      * @throws ArithmeticException when amount has more than 7 decimal places.
      */
     public Builder(Asset selling, Asset buying, String amount, String price) {
+      this.selling = checkNotNull(selling, "selling cannot be null");
+      this.buying = checkNotNull(buying, "buying cannot be null");
+      this.amount = checkNotNull(amount, "amount cannot be null");
+      this.price = Price.fromString(checkNotNull(price, "price cannot be null"));
+    }
+
+    /**
+     * Creates a new CreatePassiveOffer builder.
+     * @param selling The asset being sold in this operation
+     * @param buying The asset being bought in this operation
+     * @param amount Amount of selling being sold.
+     * @param price Price of 1 unit of selling in terms of buying.
+     * @throws ArithmeticException when amount has more than 7 decimal places.
+     */
+    public Builder(Asset selling, Asset buying, String amount, Price price) {
       this.selling = checkNotNull(selling, "selling cannot be null");
       this.buying = checkNotNull(buying, "buying cannot be null");
       this.amount = checkNotNull(amount, "amount cannot be null");

--- a/src/main/java/org/stellar/sdk/ManageOfferOperation.java
+++ b/src/main/java/org/stellar/sdk/ManageOfferOperation.java
@@ -81,8 +81,7 @@ public class ManageOfferOperation extends Operation {
     Int64 amount = new Int64();
     amount.setInt64(Operation.toXdrAmount(this.amount));
     op.setAmount(amount);
-    Price price = this.price;
-    op.setPrice(price.toXdr());
+    op.setPrice(this.price.toXdr());
     Uint64 offerId = new Uint64();
     offerId.setUint64(Long.valueOf(this.offerId));
     op.setOfferID(offerId);

--- a/src/main/java/org/stellar/sdk/ManageOfferOperation.java
+++ b/src/main/java/org/stellar/sdk/ManageOfferOperation.java
@@ -19,10 +19,10 @@ public class ManageOfferOperation extends Operation {
   private final Asset selling;
   private final Asset buying;
   private final String amount;
-  private final String price;
+  private final Price price;
   private final long offerId;
 
-  private ManageOfferOperation(Asset selling, Asset buying, String amount, String price, long offerId) {
+  private ManageOfferOperation(Asset selling, Asset buying, String amount, Price price, long offerId) {
     this.selling = checkNotNull(selling, "selling cannot be null");
     this.buying = checkNotNull(buying, "buying cannot be null");
     this.amount = checkNotNull(amount, "amount cannot be null");
@@ -56,6 +56,13 @@ public class ManageOfferOperation extends Operation {
    * Price of 1 unit of selling in terms of buying.
    */
   public String getPrice() {
+    return new BigDecimal(price.getNumerator()).divide(new BigDecimal(price.getDenominator())).toString();
+  }
+
+  /**
+   * Price of 1 unit of selling in terms of buying.
+   */
+  public Price getPriceObject() {
     return price;
   }
 
@@ -74,7 +81,7 @@ public class ManageOfferOperation extends Operation {
     Int64 amount = new Int64();
     amount.setInt64(Operation.toXdrAmount(this.amount));
     op.setAmount(amount);
-    Price price = Price.fromString(this.price);
+    Price price = this.price;
     op.setPrice(price.toXdr());
     Uint64 offerId = new Uint64();
     offerId.setUint64(Long.valueOf(this.offerId));
@@ -97,7 +104,7 @@ public class ManageOfferOperation extends Operation {
     private final Asset selling;
     private final Asset buying;
     private final String amount;
-    private final String price;
+    private final Price price;
     private long offerId = 0;
 
     private KeyPair mSourceAccount;
@@ -112,7 +119,7 @@ public class ManageOfferOperation extends Operation {
       amount = Operation.fromXdrAmount(op.getAmount().getInt64().longValue());
       int n = op.getPrice().getN().getInt32().intValue();
       int d = op.getPrice().getD().getInt32().intValue();
-      price = new BigDecimal(n).divide(new BigDecimal(d)).toString();
+      price = new Price(n,d);
       offerId = op.getOfferID().getUint64().longValue();
     }
 
@@ -126,6 +133,22 @@ public class ManageOfferOperation extends Operation {
      * @throws ArithmeticException when amount has more than 7 decimal places.
      */
     public Builder(Asset selling, Asset buying, String amount, String price) {
+      this.selling = checkNotNull(selling, "selling cannot be null");
+      this.buying = checkNotNull(buying, "buying cannot be null");
+      this.amount = checkNotNull(amount, "amount cannot be null");
+      this.price =Price.fromString(checkNotNull(price, "price cannot be null"));
+    }
+
+    /**
+     * Creates a new ManageOffer builder. If you want to update existing offer use
+     * {@link org.stellar.sdk.ManageOfferOperation.Builder#setOfferId(long)}.
+     * @param selling The asset being sold in this operation
+     * @param buying The asset being bought in this operation
+     * @param amount Amount of selling being sold.
+     * @param price Price of 1 unit of selling in terms of buying.
+     * @throws ArithmeticException when amount has more than 7 decimal places.
+     */
+    public Builder(Asset selling, Asset buying, String amount, Price price) {
       this.selling = checkNotNull(selling, "selling cannot be null");
       this.buying = checkNotNull(buying, "buying cannot be null");
       this.amount = checkNotNull(amount, "amount cannot be null");

--- a/src/main/java/org/stellar/sdk/requests/AssetsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/AssetsRequestBuilder.java
@@ -38,4 +38,22 @@ public class AssetsRequestBuilder extends RequestBuilder {
     public Page<AssetResponse> execute() throws IOException, TooManyRequestsException {
         return this.execute(this.httpClient, this.buildUri());
     }
+
+    @Override
+    public AssetsRequestBuilder cursor(String token) {
+        super.cursor(token);
+        return this;
+    }
+
+    @Override
+    public AssetsRequestBuilder limit(int number) {
+        super.limit(number);
+        return this;
+    }
+
+    @Override
+    public AssetsRequestBuilder order(Order direction) {
+        super.order(direction);
+        return this;
+    }
 }

--- a/src/main/java/org/stellar/sdk/requests/TradeAggregationsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/TradeAggregationsRequestBuilder.java
@@ -57,4 +57,16 @@ public class TradeAggregationsRequestBuilder extends RequestBuilder {
     public Page<TradeAggregationResponse> execute() throws IOException, TooManyRequestsException {
         return this.execute(this.httpClient, this.buildUri());
     }
+
+    @Override
+    public TradeAggregationsRequestBuilder limit(int number) {
+         super.limit(number);
+        return this;
+    }
+
+    @Override
+    public TradeAggregationsRequestBuilder order(Order direction) {
+        super.order(direction);
+        return this;
+    }
 }

--- a/src/main/java/org/stellar/sdk/requests/TradesRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/TradesRequestBuilder.java
@@ -73,4 +73,22 @@ public class TradesRequestBuilder extends RequestBuilder {
         uriBuilder.setQueryParameter("offer_id", offerId);
         return this;
     }
+
+    @Override
+    public TradesRequestBuilder cursor(String cursor) {
+         super.cursor(cursor);
+        return this;
+    }
+
+    @Override
+    public TradesRequestBuilder limit(int number) {
+         super.limit(number);
+        return this;
+    }
+
+    @Override
+    public TradesRequestBuilder order(Order direction) {
+         super.order(direction);
+        return this;
+    }
 }

--- a/src/main/java/org/stellar/sdk/responses/OfferResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/OfferResponse.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.KeyPair;
+import org.stellar.sdk.Price;
 
 /**
  * Represents offer response.
@@ -26,10 +27,13 @@ public class OfferResponse extends Response {
   private final String amount;
   @SerializedName("price")
   private final String price;
+  @SerializedName("price_r")
+  private final Price price_r;
   @SerializedName("_links")
   private final Links links;
 
-  OfferResponse(Long id, String pagingToken, KeyPair seller, Asset selling, Asset buying, String amount, String price, Links links) {
+  OfferResponse(Long id, String pagingToken, KeyPair seller, Asset selling, Asset buying,
+      String amount, String price, Price price_r, Links links) {
     this.id = id;
     this.pagingToken = pagingToken;
     this.seller = seller;
@@ -37,6 +41,7 @@ public class OfferResponse extends Response {
     this.buying = buying;
     this.amount = amount;
     this.price = price;
+    this.price_r = price_r;
     this.links = links;
   }
 
@@ -62,6 +67,10 @@ public class OfferResponse extends Response {
 
   public String getAmount() {
     return amount;
+  }
+
+  public Price getPrice_r() {
+    return price_r;
   }
 
   public String getPrice() {


### PR DESCRIPTION
recommit #108  

use org.stellar.sdk.Price instead of String both in org.stellar.sdk.ManageOfferOperation and org.stellar.sdk.CreatePassiveOfferOperation

And I keep the getPrice method and add a new method getPriceObject. Maybe I should rename it to getPricePrice or something?

And I also add some @Override method in AssetsRequestBuilder, TradeAggregationsRequestBuilder and TradesRequestBuilder to make it easier to use.