### PR TITLE
Add Transaction.Builder.setTimeout method

### DIFF
--- a/src/main/java/org/stellar/sdk/Transaction.java
+++ b/src/main/java/org/stellar/sdk/Transaction.java
@@ -344,6 +344,10 @@ public class Transaction {
         throw new RuntimeException("TimeBounds.max_time has been already set - setting timeout would overwrite it.");
       }
 
+      if (timeout < 0) {
+        throw new RuntimeException("timeout cannot be negative");
+      }
+
       timeoutSet = true;
       if (timeout > 0) {
         long timeoutTimestamp = System.currentTimeMillis() / 1000L + timeout;

--- a/src/test/java/org/stellar/sdk/OperationTest.java
+++ b/src/test/java/org/stellar/sdk/OperationTest.java
@@ -352,6 +352,7 @@ public class OperationTest {
     Account account = new Account(source, sequenceNumber);
     Transaction transaction = new Transaction.Builder(account)
             .addOperation(new CreateAccountOperation.Builder(destination, "2000").build())
+            .setTimeout(Transaction.Builder.TIMEOUT_INFINITE)
             .build();
 
     // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF

--- a/src/test/java/org/stellar/sdk/ServerTest.java
+++ b/src/test/java/org/stellar/sdk/ServerTest.java
@@ -135,7 +135,8 @@ public class ServerTest {
         Account account = new Account(source, 2908908335136768L);
         Transaction.Builder builder = new Transaction.Builder(account)
                 .addOperation(new CreateAccountOperation.Builder(destination, "2000").build())
-                .addMemo(Memo.text("Hello world!"));
+                .addMemo(Memo.text("Hello world!"))
+                .setTimeout(Transaction.Builder.TIMEOUT_INFINITE);
 
         assertEquals(1, builder.getOperationsCount());
         Transaction transaction = builder.build();

--- a/src/test/java/org/stellar/sdk/TransactionTest.java
+++ b/src/test/java/org/stellar/sdk/TransactionTest.java
@@ -140,6 +140,22 @@ public class TransactionTest {
   }
 
   @Test
+  public void testBuilderTimeoutNegative() throws IOException {
+    Account account = new Account(KeyPair.random(), 2908908335136768L);
+    try {
+      new Transaction.Builder(account)
+              .addOperation(new CreateAccountOperation.Builder(KeyPair.random(), "2000").build())
+              .addMemo(Memo.hash("abcdef"))
+              .setTimeout(-1)
+              .build();
+      fail();
+    } catch (RuntimeException exception) {
+      assertTrue(exception.getMessage().contains("timeout cannot be negative"));
+      assertEquals(new Long(2908908335136768L), account.getSequenceNumber());
+    }
+  }
+
+  @Test
   public void testBuilderTimeoutSetsTimeBounds() throws IOException {
     Account account = new Account(KeyPair.random(), 2908908335136768L);
     Transaction transaction = new Transaction.Builder(account)


### PR DESCRIPTION
This PR adds `Transaction.Builder.setTimeout` method to help prevent situations described in https://github.com/stellar/stellar-core/issues/1811. `Transaction.Builder.setTimeout` sets `timebounds.max_time` on a transaction if it is not set yet. It is required to call:
```java
TransactionBuilder.setTimeout(Transaction.Builder.TIMEOUT_INFINITE);
```
if no `timebounds.max_time` should be set to ensure that developers know about possible implications.