### PR TITLE
Add Support for InflationOperation in Operation.fromXdr

### DIFF
--- a/src/main/java/org/stellar/sdk/Operation.java
+++ b/src/main/java/org/stellar/sdk/Operation.java
@@ -96,6 +96,9 @@ public abstract class Operation {
       case ACCOUNT_MERGE:
         operation = new AccountMergeOperation.Builder(body).build();
         break;
+      case INFLATION:
+        operation = new InflationOperation();
+        break;
       case MANAGE_DATA:
         operation = new ManageDataOperation.Builder(body.getManageDataOp()).build();
         break;

--- a/src/main/java/org/stellar/sdk/xdr/Operation.java
+++ b/src/main/java/org/stellar/sdk/xdr/Operation.java
@@ -4,8 +4,6 @@
 package org.stellar.sdk.xdr;
 
 
-import org.stellar.sdk.InflationOperation;
-
 import java.io.IOException;
 
 // === xdr source ============================================================

--- a/src/main/java/org/stellar/sdk/xdr/Operation.java
+++ b/src/main/java/org/stellar/sdk/xdr/Operation.java
@@ -4,6 +4,8 @@
 package org.stellar.sdk.xdr;
 
 
+import org.stellar.sdk.InflationOperation;
+
 import java.io.IOException;
 
 // === xdr source ============================================================

--- a/src/test/java/org/stellar/sdk/OperationTest.java
+++ b/src/test/java/org/stellar/sdk/OperationTest.java
@@ -595,4 +595,25 @@ public class OperationTest {
     assertEquals("101401671144.6800155", Operation.fromXdrAmount(1014016711446800155L));
     assertEquals("922337203685.4775807", Operation.fromXdrAmount(9223372036854775807L));
   }
+
+  @Test
+  public void testInflationOperation() {
+    // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF
+    KeyPair source = KeyPair.fromSecretSeed("SC4CGETADVYTCR5HEAVZRB3DZQY5Y4J7RFNJTRA6ESMHIPEZUSTE2QDK");
+
+    InflationOperation operation = new InflationOperation();
+
+    org.stellar.sdk.xdr.Operation xdr = operation.toXdr();
+    InflationOperation parsedOperation = (InflationOperation) Operation.fromXdr(xdr);
+
+    assertEquals(
+            "AAAAAAAAAAk=",
+            operation.toXdrBase64());
+
+    operation.setSourceAccount(source);
+
+    assertEquals(
+            "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAk=",
+            operation.toXdrBase64());
+  }
 }

--- a/src/test/java/org/stellar/sdk/xdr/InflationDecodeTest.java
+++ b/src/test/java/org/stellar/sdk/xdr/InflationDecodeTest.java
@@ -1,0 +1,16 @@
+package org.stellar.sdk.xdr;
+
+import org.junit.Test;
+import org.stellar.sdk.InflationOperation;
+
+import static org.junit.Assert.assertTrue;
+
+public class InflationDecodeTest {
+
+    @Test
+    public void testDecodeInflationOperation() throws Exception {
+        org.stellar.sdk.Transaction tx = org.stellar.sdk.Transaction.fromEnvelopeXdr("AAAAAALC+FwxReetNDfMNvY5LOS1qSe7QqrfQPS28dnIV95NAAAAZAAAAAAAAATSAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAJAAAAAAAAAAA=");
+        org.stellar.sdk.Operation[] ops = tx.getOperations();
+        assertTrue(ops[0] instanceof InflationOperation);
+    }
+}


### PR DESCRIPTION
Attempting to decode an inflation operation using `Transaction.fromEnvelopeXdr` would result in an "Unknown operation body INFLATION" exception. 

This change adds a case for this to support decoding Inflation operations from XDR.