### PR TITLE
Fix circle ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,10 @@ workflows:
   version: 2
   test-and-deploy:
     jobs:
-      - test
+      - test:
+          filters:  # required since `deploy` has tag filters AND requires `build`
+            tags:
+              only: /.*/
       - shadow_jar:
           requires:
             - test

--- a/after_deploy.sh
+++ b/after_deploy.sh
@@ -9,6 +9,8 @@ fi
 rm -rf javadoc/* # Remove all files without hidden (.git)
 javadoc -public -splitindex -windowtitle "java-stellar-sdk documentation" -d ./javadoc -sourcepath ./src/main/java/ -subpackages org.stellar.sdk -exclude org.stellar.sdk.xdr
 cd javadoc
+git config user.name "post-release-script"
+git config user.email "post-release-script@stellar.org"
 git add .
 git commit -m $CIRCLE_TAG
 git push origin gh-pages


### PR DESCRIPTION
Previously, the workflow did not run on tags. Now that the correct filter is applied
to the test job, the workflow will run for both releases and merges