### PR TITLE
Fix #183: Exception thrown from ManageOfferOperation.fromXDR for certain offers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     testCompile 'org.mockito:mockito-core:2.21.0'
     testCompile "com.squareup.okhttp3:mockwebserver:${okhttpclientVersion}"
     testCompile 'junit:junit:4.12'
+    testCompile 'javax.xml.bind:jaxb-api:2.3.0'
 }
 
 project.configurations.compile 

--- a/src/main/java/org/stellar/sdk/CreatePassiveOfferOperation.java
+++ b/src/main/java/org/stellar/sdk/CreatePassiveOfferOperation.java
@@ -5,6 +5,7 @@ import org.stellar.sdk.xdr.Int64;
 import org.stellar.sdk.xdr.OperationType;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -92,9 +93,7 @@ public class CreatePassiveOfferOperation extends Operation {
       selling = Asset.fromXdr(op.getSelling());
       buying = Asset.fromXdr(op.getBuying());
       amount = Operation.fromXdrAmount(op.getAmount().getInt64().longValue());
-      int n = op.getPrice().getN().getInt32().intValue();
-      int d = op.getPrice().getD().getInt32().intValue();
-      price = new BigDecimal(n).divide(new BigDecimal(d)).toString();
+      price = Price.fromXdr(op.getPrice()).toString();
     }
 
     /**

--- a/src/main/java/org/stellar/sdk/ManageOfferOperation.java
+++ b/src/main/java/org/stellar/sdk/ManageOfferOperation.java
@@ -7,6 +7,7 @@ import org.stellar.sdk.xdr.OperationType;
 import org.stellar.sdk.xdr.Uint64;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -110,9 +111,7 @@ public class ManageOfferOperation extends Operation {
       selling = Asset.fromXdr(op.getSelling());
       buying = Asset.fromXdr(op.getBuying());
       amount = Operation.fromXdrAmount(op.getAmount().getInt64().longValue());
-      int n = op.getPrice().getN().getInt32().intValue();
-      int d = op.getPrice().getD().getInt32().intValue();
-      price = new BigDecimal(n).divide(new BigDecimal(d)).toString();
+      price = Price.fromXdr(op.getPrice()).toString();
       offerId = op.getOfferID().getUint64().longValue();
     }
 

--- a/src/main/java/org/stellar/sdk/Price.java
+++ b/src/main/java/org/stellar/sdk/Price.java
@@ -4,6 +4,8 @@ import com.google.gson.annotations.SerializedName;
 import org.stellar.sdk.xdr.Int32;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -82,6 +84,14 @@ public class Price {
     }
 
     /**
+     * Generates a Price SDK object from the XDR representation.
+     */
+    public static Price fromXdr(org.stellar.sdk.xdr.Price price) {
+        return new Price(price.getN().getInt32().intValue(), price.getD().getInt32().intValue());
+    }
+
+      
+    /**
      * Generates Price XDR object.
      */
     public org.stellar.sdk.xdr.Price toXdr() {
@@ -93,6 +103,16 @@ public class Price {
         xdr.setN(n);
         xdr.setD(d);
         return xdr;
+    }
+
+    /**
+     * Returns price as a string.
+     */
+    public String toString() {
+        MathContext mc = MathContext.DECIMAL64;
+        BigDecimal result = new BigDecimal(this.n).divide(new BigDecimal(this.d), mc);
+
+        return result.toString();
     }
 
     @Override

--- a/src/test/java/org/stellar/sdk/OperationTest.java
+++ b/src/test/java/org/stellar/sdk/OperationTest.java
@@ -2,7 +2,11 @@ package org.stellar.sdk;
 
 import org.junit.Test;
 import org.stellar.sdk.xdr.SignerKey;
+import org.stellar.sdk.xdr.XdrDataInputStream;
 
+import com.google.common.io.BaseEncoding;
+
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
@@ -419,6 +423,23 @@ public class OperationTest {
             "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAMAAAAAAAAAAVVTRAAAAAAARP7bVZfAS1dHLFv8YF7W1zlX9ZTMg5bjImn5dCA1RSIAAAAAAAAAZABRYZcAX14QAAAAAAAAAAE=",
             operation.toXdrBase64());
   }
+
+  @Test
+  public void testManageOfferOperation_BadArithmeticRegression() throws IOException {
+      // from https://github.com/stellar/java-stellar-sdk/issues/183
+      
+      String transactionEnvelopeToDecode = "AAAAAButy5zasS3DLZ5uFpZHL25aiHUfKRwdv1+3Wp12Ce7XAAAAZAEyGwYAAAAOAAAAAAAAAAAAAAABAAAAAQAAAAAbrcuc2rEtwy2ebhaWRy9uWoh1HykcHb9ft1qddgnu1wAAAAMAAAAAAAAAAUtJTgAAAAAARkrT28ebM6YQyhVZi1ttlwq/dk6ijTpyTNuHIMgUp+EAAAAAAAARPSfDKZ0AAv7oAAAAAAAAAAAAAAAAAAAAAXYJ7tcAAABAbE8rEoFt0Hcv41iwVCl74C1Hyr+Lj8ZyaYn7zTJhezClbc+pTW1KgYFIZOJiGVth2xFnBT1pMXuQkVdTlB3FCw==";
+      BaseEncoding base64Encoding = BaseEncoding.base64();
+      byte[] bytes = base64Encoding.decode(transactionEnvelopeToDecode);
+
+      org.stellar.sdk.xdr.TransactionEnvelope transactionEnvelope = org.stellar.sdk.xdr.TransactionEnvelope.decode(new XdrDataInputStream(new ByteArrayInputStream(bytes)));
+      assertEquals(1, transactionEnvelope.getTx().getOperations().length);
+
+      ManageOfferOperation op = (ManageOfferOperation)Operation.fromXdr(transactionEnvelope.getTx().getOperations()[0]);
+
+      assertEquals("3397.893306099996", op.getPrice());
+  }
+
 
   @Test
   public void testCreatePassiveOfferOperation() throws IOException, FormatException {


### PR DESCRIPTION
This is a small PR to fix #183 that introduces rounding into the process of converting an xdr Price object into a string representation.