### PR TITLE
Deserialization of TransactionEnvelope instances from XDR Base64 Strings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compile 'com.google.guava:guava:18.0'
     compile 'com.google.code.gson:gson:2.4'
     compile 'commons-io:commons-io:2.4'
+    compile 'org.apache.commons:commons-lang3:3.7'
     compile 'org.glassfish.jersey.core:jersey-client:2.22.1'
     compile 'org.glassfish.jersey.media:jersey-media-sse:2.22.1'
     compile fileTree(dir: 'libs', include: '*.jar')

--- a/src/main/java/org/stellar/sdk/AccountMergeOperation.java
+++ b/src/main/java/org/stellar/sdk/AccountMergeOperation.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.AccountID;
 import org.stellar.sdk.xdr.Operation.OperationBody;
 import org.stellar.sdk.xdr.OperationType;
@@ -76,5 +78,25 @@ public class AccountMergeOperation extends Operation {
             }
             return operation;
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AccountMergeOperation that = (AccountMergeOperation) o;
+
+        return super.equals(o) && new EqualsBuilder()
+                .append(getDestination().getAccountId(), that.getDestination().getAccountId())
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(getDestination().getAccountId())
+                .toHashCode();
     }
 }

--- a/src/main/java/org/stellar/sdk/AllowTrustOperation.java
+++ b/src/main/java/org/stellar/sdk/AllowTrustOperation.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.AccountID;
 import org.stellar.sdk.xdr.AllowTrustOp;
 import org.stellar.sdk.xdr.AssetType;
@@ -129,5 +131,29 @@ public class AllowTrustOperation extends Operation {
       }
       return operation;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    AllowTrustOperation that = (AllowTrustOperation) o;
+
+    return super.equals(o) && new EqualsBuilder()
+            .append(getAuthorize(), that.getAuthorize())
+            .append(getTrustor().getAccountId(), that.getTrustor().getAccountId())
+            .append(getAssetCode(), that.getAssetCode())
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(getTrustor().getAccountId())
+            .append(getAssetCode())
+            .append(getAuthorize())
+            .toHashCode();
   }
 }

--- a/src/main/java/org/stellar/sdk/ChangeTrustOperation.java
+++ b/src/main/java/org/stellar/sdk/ChangeTrustOperation.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.ChangeTrustOp;
 import org.stellar.sdk.xdr.Int64;
 import org.stellar.sdk.xdr.OperationType;
@@ -94,5 +96,27 @@ public class ChangeTrustOperation extends Operation {
       }
       return operation;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ChangeTrustOperation that = (ChangeTrustOperation) o;
+
+    return super.equals(o) && new EqualsBuilder()
+            .append(getAsset(), that.getAsset())
+            .append(getLimit(), that.getLimit())
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(getAsset())
+            .append(getLimit())
+            .toHashCode();
   }
 }

--- a/src/main/java/org/stellar/sdk/CreateAccountOperation.java
+++ b/src/main/java/org/stellar/sdk/CreateAccountOperation.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.AccountID;
 import org.stellar.sdk.xdr.CreateAccountOp;
 import org.stellar.sdk.xdr.Int64;
@@ -101,5 +103,27 @@ public class CreateAccountOperation extends Operation {
       }
       return operation;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    CreateAccountOperation that = (CreateAccountOperation) o;
+
+    return super.equals(o) && new EqualsBuilder()
+            .append(getDestination().getAccountId(), that.getDestination().getAccountId())
+            .append(getStartingBalance(), that.getStartingBalance())
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(getDestination().getAccountId())
+            .append(getStartingBalance())
+            .toHashCode();
   }
 }

--- a/src/main/java/org/stellar/sdk/CreatePassiveOfferOperation.java
+++ b/src/main/java/org/stellar/sdk/CreatePassiveOfferOperation.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.CreatePassiveOfferOp;
 import org.stellar.sdk.xdr.Int64;
 import org.stellar.sdk.xdr.OperationType;
@@ -132,5 +134,31 @@ public class CreatePassiveOfferOperation extends Operation {
       }
       return operation;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    CreatePassiveOfferOperation that = (CreatePassiveOfferOperation) o;
+
+    return super.equals(o) && new EqualsBuilder()
+            .append(getSelling(), that.getSelling())
+            .append(getBuying(), that.getBuying())
+            .append(getAmount(), that.getAmount())
+            .append(getPrice(), that.getPrice())
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(getSelling())
+            .append(getBuying())
+            .append(getAmount())
+            .append(getPrice())
+            .toHashCode();
   }
 }

--- a/src/main/java/org/stellar/sdk/InflationOperation.java
+++ b/src/main/java/org/stellar/sdk/InflationOperation.java
@@ -13,4 +13,15 @@ public class InflationOperation extends Operation {
         body.setDiscriminant(OperationType.INFLATION);
         return body;
     }
+
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o || super.equals(o) && o instanceof InflationOperation;
+    }
+
+    @Override
+    public int hashCode() {
+        return InflationOperation.class.hashCode();
+    }
 }

--- a/src/main/java/org/stellar/sdk/ManageDataOperation.java
+++ b/src/main/java/org/stellar/sdk/ManageDataOperation.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.DataValue;
 import org.stellar.sdk.xdr.ManageDataOp;
 import org.stellar.sdk.xdr.OperationType;
@@ -103,5 +105,27 @@ public class ManageDataOperation extends Operation {
       }
       return operation;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ManageDataOperation that = (ManageDataOperation) o;
+
+    return super.equals(o) && new EqualsBuilder()
+            .append(getName(), that.getName())
+            .append(getValue(), that.getValue())
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(getName())
+            .append(getValue())
+            .toHashCode();
   }
 }

--- a/src/main/java/org/stellar/sdk/ManageOfferOperation.java
+++ b/src/main/java/org/stellar/sdk/ManageOfferOperation.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.CreateAccountOp;
 import org.stellar.sdk.xdr.Int64;
 import org.stellar.sdk.xdr.ManageOfferOp;
@@ -161,5 +163,33 @@ public class ManageOfferOperation extends Operation {
       }
       return operation;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ManageOfferOperation that = (ManageOfferOperation) o;
+
+    return super.equals(o) && new EqualsBuilder()
+            .append(getOfferId(), that.getOfferId())
+            .append(getSelling(), that.getSelling())
+            .append(getBuying(), that.getBuying())
+            .append(getAmount(), that.getAmount())
+            .append(getPrice(), that.getPrice())
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(getSelling())
+            .append(getBuying())
+            .append(getAmount())
+            .append(getPrice())
+            .append(getOfferId())
+            .toHashCode();
   }
 }

--- a/src/main/java/org/stellar/sdk/Memo.java
+++ b/src/main/java/org/stellar/sdk/Memo.java
@@ -71,5 +71,28 @@ public abstract class Memo {
         return new MemoReturnHash(BaseEncoding.base16().lowerCase().decode(hexString.toLowerCase()));
     }
 
+    /**
+     * Creates a Memo from an XDR Memo instance.
+     */
+    public static Memo fromXdr(org.stellar.sdk.xdr.Memo memo) {
+        if (memo == null) {
+            return Memo.none();
+        }
+        switch (memo.getDiscriminant()) {
+            case MEMO_NONE:
+                return Memo.none();
+            case MEMO_TEXT:
+                return new MemoText(memo.getText());
+            case MEMO_ID:
+                return new MemoId(memo.getId().getUint64());
+            case MEMO_HASH:
+                return new MemoHash(memo.getHash().getHash());
+            case MEMO_RETURN:
+                return new MemoReturnHash(memo.getHash().getHash());
+            default:
+                throw new AssertionError("Unrecognized memo discriminant: " + memo.getDiscriminant());
+        }
+    }
+
     abstract org.stellar.sdk.xdr.Memo toXdr();
 }

--- a/src/main/java/org/stellar/sdk/Memo.java
+++ b/src/main/java/org/stellar/sdk/Memo.java
@@ -88,7 +88,7 @@ public abstract class Memo {
             case MEMO_HASH:
                 return new MemoHash(memo.getHash().getHash());
             case MEMO_RETURN:
-                return new MemoReturnHash(memo.getHash().getHash());
+                return new MemoReturnHash(memo.getRetHash().getHash());
             default:
                 throw new AssertionError("Unrecognized memo discriminant: " + memo.getDiscriminant());
         }

--- a/src/main/java/org/stellar/sdk/MemoHashAbstract.java
+++ b/src/main/java/org/stellar/sdk/MemoHashAbstract.java
@@ -2,6 +2,8 @@ package org.stellar.sdk;
 
 import com.google.common.io.BaseEncoding;
 
+import java.util.Arrays;
+
 abstract class MemoHashAbstract extends Memo {
   protected byte[] bytes;
 
@@ -57,4 +59,19 @@ abstract class MemoHashAbstract extends Memo {
 
   @Override
   abstract org.stellar.sdk.xdr.Memo toXdr();
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    MemoHashAbstract that = (MemoHashAbstract) o;
+
+    return Arrays.equals(getBytes(), that.getBytes());
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(getBytes());
+  }
 }

--- a/src/main/java/org/stellar/sdk/MemoId.java
+++ b/src/main/java/org/stellar/sdk/MemoId.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.MemoType;
 import org.stellar.sdk.xdr.Uint64;
 
@@ -28,5 +30,25 @@ public class MemoId extends Memo {
     idXdr.setUint64(id);
     memo.setId(idXdr);
     return memo;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    MemoId memoId = (MemoId) o;
+
+    return new EqualsBuilder()
+            .append(getId(), memoId.getId())
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(getId())
+            .toHashCode();
   }
 }

--- a/src/main/java/org/stellar/sdk/MemoNone.java
+++ b/src/main/java/org/stellar/sdk/MemoNone.java
@@ -12,4 +12,14 @@ public class MemoNone extends Memo {
     memo.setDiscriminant(MemoType.MEMO_NONE);
     return memo;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    return this == o || o instanceof MemoNone;
+  }
+
+  @Override
+  public int hashCode() {
+    return MemoNone.class.hashCode();
+  }
 }

--- a/src/main/java/org/stellar/sdk/MemoReturnHash.java
+++ b/src/main/java/org/stellar/sdk/MemoReturnHash.java
@@ -21,9 +21,9 @@ public class MemoReturnHash extends MemoHashAbstract {
     memo.setDiscriminant(MemoType.MEMO_RETURN);
 
     org.stellar.sdk.xdr.Hash hash = new org.stellar.sdk.xdr.Hash();
-    hash.setHash(bytes); // todo -
+    hash.setHash(bytes);
 
-    memo.setHash(hash);
+    memo.setRetHash(hash);
     return memo;
   }
 }

--- a/src/main/java/org/stellar/sdk/MemoReturnHash.java
+++ b/src/main/java/org/stellar/sdk/MemoReturnHash.java
@@ -21,7 +21,7 @@ public class MemoReturnHash extends MemoHashAbstract {
     memo.setDiscriminant(MemoType.MEMO_RETURN);
 
     org.stellar.sdk.xdr.Hash hash = new org.stellar.sdk.xdr.Hash();
-    hash.setHash(bytes);
+    hash.setHash(bytes); // todo -
 
     memo.setHash(hash);
     return memo;

--- a/src/main/java/org/stellar/sdk/MemoText.java
+++ b/src/main/java/org/stellar/sdk/MemoText.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.MemoType;
 
 import java.nio.charset.Charset;
@@ -31,5 +33,25 @@ public class MemoText extends Memo {
     memo.setDiscriminant(MemoType.MEMO_TEXT);
     memo.setText(text);
     return memo;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    MemoText memoText = (MemoText) o;
+
+    return new EqualsBuilder()
+            .append(getText(), memoText.getText())
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(getText())
+            .toHashCode();
   }
 }

--- a/src/main/java/org/stellar/sdk/Operation.java
+++ b/src/main/java/org/stellar/sdk/Operation.java
@@ -1,6 +1,8 @@
 package org.stellar.sdk;
 
 import com.google.common.io.BaseEncoding;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.AccountID;
 import org.stellar.sdk.xdr.XdrDataOutputStream;
 
@@ -128,4 +130,18 @@ public abstract class Operation {
    * @return OperationBody XDR object
    */
   abstract org.stellar.sdk.xdr.Operation.OperationBody toOperationBody();
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    Operation operation = (Operation) o;
+
+    return (mSourceAccount == null) ? operation.mSourceAccount == null : operation.mSourceAccount != null &&
+            new EqualsBuilder()
+            .append(mSourceAccount.getAccountId(), operation.mSourceAccount.getAccountId())
+            .isEquals();
+  }
 }

--- a/src/main/java/org/stellar/sdk/PathPaymentOperation.java
+++ b/src/main/java/org/stellar/sdk/PathPaymentOperation.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.AccountID;
 import org.stellar.sdk.xdr.Int64;
 import org.stellar.sdk.xdr.OperationType;
@@ -188,5 +190,35 @@ public class PathPaymentOperation extends Operation {
       }
       return operation;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    PathPaymentOperation that = (PathPaymentOperation) o;
+
+    return super.equals(o) && new EqualsBuilder()
+            .append(getSendAsset(), that.getSendAsset())
+            .append(getSendMax(), that.getSendMax())
+            .append(getDestination().getAccountId(), that.getDestination().getAccountId())
+            .append(getDestAsset(), that.getDestAsset())
+            .append(getDestAmount(), that.getDestAmount())
+            .append(getPath(), that.getPath())
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(getSendAsset())
+            .append(getSendMax())
+            .append(getDestination().getAccountId())
+            .append(getDestAsset())
+            .append(getDestAmount())
+            .append(getPath())
+            .toHashCode();
   }
 }

--- a/src/main/java/org/stellar/sdk/PaymentOperation.java
+++ b/src/main/java/org/stellar/sdk/PaymentOperation.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.AccountID;
 import org.stellar.sdk.xdr.Int64;
 import org.stellar.sdk.xdr.OperationType;
@@ -119,5 +121,29 @@ public class PaymentOperation extends Operation {
       }
       return operation;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    PaymentOperation that = (PaymentOperation) o;
+
+    return super.equals(o) && new EqualsBuilder()
+            .append(getDestination().getAccountId(), that.getDestination().getAccountId())
+            .append(getAsset(), that.getAsset())
+            .append(getAmount(), that.getAmount())
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(getDestination())
+            .append(getAsset())
+            .append(getAmount())
+            .toHashCode();
   }
 }

--- a/src/main/java/org/stellar/sdk/SetOptionsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetOptionsOperation.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.*;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -339,5 +341,49 @@ public class SetOptionsOperation extends Operation {
       }
       return operation;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    SetOptionsOperation that = (SetOptionsOperation) o;
+
+    return super.equals(o) && new EqualsBuilder()
+            .append(getInflationDestination().getAccountId(), that.getInflationDestination().getAccountId())
+            .append(getClearFlags(), that.getClearFlags())
+            .append(getSetFlags(), that.getSetFlags())
+            .append(getMasterKeyWeight(), that.getMasterKeyWeight())
+            .append(getLowThreshold(), that.getLowThreshold())
+            .append(getMediumThreshold(), that.getMediumThreshold())
+            .append(getHighThreshold(), that.getHighThreshold())
+            .append(getHomeDomain(), that.getHomeDomain())
+            .append(getSigner().getDiscriminant(), that.getSigner().getDiscriminant())
+            .append(getSigner().getEd25519().getUint256(), that.getSigner().getEd25519().getUint256())
+            .append(getSigner().getHashX().getUint256(), that.getSigner().getHashX().getUint256())
+            .append(getSigner().getPreAuthTx().getUint256(), that.getSigner().getPreAuthTx().getUint256())
+            .append(getSignerWeight(), that.getSignerWeight())
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(getInflationDestination())
+            .append(getClearFlags())
+            .append(getSetFlags())
+            .append(getMasterKeyWeight())
+            .append(getLowThreshold())
+            .append(getMediumThreshold())
+            .append(getHighThreshold())
+            .append(getHomeDomain())
+            .append(getSigner().getDiscriminant())
+            .append(getSigner().getEd25519().getUint256())
+            .append(getSigner().getHashX().getUint256())
+            .append(getSigner().getPreAuthTx().getUint256())
+            .append(getSignerWeight())
+            .toHashCode();
   }
 }

--- a/src/main/java/org/stellar/sdk/TimeBounds.java
+++ b/src/main/java/org/stellar/sdk/TimeBounds.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.stellar.sdk.xdr.Uint64;
 
 /**
@@ -22,8 +24,8 @@ final public class TimeBounds {
 		mMinTime = minTime;
 		mMaxTime = maxTime;
 	}
-	
-	public long getMinTime() {
+
+    public long getMinTime() {
 		return mMinTime;
 	}
 	
@@ -40,5 +42,37 @@ final public class TimeBounds {
 		timeBounds.setMinTime(minTime);
 		timeBounds.setMaxTime(maxTime);
 		return timeBounds;
+	}
+
+	/**
+	 * Constructs a TimeBounds instance from an XDR TimeBounds instance.
+	 */
+	public static TimeBounds fromXdr(org.stellar.sdk.xdr.TimeBounds bounds) {
+		return (bounds == null) ? null : new TimeBounds(
+				bounds.getMinTime().getUint64(),
+				bounds.getMaxTime().getUint64()
+		);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+
+		if (o == null || getClass() != o.getClass()) return false;
+
+		TimeBounds that = (TimeBounds) o;
+
+		return new EqualsBuilder()
+				.append(mMinTime, that.mMinTime)
+				.append(mMaxTime, that.mMaxTime)
+				.isEquals();
+	}
+
+	@Override
+	public int hashCode() {
+		return new HashCodeBuilder(17, 37)
+				.append(mMinTime)
+				.append(mMaxTime)
+				.toHashCode();
 	}
 }

--- a/src/test/java/org/stellar/sdk/MemoTest.java
+++ b/src/test/java/org/stellar/sdk/MemoTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.stellar.sdk.xdr.MemoType;
 
 import java.util.Arrays;
+import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -114,5 +115,55 @@ public class MemoTest {
         MemoReturnHash memo = Memo.returnHash("4142434445464748494a4b4c");
         assertEquals(MemoType.MEMO_RETURN, memo.toXdr().getDiscriminant());
         assertEquals("4142434445464748494a4b4c", memo.getTrimmedHexValue());
+    }
+
+    @Test
+    public void testMemoNoneFromXDR() {
+        Memo expected = new MemoNone();
+        Memo actual = Memo.fromXdr(expected.toXdr());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testMemoIdFromXDR() {
+        Memo expected = new MemoId(Math.abs(new Random().nextLong()));
+        Memo actual = Memo.fromXdr(expected.toXdr());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testMemoTextFromXDR() {
+        Memo expected = new MemoText(randomString());
+        Memo actual = Memo.fromXdr(expected.toXdr());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testMemoHashFromXDR() {
+        Memo expected = new MemoHash(randomString().getBytes());
+        Memo actual = Memo.fromXdr(expected.toXdr());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testMemoRetHashFromXDR() {
+        Memo expected = new MemoReturnHash(randomString().getBytes());
+        Memo actual = Memo.fromXdr(expected.toXdr());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testMemoNullFromXDR() {
+        assertEquals(Memo.none(), Memo.fromXdr(null));
+    }
+
+    private String randomString() {
+        StringBuilder b = new StringBuilder();
+        Random rand = new Random();
+        int length = rand.nextInt(27) + 1;
+        for (int i = 0; i < length; i++) {
+            b.append((char)(rand.nextInt(95)+ 32));
+        }
+        return b.toString();
     }
 }

--- a/src/test/java/org/stellar/sdk/TimeBoundsTest.java
+++ b/src/test/java/org/stellar/sdk/TimeBoundsTest.java
@@ -1,0 +1,31 @@
+package org.stellar.sdk;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class TimeBoundsTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMinEqualsMax() {
+        new TimeBounds(5000, 5000);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMinAfterMax() {
+        new TimeBounds(5001, 5000);
+    }
+
+    @Test
+    public void testFromXdr() {
+        TimeBounds expected = new TimeBounds(3000, 9000);
+        TimeBounds actual = TimeBounds.fromXdr(expected.toXdr());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testFromXdrWhenNull() {
+        assertNull(TimeBounds.fromXdr(null));
+    }
+}

--- a/src/test/java/org/stellar/sdk/TransactionTest.java
+++ b/src/test/java/org/stellar/sdk/TransactionTest.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -147,6 +148,23 @@ public class TransactionTest {
     } catch (RuntimeException exception) {
       assertTrue(exception.getMessage().contains("Transaction must be signed by at least one signer."));
     }
+  }
+
+  @Test
+  public void testFromEnvelopeXdrBase64Success() {
+    KeyPair source = KeyPair.random();
+    KeyPair destination = KeyPair.random();
+
+    Account account = new Account(source, Math.abs(new Random().nextLong()));
+    Transaction transaction = new Transaction.Builder(account)
+            .addOperation(new CreateAccountOperation.Builder(destination, "2000").build())
+            .addOperation(new PaymentOperation.Builder(destination, new AssetTypeNative(), "5000").build())
+            .build();
+    transaction.sign(source);
+
+    Transaction actual = Transaction.fromEnvelopeXdrBase64(transaction.toEnvelopeXdrBase64());
+
+    assertEquals(transaction, actual);
   }
 
   @Test


### PR DESCRIPTION
Addition of methods to deserialize TransactionEnvelope instances from XDR Base64 Strings.

- `public static Transaction fromEnvelopeXdrBase64(String base64)`
- `public static Transaction fromEnvelopeXdr(TransactionEnvelope envelope)`
- `public static Transaction fromXdr(org.stellar.sdk.xdr.Transaction tx)`

Added other static `fromXdr` methods as needed:

- `public static TimeBounds fromXdr(org.stellar.sdk.xdr.TimeBounds bounds)`
- `public static Memo fromXdr(org.stellar.sdk.xdr.Memo memo)`

Added `equals(Object other)` and `hashCode()` methods where appropriate to permit test coverage.
