### PR TITLE
Allow operations to include transaction data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Deprecated | New method/class
 
 * Stellar Protocol 12 compatibility.
 * Include `path` property in path payment operation responses.
+* Provide method for constructing operations requests which include transaction data in the operations response.
 
 ## 0.9.0
 * Use strings to represent account ids instead of KeyPair instances because account ids will not necessarily be valid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Deprecated | New method/class
 
 * Stellar Protocol 12 compatibility.
 * Include `path` property in path payment operation responses.
-* Provide method for constructing operations requests which include transaction data in the operations response.
+* Provide `includeTransactions()` method for constructing operations requests which include transaction data in the operations response.
+* Provide `includeTransactions()` method for constructing payments requests which include transaction data in the payments response.
 
 ## 0.9.0
 * Use strings to represent account ids instead of KeyPair instances because account ids will not necessarily be valid

--- a/src/main/java/org/stellar/sdk/requests/OperationsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/OperationsRequestBuilder.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk.requests;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.Sets;
 import com.google.gson.reflect.TypeToken;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -9,6 +11,7 @@ import org.stellar.sdk.responses.Page;
 import org.stellar.sdk.responses.operations.OperationResponse;
 
 import java.io.IOException;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -16,8 +19,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Builds requests connected to operations.
  */
 public class OperationsRequestBuilder extends RequestBuilder {
+  protected Set<String> toJoin;
+
   public OperationsRequestBuilder(OkHttpClient httpClient, HttpUrl serverURI) {
     super(httpClient, serverURI, "operations");
+    toJoin = Sets.newHashSet();
   }
 
   /**
@@ -86,6 +92,29 @@ public class OperationsRequestBuilder extends RequestBuilder {
   public OperationsRequestBuilder includeFailed(boolean value) {
     uriBuilder.setQueryParameter("include_failed", String.valueOf(value));
     return this;
+  }
+
+  /**
+   * Adds a parameter defining whether to include transactions in the response. By default transaction data
+   * is not included.
+   * @param include Set to <code>true</code> to include transaction data in the operations response.
+   */
+  public OperationsRequestBuilder includeTransactions(boolean include) {
+    updateToJoin("transactions", include);
+    return this;
+  }
+
+  protected void updateToJoin(String value, boolean include) {
+    if (include) {
+      toJoin.add(value);
+    } else {
+      toJoin.remove(value);
+    }
+    if (toJoin.isEmpty()) {
+      uriBuilder.removeAllQueryParameters("join");
+    } else {
+      uriBuilder.setQueryParameter("join", Joiner.on(",").join(toJoin));
+    }
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/requests/PaymentsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/PaymentsRequestBuilder.java
@@ -1,5 +1,7 @@
 package org.stellar.sdk.requests;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.Sets;
 import com.google.gson.reflect.TypeToken;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -9,6 +11,7 @@ import org.stellar.sdk.responses.Page;
 import org.stellar.sdk.responses.operations.OperationResponse;
 
 import java.io.IOException;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -16,8 +19,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Builds requests connected to payments.
  */
 public class PaymentsRequestBuilder extends RequestBuilder {
+  protected Set<String> toJoin;
+
   public PaymentsRequestBuilder(OkHttpClient httpClient, HttpUrl serverURI) {
     super(httpClient, serverURI, "payments");
+    toJoin = Sets.newHashSet();
   }
 
   /**
@@ -50,6 +56,29 @@ public class PaymentsRequestBuilder extends RequestBuilder {
     transactionId = checkNotNull(transactionId, "transactionId cannot be null");
     this.setSegments("transactions", transactionId, "payments");
     return this;
+  }
+
+  /**
+   * Adds a parameter defining whether to include transactions in the response. By default transaction data
+   * is not included.
+   * @param include Set to <code>true</code> to include transaction data in the operations response.
+   */
+  public PaymentsRequestBuilder includeTransactions(boolean include) {
+    updateToJoin("transactions", include);
+    return this;
+  }
+
+  protected void updateToJoin(String value, boolean include) {
+    if (include) {
+      toJoin.add(value);
+    } else {
+      toJoin.remove(value);
+    }
+    if (toJoin.isEmpty()) {
+      uriBuilder.removeAllQueryParameters("join");
+    } else {
+      uriBuilder.setQueryParameter("join", Joiner.on(",").join(toJoin));
+    }
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/responses/OperationDeserializer.java
+++ b/src/main/java/org/stellar/sdk/responses/OperationDeserializer.java
@@ -20,6 +20,7 @@ class OperationDeserializer implements JsonDeserializer<OperationResponse> {
     // Create new Gson object with adapters needed in Operation
     Gson gson = new GsonBuilder()
             .registerTypeAdapter(Asset.class, new AssetDeserializer())
+            .registerTypeAdapter(TransactionResponse.class, new TransactionDeserializer())
             .create();
 
     int type = json.getAsJsonObject().get("type_i").getAsInt();

--- a/src/main/java/org/stellar/sdk/responses/operations/OperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/OperationResponse.java
@@ -1,10 +1,12 @@
 package org.stellar.sdk.responses.operations;
 
+import com.google.common.base.Optional;
 import com.google.gson.annotations.SerializedName;
 
 import org.stellar.sdk.responses.Link;
 import org.stellar.sdk.responses.Pageable;
 import org.stellar.sdk.responses.Response;
+import org.stellar.sdk.responses.TransactionResponse;
 
 /**
  * Abstract class for operation responses.
@@ -29,6 +31,8 @@ public abstract class OperationResponse extends Response implements Pageable {
   protected String type;
   @SerializedName("_links")
   private Links links;
+  @SerializedName("transaction")
+  private TransactionResponse transaction;
 
   public Long getId() {
     return id;
@@ -79,6 +83,10 @@ public abstract class OperationResponse extends Response implements Pageable {
 
   public Links getLinks() {
     return links;
+  }
+
+  public Optional<TransactionResponse> getTransaction() {
+    return Optional.fromNullable(transaction);
   }
 
   /**

--- a/src/test/java/org/stellar/sdk/requests/OperationsRequestBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/requests/OperationsRequestBuilderTest.java
@@ -61,4 +61,39 @@ public class OperationsRequestBuilderTest {
             .buildUri();
     assertEquals("https://horizon-testnet.stellar.org/ledgers/200000000000/operations?include_failed=true&limit=50&order=asc", uri.toString());
   }
+
+  @Test
+  public void testIncludeTransactions() {
+    Server server = new Server("https://horizon-testnet.stellar.org");
+    HttpUrl uri = server.operations()
+        .forLedger(200000000000L)
+        .includeTransactions(true)
+        .limit(50)
+        .order(RequestBuilder.Order.ASC)
+        .buildUri();
+    assertEquals("https://horizon-testnet.stellar.org/ledgers/200000000000/operations?join=transactions&limit=50&order=asc", uri.toString());
+
+    uri = server.operations()
+        .forLedger(200000000000L)
+        .includeTransactions(true)
+        .limit(50)
+        .includeTransactions(false)
+        .order(RequestBuilder.Order.ASC)
+        .includeTransactions(true)
+        .buildUri();
+    assertEquals("https://horizon-testnet.stellar.org/ledgers/200000000000/operations?limit=50&order=asc&join=transactions", uri.toString());
+  }
+
+  @Test
+  public void testExcludeTransactions() {
+    Server server = new Server("https://horizon-testnet.stellar.org");
+    HttpUrl uri = server.operations()
+        .forLedger(200000000000L)
+        .includeTransactions(true)
+        .limit(50)
+        .order(RequestBuilder.Order.ASC)
+        .includeTransactions(false)
+        .buildUri();
+    assertEquals("https://horizon-testnet.stellar.org/ledgers/200000000000/operations?limit=50&order=asc", uri.toString());
+  }
 }

--- a/src/test/java/org/stellar/sdk/requests/PaymentsRequestBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/requests/PaymentsRequestBuilderTest.java
@@ -2,8 +2,6 @@ package org.stellar.sdk.requests;
 
 import okhttp3.HttpUrl;
 import org.junit.Test;
-import org.stellar.sdk.KeyPair;
-import org.stellar.sdk.Network;
 import org.stellar.sdk.Server;
 
 import static org.junit.Assert.assertEquals;
@@ -47,6 +45,36 @@ public class PaymentsRequestBuilderTest {
     HttpUrl uri = server.payments()
             .forTransaction("991534d902063b7715cd74207bef4e7bd7aa2f108f62d3eba837ce6023b2d4f3")
             .buildUri();
+    assertEquals("https://horizon-testnet.stellar.org/transactions/991534d902063b7715cd74207bef4e7bd7aa2f108f62d3eba837ce6023b2d4f3/payments", uri.toString());
+  }
+
+
+  @Test
+  public void testIncludeTransactions() {
+    Server server = new Server("https://horizon-testnet.stellar.org");
+    HttpUrl uri = server.payments()
+        .forTransaction("991534d902063b7715cd74207bef4e7bd7aa2f108f62d3eba837ce6023b2d4f3")
+        .includeTransactions(true)
+        .buildUri();
+    assertEquals("https://horizon-testnet.stellar.org/transactions/991534d902063b7715cd74207bef4e7bd7aa2f108f62d3eba837ce6023b2d4f3/payments?join=transactions", uri.toString());
+
+    uri = server.payments()
+        .forTransaction("991534d902063b7715cd74207bef4e7bd7aa2f108f62d3eba837ce6023b2d4f3")
+        .includeTransactions(true)
+        .includeTransactions(false)
+        .order(RequestBuilder.Order.ASC)
+        .includeTransactions(true)
+        .buildUri();
+    assertEquals("https://horizon-testnet.stellar.org/transactions/991534d902063b7715cd74207bef4e7bd7aa2f108f62d3eba837ce6023b2d4f3/payments?order=asc&join=transactions", uri.toString());
+  }
+
+  @Test
+  public void testExcludeTransactions() {
+    Server server = new Server("https://horizon-testnet.stellar.org");
+    HttpUrl uri = server.payments()
+        .forTransaction("991534d902063b7715cd74207bef4e7bd7aa2f108f62d3eba837ce6023b2d4f3")
+        .includeTransactions(false)
+        .buildUri();
     assertEquals("https://horizon-testnet.stellar.org/transactions/991534d902063b7715cd74207bef4e7bd7aa2f108f62d3eba837ce6023b2d4f3/payments", uri.toString());
   }
 }

--- a/src/test/java/org/stellar/sdk/responses/OperationsPageDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/OperationsPageDeserializerTest.java
@@ -6,6 +6,7 @@ import junit.framework.TestCase;
 
 import org.junit.Test;
 import org.stellar.sdk.AssetTypeNative;
+import org.stellar.sdk.Memo;
 import org.stellar.sdk.responses.operations.CreateAccountOperationResponse;
 import org.stellar.sdk.responses.operations.OperationResponse;
 import org.stellar.sdk.responses.operations.PaymentOperationResponse;
@@ -22,13 +23,36 @@ public class OperationsPageDeserializerTest extends TestCase {
     assertEquals(createAccountOperation.getFunder(), "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K");
     assertEquals(createAccountOperation.getCreatedAt(), "2018-01-22T21:30:53Z");
     assertEquals(createAccountOperation.getTransactionHash(), "dd9d10c80a344f4464df3ecaa63705a5ef4a0533ff2f2099d5ef371ab5e1c046");
+    assertFalse(createAccountOperation.getTransaction().isPresent());
 
     PaymentOperationResponse paymentOperation = (PaymentOperationResponse) operationsPage.getRecords().get(4);
     assertEquals(paymentOperation.getAmount(), "10.123");
     TestCase.assertEquals(paymentOperation.getAsset(), new AssetTypeNative());
     assertEquals(paymentOperation.getFrom(), "GCYK67DDGBOANS6UODJ62QWGLEB2A7JQ3XUV25HCMLT7CI23PMMK3W6R");
     assertEquals(paymentOperation.getTo(), "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H");
+    assertFalse(paymentOperation.getTransaction().isPresent());
   }
+
+  @Test
+  public void testDeserializeWithTransactions() {
+    Page<OperationResponse> operationsPage = GsonSingleton.getInstance().fromJson(includeTransactionsJSON, new TypeToken<Page<OperationResponse>>() {}.getType());
+
+    assertEquals(operationsPage.getRecords().size(), 1);
+    CreateAccountOperationResponse createAccountOperation = (CreateAccountOperationResponse) operationsPage.getRecords().get(0);
+    assertEquals(createAccountOperation.getStartingBalance(), "10000000000.0000000");
+    assertEquals(createAccountOperation.getPagingToken(), "828928692225");
+    assertEquals(createAccountOperation.getAccount(), "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR");
+    assertEquals(createAccountOperation.getFunder(), "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H");
+    assertEquals(createAccountOperation.getCreatedAt(), "2019-07-31T09:30:47Z");
+    assertEquals(createAccountOperation.getTransactionHash(), "749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e");
+    assertTrue(createAccountOperation.getTransaction().isPresent());
+
+    TransactionResponse transaction = createAccountOperation.getTransaction().get();
+    assertEquals(transaction.getHash(), "749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e");
+    assertEquals(transaction.getLedger(), Long.valueOf(193));
+    assertEquals(transaction.getMemo(), Memo.none());
+  }
+
 
   String json = "{\n" +
           "  \"_links\": {\n" +
@@ -321,4 +345,102 @@ public class OperationsPageDeserializerTest extends TestCase {
           "    ]\n" +
           "  }\n" +
           "}";
+
+  String includeTransactionsJSON = "{\n" +
+      "  \"_links\": {\n" +
+      "    \"self\": {\n" +
+      "      \"href\": \"https://horizon-testnet.stellar.org/operations?cursor=\\u0026join=transactions\\u0026limit=1\\u0026order=asc\"\n" +
+      "    },\n" +
+      "    \"next\": {\n" +
+      "      \"href\": \"https://horizon-testnet.stellar.org/operations?cursor=828928692225\\u0026join=transactions\\u0026limit=1\\u0026order=asc\"\n" +
+      "    },\n" +
+      "    \"prev\": {\n" +
+      "      \"href\": \"https://horizon-testnet.stellar.org/operations?cursor=828928692225\\u0026join=transactions\\u0026limit=1\\u0026order=desc\"\n" +
+      "    }\n" +
+      "  },\n" +
+      "  \"_embedded\": {\n" +
+      "    \"records\": [\n" +
+      "      {\n" +
+      "        \"_links\": {\n" +
+      "          \"self\": {\n" +
+      "            \"href\": \"https://horizon-testnet.stellar.org/operations/828928692225\"\n" +
+      "          },\n" +
+      "          \"transaction\": {\n" +
+      "            \"href\": \"https://horizon-testnet.stellar.org/transactions/749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e\"\n" +
+      "          },\n" +
+      "          \"effects\": {\n" +
+      "            \"href\": \"https://horizon-testnet.stellar.org/operations/828928692225/effects\"\n" +
+      "          },\n" +
+      "          \"succeeds\": {\n" +
+      "            \"href\": \"https://horizon-testnet.stellar.org/effects?order=desc\\u0026cursor=828928692225\"\n" +
+      "          },\n" +
+      "          \"precedes\": {\n" +
+      "            \"href\": \"https://horizon-testnet.stellar.org/effects?order=asc\\u0026cursor=828928692225\"\n" +
+      "          }\n" +
+      "        },\n" +
+      "        \"id\": \"828928692225\",\n" +
+      "        \"paging_token\": \"828928692225\",\n" +
+      "        \"transaction_successful\": true,\n" +
+      "        \"source_account\": \"GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H\",\n" +
+      "        \"type\": \"create_account\",\n" +
+      "        \"type_i\": 0,\n" +
+      "        \"created_at\": \"2019-07-31T09:30:47Z\",\n" +
+      "        \"transaction_hash\": \"749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e\",\n" +
+      "        \"transaction\": {\n" +
+      "          \"_links\": {\n" +
+      "            \"self\": {\n" +
+      "              \"href\": \"https://horizon-testnet.stellar.org/transactions/749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e\"\n" +
+      "            },\n" +
+      "            \"account\": {\n" +
+      "              \"href\": \"https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H\"\n" +
+      "            },\n" +
+      "            \"ledger\": {\n" +
+      "              \"href\": \"https://horizon-testnet.stellar.org/ledgers/193\"\n" +
+      "            },\n" +
+      "            \"operations\": {\n" +
+      "              \"href\": \"https://horizon-testnet.stellar.org/transactions/749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e/operations{?cursor,limit,order}\",\n" +
+      "              \"templated\": true\n" +
+      "            },\n" +
+      "            \"effects\": {\n" +
+      "              \"href\": \"https://horizon-testnet.stellar.org/transactions/749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e/effects{?cursor,limit,order}\",\n" +
+      "              \"templated\": true\n" +
+      "            },\n" +
+      "            \"precedes\": {\n" +
+      "              \"href\": \"https://horizon-testnet.stellar.org/transactions?order=asc\\u0026cursor=828928692224\"\n" +
+      "            },\n" +
+      "            \"succeeds\": {\n" +
+      "              \"href\": \"https://horizon-testnet.stellar.org/transactions?order=desc\\u0026cursor=828928692224\"\n" +
+      "            }\n" +
+      "          },\n" +
+      "          \"id\": \"749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e\",\n" +
+      "          \"paging_token\": \"828928692224\",\n" +
+      "          \"successful\": true,\n" +
+      "          \"hash\": \"749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e\",\n" +
+      "          \"ledger\": 193,\n" +
+      "          \"created_at\": \"2019-07-31T09:30:47Z\",\n" +
+      "          \"source_account\": \"GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H\",\n" +
+      "          \"source_account_sequence\": \"1\",\n" +
+      "          \"fee_paid\": 1000,\n" +
+      "          \"fee_charged\": 1000,\n" +
+      "          \"max_fee\": 1000,\n" +
+      "          \"operation_count\": 10,\n" +
+      "          \"envelope_xdr\": \"AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAD6AAAAAAAAAABAAAAAAAAAAAAAAAKAAAAAAAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwBY0V4XYoAAAAAAAAAAAAAAAAAAN2+SherpNcNX0imC680fIBdpQfgBwIuqFOgmlobpwLJAAAAF0h26AAAAAAAAAAAAAAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAABdIdugAAAAAAAAAAAAAAAAAmv+knlR6JR2VqWeU0k/4FgvZ/tSV5DEY4gu0iOTKgpUAAAAXSHboAAAAAAAAAAAAAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAF0h26AAAAAABAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAAJr/pJ5UeiUdlalnlNJP+BYL2f7UleQxGOILtIjkyoKVAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAAAAAAAAAAAAABKBB+2UBMP/abwcm/M1TXO+/JQWhPwkalgqizKmXyRIQx9cN3sY5YAAAAAAAAAAARW/AX3AAAAQDX5vrTLWyUxzrvpeEghwlfZYjb8PhnV+vjXAQE+iCNotx2S0qDtnNppNy9p0qlsXtKKyZqn036kHMFGQ7RxBQ3GYc0bAAAAQOquRvJeUiQ8uDcNGUnIxXT0xaHe91JZHCVjPEm6j9Biii954p9o7Muer9B9ipn6O4Y+4oiF9NbUxyeqh1VJnQw4WbfcAAAAQG/GEctb+uefyEvdeP8V61fCvvdGCW7KoH7iLXxtvanGk9CyydtRGEIxu66hPdUKKbXpXPEKWvnAAp5V+XQqjQnkyoKVAAAAQNTyKwB94kyBjjczpFwMFVtbhHtugo+DYeQKN13jQUjWQDSgistLE+TDrxlxW0qiIhl/GkOdVLMtG6YhfZeVOQU=\",\n" +
+      "          \"result_xdr\": \"AAAAAAAAA+gAAAAAAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\n" +
+      "          \"result_meta_xdr\": \"AAAAAQAAAAAAAAAKAAAAAwAAAAMAAADBAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/wYAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAADBAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wx9cTtJ2fwYAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAADBAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFjRXhdigAAAAAAwQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAAAADAAAAwQAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcMfXE7Sdn8GAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAwQAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcMfXEkAWMUGAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwQAAAAAAAAAA3b5KF6uk1w1fSKYLrzR8gF2lB+AHAi6oU6CaWhunAskAAAAXSHboAAAAAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAADAAAAAwAAAMEAAAAAAAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3DH1xJAFjFBgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAAAMEAAAAAAAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3DH1xDLjsLBgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMEAAAAAAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAAF0h26AAAAADBAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMAAADBAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wx9cQy47CwYAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAADBAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wx9cPVwdUQYAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAADBAAAAAAAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAABdIdugAAAAAwQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAAAADAAAAwQAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcMfXD1cHVEGAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAwQAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcMfXDeJ/5cGAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwQAAAAAAAAAA2lpYuiO4618LRyYyH4O9BN88OuR9eFuVBN0VesZhzRsAAAAXSHboAAAAAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAADAAAAAwAAAMEAAAAAAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAAF0h26AAAAADBAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAAAMEAAAAAAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAAF0h26AAAAADBAAAAAAAAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMEAAAABAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAAAVRFU1QAAAAA2lpYuiO4618LRyYyH4O9BN88OuR9eFuVBN0VesZhzRsAAAAAAAAAAH//////////AAAAAQAAAAAAAAAAAAAAAwAAAAMAAADBAAAAAAAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAABdIdugAAAAAwQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAADBAAAAAAAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAABdIdugAAAAAwQAAAAAAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAADBAAAAAQAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAAAAAAB//////////wAAAAEAAAAAAAAAAAAAAAIAAAADAAAAwQAAAAEAAAAAAJUbdoKPbKexNWuWVr6+74p+FD6xUE4aUGsdZThZt9wAAAABVEVTVAAAAADaWli6I7jrXwtHJjIfg70E3zw65H14W5UE3RV6xmHNGwAAAAAAAAAAf/////////8AAAABAAAAAAAAAAAAAAABAAAAwQAAAAEAAAAAAJUbdoKPbKexNWuWVr6+74p+FD6xUE4aUGsdZThZt9wAAAABVEVTVAAAAADaWli6I7jrXwtHJjIfg70E3zw65H14W5UE3RV6xmHNGwAACRhOcqAAf/////////8AAAABAAAAAAAAAAAAAAACAAAAAwAAAMEAAAABAAAAAJr/pJ5UeiUdlalnlNJP+BYL2f7UleQxGOILtIjkyoKVAAAAAVRFU1QAAAAA2lpYuiO4618LRyYyH4O9BN88OuR9eFuVBN0VesZhzRsAAAAAAAAAAH//////////AAAAAQAAAAAAAAAAAAAAAQAAAMEAAAABAAAAAJr/pJ5UeiUdlalnlNJP+BYL2f7UleQxGOILtIjkyoKVAAAAAVRFU1QAAAAA2lpYuiO4618LRyYyH4O9BN88OuR9eFuVBN0VesZhzRsAAAkYTnKgAH//////////AAAAAQAAAAAAAAAAAAAAAwAAAAMAAADBAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wx9cN4n/lwYAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAADBAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wAAAAA7msYYAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAADBAAAAAAAAAABKBB+2UBMP/abwcm/M1TXO+/JQWhPwkalgqizKmXyRIQx9cN3sY5YAAAAAwQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==\",\n" +
+      "          \"fee_meta_xdr\": \"AAAAAgAAAAMAAAABAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAADBAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/wYAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==\",\n" +
+      "          \"memo_type\": \"none\",\n" +
+      "          \"signatures\": [\n" +
+      "            \"Nfm+tMtbJTHOu+l4SCHCV9liNvw+GdX6+NcBAT6II2i3HZLSoO2c2mk3L2nSqWxe0orJmqfTfqQcwUZDtHEFDQ==\",\n" +
+      "            \"6q5G8l5SJDy4Nw0ZScjFdPTFod73UlkcJWM8SbqP0GKKL3nin2jsy56v0H2Kmfo7hj7iiIX01tTHJ6qHVUmdDA==\",\n" +
+      "            \"b8YRy1v655/IS914/xXrV8K+90YJbsqgfuItfG29qcaT0LLJ21EYQjG7rqE91Qoptelc8Qpa+cACnlX5dCqNCQ==\",\n" +
+      "            \"1PIrAH3iTIGONzOkXAwVW1uEe26Cj4Nh5Ao3XeNBSNZANKCKy0sT5MOvGXFbSqIiGX8aQ51Usy0bpiF9l5U5BQ==\"\n" +
+      "          ]\n" +
+      "        },\n" +
+      "        \"starting_balance\": \"10000000000.0000000\",\n" +
+      "        \"funder\": \"GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H\",\n" +
+      "        \"account\": \"GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR\"\n" +
+      "      }\n" +
+      "    ]\n" +
+      "  }\n" +
+      "}";
 }


### PR DESCRIPTION
Horizon v0.19 introduces a join parameter when querying for operations. This allows users to get transaction details with operation responses.



fixes https://github.com/stellar/java-stellar-sdk/issues/236