### PR TITLE
Improve Server.submitTransaction

### DIFF
--- a/src/main/java/org/stellar/sdk/Server.java
+++ b/src/main/java/org/stellar/sdk/Server.java
@@ -160,6 +160,8 @@ public class Server {
      * Submits transaction to the network.
      * @param transaction transaction to submit to the network.
      * @return {@link SubmitTransactionResponse}
+     * @throws SubmitTransactionTimeoutResponseException When Horizon returns a <code>Timeout</code> or connection timeout occured.
+     * @throws SubmitTransactionUnknownResponseException When unknown Horizon response is returned.
      * @throws IOException
      */
     public SubmitTransactionResponse submitTransaction(Transaction transaction) throws IOException {

--- a/src/main/java/org/stellar/sdk/responses/SubmitTransactionTimeoutResponseException.java
+++ b/src/main/java/org/stellar/sdk/responses/SubmitTransactionTimeoutResponseException.java
@@ -1,0 +1,8 @@
+package org.stellar.sdk.responses;
+
+public class SubmitTransactionTimeoutResponseException extends RuntimeException {
+    @Override
+    public String getMessage() {
+        return "Timeout. Please resubmit your transaction to receive submission status. More info: https://www.stellar.org/developers/horizon/reference/errors/timeout.html";
+    }
+}

--- a/src/main/java/org/stellar/sdk/responses/SubmitTransactionUnknownResponseException.java
+++ b/src/main/java/org/stellar/sdk/responses/SubmitTransactionUnknownResponseException.java
@@ -1,0 +1,24 @@
+package org.stellar.sdk.responses;
+
+public class SubmitTransactionUnknownResponseException extends RuntimeException {
+    private int code;
+    private String body;
+
+    public SubmitTransactionUnknownResponseException(int code, String body) {
+        this.code = code;
+        this.body = body;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Unknown response from Horizon";
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getBody() {
+        return body;
+    }
+}


### PR DESCRIPTION
Improves `Server.submitTransaction` by:
- Creating another `OkHttpClient` internal instance used only for
  submitting transactions. This special instance has a longer read
  timeout.
- Throwing `SubmitTransactionTimeoutResponseException` when Horizon
  returns `Timeout` response or HTTP client throws
  `SocketTimeoutException`.
- Throwing `SubmitTransactionUnknownResponseException` for unknown
  responses with attached response code and body.

This is a breaking change so I want to release it along #112 and #96.