### PR TITLE
solution to okhttpclient not shutting down cleanly

### DIFF
--- a/src/main/java/org/stellar/sdk/Server.java
+++ b/src/main/java/org/stellar/sdk/Server.java
@@ -6,6 +6,7 @@ import okhttp3.Response;
 import org.stellar.sdk.requests.*;
 import org.stellar.sdk.responses.*;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.TimeUnit;
@@ -13,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Main class used to connect to Horizon server.
  */
-public class Server {
+public class Server implements Closeable {
     private HttpUrl serverURI;
     private OkHttpClient httpClient;
     /**
@@ -28,18 +29,25 @@ public class Server {
     private static final int HORIZON_SUBMIT_TIMEOUT = 60;
 
     public Server(String uri) {
-        serverURI = HttpUrl.parse(uri);
-        httpClient = new OkHttpClient.Builder()
-                .connectTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS)
-                .retryOnConnectionFailure(true)
-                .build();
+        this(uri,
+                new OkHttpClient.Builder()
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(30, TimeUnit.SECONDS)
+                    .retryOnConnectionFailure(true)
+                    .build(),
+                new OkHttpClient.Builder()
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(HORIZON_SUBMIT_TIMEOUT + 5, TimeUnit.SECONDS)
+                    .retryOnConnectionFailure(true)
+                    .build()
+        );
 
-        submitHttpClient = new OkHttpClient.Builder()
-                .connectTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(HORIZON_SUBMIT_TIMEOUT + 5, TimeUnit.SECONDS)
-                .retryOnConnectionFailure(true)
-                .build();
+    }
+
+    public Server(String serverURI, OkHttpClient httpClient, OkHttpClient submitHttpClient) {
+        this.serverURI = HttpUrl.parse(serverURI);
+        this.httpClient = httpClient;
+        this.submitHttpClient = submitHttpClient;
     }
 
 
@@ -199,5 +207,13 @@ public class Server {
         }
 
         return submitTransactionResponse;
+    }
+
+    @Override
+    public void close() {
+        // workaround for https://github.com/square/okhttp/issues/3372
+        // sometimes, the connection pool keeps running and this can prevent a clean shut down.
+        this.httpClient.connectionPool().evictAll();
+        this.submitHttpClient.connectionPool().evictAll();
     }
 }


### PR DESCRIPTION
- makes Server closable to workaround the issue that okhttpclient does not shut down cleanly.
- adds a second constructor to Server so users can provide their own okhttpclient configuration if they want to

I ran into this today with 0.6.0; seems to be a new issue relative to a 0.4.0. Closing okhttpclient by calling evictAll() on the connection pool fixes things. They may provide a proper solution at some point; in that case we should update the close method on Server.

Note. I assume we want to stick with java 1.6/Android compatibility. If not, we could modify this to AutoCloseable. This works a bit nicer in combination with try with resources introduced in 1.7.

Also see, https://github.com/square/okhttp/issues/3372