### PR TITLE
shade all dependencies to avoid conflicts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,11 @@ dependencies {
 }
 
 jar.enabled = false
+
 assemble.dependsOn(shadowJar);
 
 shadowJar {
+   archiveName 'stellar-sdk.jar'
    relocate 'com','shadow.com'
    relocate 'net','shadow.net'
    relocate 'org.glassfish','shadow.org.glassfish'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+
+plugins {
+  id "com.github.johnrengelman.shadow" version "2.0.4"
+}
+
+apply plugin: "com.github.johnrengelman.shadow"
 apply plugin: 'java'
 apply plugin: 'ivy-publish'
 
@@ -44,4 +50,23 @@ dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
     testCompile 'com.squareup.okhttp3:mockwebserver:3.9.1'
     testCompile group: 'junit', name: 'junit', version: '4.11'
+}
+
+jar.enabled = false
+assemble.dependsOn(shadowJar);
+
+shadowJar {
+   relocate 'com','shadow.com'
+   relocate 'net','shadow.net'
+   relocate 'org.glassfish','shadow.org.glassfish'
+   relocate 'org.mockito','shadow.org.mockito'
+   relocate 'org.aopalliance','shadow.org.aopalliance'
+   relocate 'org.apache','shadow.org.apache'
+   relocate 'org.jvnet','shadow.org.jvnet'
+   relocate 'org.objenesis','shadow.org.objenesis'
+   relocate 'javassist','shadow.javassist'
+   relocate 'javax', 'shadow.javax'
+   relocate 'commons-io', 'shadow.commons-io'
+   relocate 'jersey', 'shadow.jersey'
+   relocate 'okhttp3','shadow.okhttp3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -65,8 +65,13 @@ shadowJar {
    relocate 'org.jvnet','shadow.org.jvnet'
    relocate 'org.objenesis','shadow.org.objenesis'
    relocate 'javassist','shadow.javassist'
-   relocate 'javax', 'shadow.javax'
+   relocate 'javax.validation', 'shadow.javax.validation'
+   relocate 'javax.annotation', 'shadow.javax.annotation'
+   relocate 'javax.inject', 'shadow.javax.inject'
+   relocate 'javax.ws', 'shadow.javax.inject'
    relocate 'commons-io', 'shadow.commons-io'
    relocate 'jersey', 'shadow.jersey'
    relocate 'okhttp3','shadow.okhttp3'
+   relocate 'okio','shadow.okio'
+
 }


### PR DESCRIPTION
Addresses #122

We cannot use the original jar because of Spring Boot autoconfiguring included things, which then fails because they are old versions. Gson and javax.validation are the two problematic dependencies. 

There are several other things in the dependencies that I'd prefer to not have there like jersey and mockito (why is this a compile dependency).

Shading takes care of removing the conflicts for us; so I simply shaded everything. 

I've signed the contributor agreement.