### PR TITLE
Drop Guava Android workaround, fix Spring Boot 2, fix Swagger 2, add …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'maven' // needed to add the install task for jitpack.io
 apply plugin: 'com.github.ben-manes.versions' // gradle dependencyUpdates -Drevision=release
 apply plugin: 'project-report' // gradle htmlDependencyReport
 
-sourceCompatibility = 1.6
+sourceCompatibility = 1.8
 version = '0.3.2'
 group = 'stellar'
 
@@ -40,13 +40,15 @@ repositories {
 dependencies {
     compile 'com.squareup.okhttp3:okhttp:3.11.0'
     compile 'com.moandjiezana.toml:toml4j:0.7.2'
-    // use the android version because we don't want java 8 stuff
-    compile 'com.google.guava:guava:26.0-android'
+    compile 'com.google.guava:guava:26.0-jre'
     compile 'com.google.code.gson:gson:2.8.5'
     compile 'commons-io:commons-io:2.6'
     compile 'org.glassfish.jersey.core:jersey-client:2.27'
     compile 'org.glassfish.jersey.media:jersey-media-sse:2.27'
     compile 'net.i2p.crypto:eddsa:0.3.0'
+    compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.11'
+    compile group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.2.11'
+    compile group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.2.11'
 
     testCompile 'org.mockito:mockito-core:2.21.0'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.11.0'
@@ -87,6 +89,7 @@ shadowJar {
    relocate 'org.codehaus','shadow.org.codehaus'
    relocate 'org.checkerframework','shadow.org.checkerframework'
    relocate 'javassist','shadow.javassist'
+   relocate 'javax.xml', 'shadow.javax.xml'
    relocate 'javax.validation', 'shadow.javax.validation'
    relocate 'javax.annotation', 'shadow.javax.annotation'
    relocate 'javax.inject', 'shadow.javax.inject'


### PR DESCRIPTION
…Java 8 support

*** Advice for build system, dependencies (Spring Boot 2.x, Swagger 2, perhaps any 2018 Java app) ***
Compiling SDK:
```
> Task :compileJava
warning: [options] source value 6 is obsolete and will be removed in a future release
warning: [options] target value 1.6 is obsolete and will be removed in a future release
```

Using SDK with Swagger 2:
```
Caused by: java.lang.NoSuchMethodError: com.google.common.collect.FluentIterable.concat(Ljava/lang/Iterable;Ljava/lang/Iterable;)Lcom/google/common/collect/FluentIterable;
~[java-stellar-sdk-0.3.3.jar:0.3.2]
```

Using SDK with Spring Boot 2:
```
javax.validation api clash on classpath v1 vs v2
```

Really? This is how you develop Java on computer? This is the nightmare and main cause of trouble and shading requirements (which does not work for me, that's why I post here):
```
    // use the android version because we don't want java 8 stuff
    compile 'com.google.guava:guava:26.0-android'
```