### PR TITLE
Construct Transaction from xdr.TransactionEnvelope

### DIFF
--- a/src/main/java/org/stellar/sdk/Memo.java
+++ b/src/main/java/org/stellar/sdk/Memo.java
@@ -71,5 +71,23 @@ public abstract class Memo {
         return new MemoReturnHash(BaseEncoding.base16().lowerCase().decode(hexString.toLowerCase()));
     }
 
+    public static Memo fromXdr(org.stellar.sdk.xdr.Memo memo) {
+        switch (memo.getDiscriminant()) {
+            case MEMO_NONE:
+                return none();
+            case MEMO_ID:
+                return id(memo.getId().getUint64().longValue());
+            case MEMO_TEXT:
+                return text(memo.getText());
+            case MEMO_HASH:
+                return hash(memo.getHash().getHash());
+            case MEMO_RETURN:
+                return returnHash(memo.getRetHash().getHash());
+            default:
+                throw new RuntimeException("Unknown memo type");
+        }
+    }
+
     abstract org.stellar.sdk.xdr.Memo toXdr();
+    abstract public boolean equals(Object o);
 }

--- a/src/main/java/org/stellar/sdk/MemoHashAbstract.java
+++ b/src/main/java/org/stellar/sdk/MemoHashAbstract.java
@@ -1,5 +1,6 @@
 package org.stellar.sdk;
 
+import com.google.common.base.Objects;
 import com.google.common.io.BaseEncoding;
 
 abstract class MemoHashAbstract extends Memo {
@@ -57,4 +58,12 @@ abstract class MemoHashAbstract extends Memo {
 
   @Override
   abstract org.stellar.sdk.xdr.Memo toXdr();
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MemoHashAbstract that = (MemoHashAbstract) o;
+    return Objects.equal(bytes, that.bytes);
+  }
 }

--- a/src/main/java/org/stellar/sdk/MemoId.java
+++ b/src/main/java/org/stellar/sdk/MemoId.java
@@ -29,4 +29,12 @@ public class MemoId extends Memo {
     memo.setId(idXdr);
     return memo;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MemoId memoId = (MemoId) o;
+    return id == memoId.id;
+  }
 }

--- a/src/main/java/org/stellar/sdk/MemoNone.java
+++ b/src/main/java/org/stellar/sdk/MemoNone.java
@@ -12,4 +12,11 @@ public class MemoNone extends Memo {
     memo.setDiscriminant(MemoType.MEMO_NONE);
     return memo;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    return true;
+  }
 }

--- a/src/main/java/org/stellar/sdk/MemoText.java
+++ b/src/main/java/org/stellar/sdk/MemoText.java
@@ -1,5 +1,6 @@
 package org.stellar.sdk;
 
+import com.google.common.base.Objects;
 import org.stellar.sdk.xdr.MemoType;
 
 import java.nio.charset.Charset;
@@ -31,5 +32,13 @@ public class MemoText extends Memo {
     memo.setDiscriminant(MemoType.MEMO_TEXT);
     memo.setText(text);
     return memo;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MemoText memoText = (MemoText) o;
+    return Objects.equal(text, memoText.text);
   }
 }

--- a/src/main/java/org/stellar/sdk/TimeBounds.java
+++ b/src/main/java/org/stellar/sdk/TimeBounds.java
@@ -30,7 +30,18 @@ final public class TimeBounds {
 	public long getMaxTime() {
 		return mMaxTime;
 	}
-	
+
+	public static TimeBounds fromXdr(org.stellar.sdk.xdr.TimeBounds timeBounds) {
+		if (timeBounds == null) {
+			return null;
+		}
+
+		return new TimeBounds(
+				timeBounds.getMinTime().getUint64().longValue(),
+				timeBounds.getMaxTime().getUint64().longValue()
+		);
+	}
+
 	public org.stellar.sdk.xdr.TimeBounds toXdr() {
 		org.stellar.sdk.xdr.TimeBounds timeBounds = new org.stellar.sdk.xdr.TimeBounds();
 		Uint64 minTime = new Uint64();
@@ -40,5 +51,16 @@ final public class TimeBounds {
 		timeBounds.setMinTime(minTime);
 		timeBounds.setMaxTime(maxTime);
 		return timeBounds;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		TimeBounds that = (TimeBounds) o;
+
+		if (mMinTime != that.mMinTime) return false;
+		return mMaxTime == that.mMaxTime;
 	}
 }

--- a/src/test/java/org/stellar/sdk/TransactionTest.java
+++ b/src/test/java/org/stellar/sdk/TransactionTest.java
@@ -41,6 +41,18 @@ public class TransactionTest {
     assertEquals(transaction.getSourceAccount(), source);
     assertEquals(transaction.getSequenceNumber(), sequenceNumber+1);
     assertEquals(transaction.getFee(), 100);
+
+    Transaction transaction2 = Transaction.fromEnvelopeXdr(transaction.toEnvelopeXdr());
+
+    assertEquals(transaction.getSourceAccount().getAccountId(), transaction2.getSourceAccount().getAccountId());
+    assertEquals(transaction.getSequenceNumber(), transaction2.getSequenceNumber());
+    assertEquals(transaction.getFee(), transaction2.getFee());
+    assertEquals(
+            ((CreateAccountOperation)transaction.getOperations()[0]).getStartingBalance(),
+            ((CreateAccountOperation)transaction2.getOperations()[0]).getStartingBalance()
+    );
+
+    assertEquals(transaction.getSignatures(), transaction2.getSignatures());
   }
 
   @Test
@@ -60,6 +72,17 @@ public class TransactionTest {
     assertEquals(
             "AAAAAF7FIiDToW1fOYUFBC0dmyufJbFTOa2GQESGz+S2h5ViAAAAZAAKVaMAAAABAAAAAAAAAAEAAAAMSGVsbG8gd29ybGQhAAAAAQAAAAAAAAAAAAAAAO3gUmG83C+VCqO6FztuMtXJF/l7grZA7MjRzqdZ9W8QAAAABKgXyAAAAAAAAAAAAbaHlWIAAABAxzofBhoayuUnz8t0T1UNWrTgmJ+lCh9KaeOGu2ppNOz9UGw0abGLhv+9oWQsstaHx6YjwWxL+8GBvwBUVWRlBQ==",
             transaction.toEnvelopeXdrBase64());
+
+    Transaction transaction2 = Transaction.fromEnvelopeXdr(transaction.toEnvelopeXdr());
+
+    assertEquals(transaction.getSourceAccount().getAccountId(), transaction2.getSourceAccount().getAccountId());
+    assertEquals(transaction.getSequenceNumber(), transaction2.getSequenceNumber());
+    assertEquals(transaction.getMemo(), transaction2.getMemo());
+    assertEquals(transaction.getFee(), transaction2.getFee());
+    assertEquals(
+            ((CreateAccountOperation)transaction.getOperations()[0]).getStartingBalance(),
+            ((CreateAccountOperation)transaction2.getOperations()[0]).getStartingBalance()
+    );
   }
   
   @Test
@@ -72,6 +95,7 @@ public class TransactionTest {
     Transaction transaction = new Transaction.Builder(account)
             .addOperation(new CreateAccountOperation.Builder(destination, "2000").build())
             .addTimeBounds(new TimeBounds(42, 1337))
+            .addMemo(Memo.hash("abcdef"))
             .build();
 
     transaction.sign(source);
@@ -86,6 +110,18 @@ public class TransactionTest {
 
     assertEquals(decodedTransaction.getTimeBounds().getMinTime().getUint64().longValue(), 42);
     assertEquals(decodedTransaction.getTimeBounds().getMaxTime().getUint64().longValue(), 1337);
+
+    Transaction transaction2 = Transaction.fromEnvelopeXdr(transaction.toEnvelopeXdr());
+
+    assertEquals(transaction.getSourceAccount().getAccountId(), transaction2.getSourceAccount().getAccountId());
+    assertEquals(transaction.getSequenceNumber(), transaction2.getSequenceNumber());
+    assertEquals(transaction.getMemo(), transaction2.getMemo());
+    assertEquals(transaction.getTimeBounds(), transaction2.getTimeBounds());
+    assertEquals(transaction.getFee(), transaction2.getFee());
+    assertEquals(
+            ((CreateAccountOperation)transaction.getOperations()[0]).getStartingBalance(),
+            ((CreateAccountOperation)transaction2.getOperations()[0]).getStartingBalance()
+    );
   }
 
   @Test


### PR DESCRIPTION
Currently it's not possible to add a new signature to the existing envelope using Java SDK. Added two methods:
* `Transaction.fromEnvelopeXdr(String envelope)`
* `Transaction.fromEnvelopeXdr(TransactionEnvelope envelope)`

that allow creating `Transaction` object from existing envelope to append a new signatures later.

Added helper functions i.e. `fromXdr` and `equals` to some classes to simplify tests.