### PR TITLE
enable setting custom base fee on transactions as default and on builder

### DIFF
--- a/src/main/java/org/stellar/sdk/Transaction.java
+++ b/src/main/java/org/stellar/sdk/Transaction.java
@@ -19,9 +19,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Represents <a href="https://www.stellar.org/developers/learn/concepts/transactions.html" target="_blank">Transaction</a> in Stellar network.
  */
 public class Transaction {
-  private static final int BASE_FEE = 100;
-  private static Integer defaultOperationFee;
-
   private final int mFee;
   private final KeyPair mSourceAccount;
   private final long mSequenceNumber;
@@ -50,14 +47,6 @@ public class Transaction {
     checkNotNull(signer, "signer cannot be null");
     byte[] txHash = this.hash();
     mSignatures.add(signer.signDecorated(txHash));
-  }
-
-  public static void setDefaultOperationFee(int opFee) {
-    if (opFee < BASE_FEE) {
-      throw new IllegalArgumentException("DefaultOperationFee cannot be smaller than the BASE_FEE (" + BASE_FEE + "): " + opFee);
-    }
-
-    defaultOperationFee = opFee;
   }
 
   /**
@@ -262,14 +251,24 @@ public class Transaction {
    * Builds a new Transaction object.
    */
   public static class Builder {
+    private static final int BASE_FEE = 100;
     private final TransactionBuilderAccount mSourceAccount;
     private Memo mMemo;
     private TimeBounds mTimeBounds;
     List<Operation> mOperations;
     private boolean timeoutSet;
+    private static Integer defaultOperationFee;
     private Integer operationFee;
 
     public static final long TIMEOUT_INFINITE = 0;
+
+    public static void setDefaultOperationFee(int opFee) {
+      if (opFee < BASE_FEE) {
+        throw new IllegalArgumentException("DefaultOperationFee cannot be smaller than the BASE_FEE (" + BASE_FEE + "): " + opFee);
+      }
+
+      defaultOperationFee = opFee;
+    }
 
     /**
      * Construct a new transaction builder.
@@ -387,7 +386,7 @@ public class Transaction {
       }
 
       if (operationFee == null) {
-        System.out.println("[TransactionBuilder] The `operationFee` parameter of `Transaction` or `TransactionBuilder` is required. Setting to BASE_FEE=" + BASE_FEE + ". Future versions of this library will error if not provided.");
+        System.out.println("[TransactionBuilder] The `operationFee` parameter of `TransactionBuilder` is required. Setting to BASE_FEE=" + BASE_FEE + ". Future versions of this library will error if not provided.");
         operationFee = BASE_FEE;
       }
 

--- a/src/test/java/org/stellar/sdk/TransactionTest.java
+++ b/src/test/java/org/stellar/sdk/TransactionTest.java
@@ -24,7 +24,7 @@ public class TransactionTest {
     KeyPair source = KeyPair.fromSecretSeed("SCH27VUZZ6UAKB67BDNF6FA42YMBMQCBKXWGMFD5TZ6S5ZZCZFLRXKHS");
     KeyPair destination = KeyPair.fromAccountId("GDW6AUTBXTOC7FIKUO5BOO3OGLK4SF7ZPOBLMQHMZDI45J2Z6VXRB5NR");
 
-    Transaction.setDefaultOperationFee(2345);
+    Transaction.Builder.setDefaultOperationFee(2345);
 
     Account account = new Account(source, 2908908335136768L);
     Transaction transaction = new Transaction.Builder(account)
@@ -52,14 +52,14 @@ public class TransactionTest {
   @Test
   public void testDefaultBaseFeeThrows() {
     try {
-      Transaction.setDefaultOperationFee(99);
+      Transaction.Builder.setDefaultOperationFee(99);
       fail("expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       // expected
     }
 
     // should succeed
-    Transaction.setDefaultOperationFee(100);
+    Transaction.Builder.setDefaultOperationFee(100);
   }
 
   @Test

--- a/src/test/java/org/stellar/sdk/TransactionTest.java
+++ b/src/test/java/org/stellar/sdk/TransactionTest.java
@@ -24,7 +24,7 @@ public class TransactionTest {
     KeyPair source = KeyPair.fromSecretSeed("SCH27VUZZ6UAKB67BDNF6FA42YMBMQCBKXWGMFD5TZ6S5ZZCZFLRXKHS");
     KeyPair destination = KeyPair.fromAccountId("GDW6AUTBXTOC7FIKUO5BOO3OGLK4SF7ZPOBLMQHMZDI45J2Z6VXRB5NR");
 
-    Transaction.setDefaultBaseFee(2345);
+    Transaction.setDefaultOperationFee(2345);
 
     Account account = new Account(source, 2908908335136768L);
     Transaction transaction = new Transaction.Builder(account)
@@ -52,14 +52,14 @@ public class TransactionTest {
   @Test
   public void testDefaultBaseFeeThrows() {
     try {
-      Transaction.setDefaultBaseFee(99);
+      Transaction.setDefaultOperationFee(99);
       fail("expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       // expected
     }
 
     // should succeed
-    Transaction.setDefaultBaseFee(100);
+    Transaction.setDefaultOperationFee(100);
   }
 
   @Test
@@ -177,7 +177,7 @@ public class TransactionTest {
     Account account = new Account(source, 2908908335136768L);
     Transaction transaction = new Transaction.Builder(account)
             .addOperation(new CreateAccountOperation.Builder(destination, "2000").build())
-            .setBaseFee(200)
+            .setOperationFee(200)
             .setTimeout(Transaction.Builder.TIMEOUT_INFINITE)
             .build();
 
@@ -206,7 +206,7 @@ public class TransactionTest {
     Account account = new Account(source, 2908908335136768L);
     Transaction.Builder builder = new Transaction.Builder(account);
     try {
-      builder.setBaseFee(99);
+      builder.setOperationFee(99);
       fail("expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       // expected

--- a/src/test/java/org/stellar/sdk/TransactionTest.java
+++ b/src/test/java/org/stellar/sdk/TransactionTest.java
@@ -19,6 +19,50 @@ public class TransactionTest {
   }
 
   @Test
+  public void testDefaultBaseFee() throws FormatException {
+    // GBPMKIRA2OQW2XZZQUCQILI5TMVZ6JNRKM423BSAISDM7ZFWQ6KWEBC4
+    KeyPair source = KeyPair.fromSecretSeed("SCH27VUZZ6UAKB67BDNF6FA42YMBMQCBKXWGMFD5TZ6S5ZZCZFLRXKHS");
+    KeyPair destination = KeyPair.fromAccountId("GDW6AUTBXTOC7FIKUO5BOO3OGLK4SF7ZPOBLMQHMZDI45J2Z6VXRB5NR");
+
+    Transaction.setDefaultBaseFee(2345);
+
+    Account account = new Account(source, 2908908335136768L);
+    Transaction transaction = new Transaction.Builder(account)
+            .addOperation(new CreateAccountOperation.Builder(destination, "2000").build())
+            .setTimeout(Transaction.Builder.TIMEOUT_INFINITE)
+            .build();
+
+    transaction.sign(source);
+
+    assertEquals(
+            "AAAAAF7FIiDToW1fOYUFBC0dmyufJbFTOa2GQESGz+S2h5ViAAAJKQAKVaMAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxAAAAAEqBfIAAAAAAAAAAABtoeVYgAAAEDf8XAGz9uOmfL0KJBP29eSXz/CZqZtl0Mm8jHye3xwLgo2HJDfvCJdijGKsx34AfNl6hvX+Cq3IVk062sLSuoK",
+            transaction.toEnvelopeXdrBase64());
+
+    Transaction transaction2 = Transaction.fromEnvelopeXdr(transaction.toEnvelopeXdr());
+
+    assertEquals(transaction.getSourceAccount().getAccountId(), transaction2.getSourceAccount().getAccountId());
+    assertEquals(transaction.getSequenceNumber(), transaction2.getSequenceNumber());
+    assertEquals(transaction.getFee(), transaction2.getFee());
+    assertEquals(
+            ((CreateAccountOperation)transaction.getOperations()[0]).getStartingBalance(),
+            ((CreateAccountOperation)transaction2.getOperations()[0]).getStartingBalance()
+    );
+  }
+
+  @Test
+  public void testDefaultBaseFeeThrows() {
+    try {
+      Transaction.setDefaultBaseFee(99);
+      fail("expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    // should succeed
+    Transaction.setDefaultBaseFee(100);
+  }
+
+  @Test
   public void testBuilderSuccessTestnet() throws FormatException {
     // GBPMKIRA2OQW2XZZQUCQILI5TMVZ6JNRKM423BSAISDM7ZFWQ6KWEBC4
     KeyPair source = KeyPair.fromSecretSeed("SCH27VUZZ6UAKB67BDNF6FA42YMBMQCBKXWGMFD5TZ6S5ZZCZFLRXKHS");
@@ -122,6 +166,51 @@ public class TransactionTest {
             ((CreateAccountOperation)transaction.getOperations()[0]).getStartingBalance(),
             ((CreateAccountOperation)transaction2.getOperations()[0]).getStartingBalance()
     );
+  }
+
+  @Test
+  public void testBuilderBaseFee() throws FormatException {
+    // GBPMKIRA2OQW2XZZQUCQILI5TMVZ6JNRKM423BSAISDM7ZFWQ6KWEBC4
+    KeyPair source = KeyPair.fromSecretSeed("SCH27VUZZ6UAKB67BDNF6FA42YMBMQCBKXWGMFD5TZ6S5ZZCZFLRXKHS");
+    KeyPair destination = KeyPair.fromAccountId("GDW6AUTBXTOC7FIKUO5BOO3OGLK4SF7ZPOBLMQHMZDI45J2Z6VXRB5NR");
+
+    Account account = new Account(source, 2908908335136768L);
+    Transaction transaction = new Transaction.Builder(account)
+            .addOperation(new CreateAccountOperation.Builder(destination, "2000").build())
+            .setBaseFee(200)
+            .setTimeout(Transaction.Builder.TIMEOUT_INFINITE)
+            .build();
+
+    transaction.sign(source);
+
+    assertEquals(
+            "AAAAAF7FIiDToW1fOYUFBC0dmyufJbFTOa2GQESGz+S2h5ViAAAAyAAKVaMAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxAAAAAEqBfIAAAAAAAAAAABtoeVYgAAAED1Mbd0oou0sfNFRuxsSqvrwJ9RzzTSnX8sTmlbMKcV0V3Kl1eDKoerD+xZ1pNQwOJZrAG2yapXyg60PQfDUcMN",
+            transaction.toEnvelopeXdrBase64());
+
+    Transaction transaction2 = Transaction.fromEnvelopeXdr(transaction.toEnvelopeXdr());
+
+    assertEquals(transaction.getSourceAccount().getAccountId(), transaction2.getSourceAccount().getAccountId());
+    assertEquals(transaction.getSequenceNumber(), transaction2.getSequenceNumber());
+    assertEquals(transaction.getFee(), transaction2.getFee());
+    assertEquals(
+            ((CreateAccountOperation)transaction.getOperations()[0]).getStartingBalance(),
+            ((CreateAccountOperation)transaction2.getOperations()[0]).getStartingBalance()
+    );
+  }
+
+  @Test
+  public void testBuilderBaseFeeThrows() throws FormatException {
+    // GBPMKIRA2OQW2XZZQUCQILI5TMVZ6JNRKM423BSAISDM7ZFWQ6KWEBC4
+    KeyPair source = KeyPair.fromSecretSeed("SCH27VUZZ6UAKB67BDNF6FA42YMBMQCBKXWGMFD5TZ6S5ZZCZFLRXKHS");
+
+    Account account = new Account(source, 2908908335136768L);
+    Transaction.Builder builder = new Transaction.Builder(account);
+    try {
+      builder.setBaseFee(99);
+      fail("expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
   }
 
   @Test


### PR DESCRIPTION
changes:
 - allow setting a default base fee for all transactions: `Transaction.setDefaultBaseFee(200);`
 - allow setting a base fee on a per transaction basis: `txBuilder.setBaseFee(200);`

both functions will throw an IllegalArgumentException if you pass in a base fee that is _less than_ `100`.

tests included.

closes https://github.com/stellar/java-stellar-sdk/issues/176
EDIT @bartekn: close #171