### PR TITLE
Remove fee_paid from Transaction response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
+## 0.11.0
+
+* The `fee_paid` field in the Horizon transaction response will be removed when Horizon 0.25 is released. The `fee_paid` field has been replaced by `max_fee`, which defines the maximum fee the source account is willing to pay, and `fee_charged`, which defines the fee that was actually paid for a transaction. Consequently, `getFeePaid()` has been removed from `org.stellar.sdk.responses.Transaction` and has been replaced with `getMaxFee()` and `getFeeCharged()`.
+
 ## 0.10.0
 
 ### Deprecations

--- a/src/main/java/org/stellar/sdk/responses/TransactionResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/TransactionResponse.java
@@ -27,8 +27,10 @@ public class TransactionResponse extends Response implements Pageable {
   private final String pagingToken;
   @SerializedName("source_account_sequence")
   private final Long sourceAccountSequence;
-  @SerializedName("fee_paid")
-  private final Long feePaid;
+  @SerializedName("max_fee")
+  private final Long maxFee;
+  @SerializedName("fee_charged")
+  private final Long feeCharged;
   @SerializedName("operation_count")
   private final Integer operationCount;
   @SerializedName("envelope_xdr")
@@ -44,7 +46,23 @@ public class TransactionResponse extends Response implements Pageable {
   // because Memo is an abstract class and GSON tries to instantiate it.
   private transient Memo memo;
 
-  TransactionResponse(String hash, Long ledger, String createdAt, String sourceAccount, Boolean successful, String pagingToken, Long sourceAccountSequence, Long feePaid, Integer operationCount, String envelopeXdr, String resultXdr, String resultMetaXdr, Memo memo, Links links) {
+  TransactionResponse(
+      String hash,
+      Long ledger,
+      String createdAt,
+      String sourceAccount,
+      Boolean successful,
+      String pagingToken,
+      Long sourceAccountSequence,
+      Long maxFee,
+      Long feeCharged,
+      Integer operationCount,
+      String envelopeXdr,
+      String resultXdr,
+      String resultMetaXdr,
+      Memo memo,
+      Links links
+  ) {
     this.hash = hash;
     this.ledger = ledger;
     this.createdAt = createdAt;
@@ -52,7 +70,8 @@ public class TransactionResponse extends Response implements Pageable {
     this.successful = successful;
     this.pagingToken = pagingToken;
     this.sourceAccountSequence = sourceAccountSequence;
-    this.feePaid = feePaid;
+    this.maxFee = maxFee;
+    this.feeCharged = feeCharged;
     this.operationCount = operationCount;
     this.envelopeXdr = envelopeXdr;
     this.resultXdr = resultXdr;
@@ -89,8 +108,12 @@ public class TransactionResponse extends Response implements Pageable {
     return sourceAccountSequence;
   }
 
-  public Long getFeePaid() {
-    return feePaid;
+  public Long getMaxFee() {
+    return maxFee;
+  }
+
+  public Long getFeeCharged() {
+    return feeCharged;
   }
 
   public Integer getOperationCount() {

--- a/src/test/java/org/stellar/sdk/responses/TransactionDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/TransactionDeserializerTest.java
@@ -17,7 +17,8 @@ public class TransactionDeserializerTest extends TestCase {
     assertEquals(transaction.isSuccessful(), new Boolean(true));
     assertEquals(transaction.getSourceAccount(), "GCUB7JL4APK7LKJ6MZF7Q2JTLHAGNBIUA7XIXD5SQTG52GQ2DAT6XZMK");
     assertEquals(transaction.getSourceAccountSequence(), new Long(2373051035426646L));
-    assertEquals(transaction.getFeePaid(), new Long(100));
+    assertEquals(transaction.getMaxFee(), new Long(200));
+    assertEquals(transaction.getFeeCharged(), new Long(100));
     assertEquals(transaction.getOperationCount(), new Integer(1));
     assertEquals(transaction.getEnvelopeXdr(), "AAAAAKgfpXwD1fWpPmZL+GkzWcBmhRQH7ouPsoTN3RoaGCfrAAAAZAAIbkcAAB9WAAAAAAAAAANRBBZE6D1qyGjISUGLY5Ldvp31PwAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAP1qe44j+i4uIT+arbD4QDQBt8ryEeJd7a0jskQ3nwDeAAAAAAAAAADA7RnarSzCwj3OT+M2btCMFpVBdqxJS+Sr00qBjtFv7gAAAABLCs/QAAAAAAAAAAEaGCfrAAAAQG/56Cj2J8W/KCZr+oC4sWND1CTGWfaccHNtuibQH8kZIb+qBSDY94g7hiaAXrlIeg9b7oz/XuP3x9MWYw2jtwM=");
     assertEquals(transaction.getResultXdr(), "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=");
@@ -77,7 +78,8 @@ public class TransactionDeserializerTest extends TestCase {
           "  \"created_at\": \"2015-11-20T17:01:28Z\",\n" +
           "  \"source_account\": \"GCUB7JL4APK7LKJ6MZF7Q2JTLHAGNBIUA7XIXD5SQTG52GQ2DAT6XZMK\",\n" +
           "  \"source_account_sequence\": 2373051035426646,\n" +
-          "  \"fee_paid\": 100,\n" +
+          "  \"max_fee\": 200,\n" +
+          "  \"fee_charged\": 100,\n" +
           "  \"operation_count\": 1,\n" +
           "  \"envelope_xdr\": \"AAAAAKgfpXwD1fWpPmZL+GkzWcBmhRQH7ouPsoTN3RoaGCfrAAAAZAAIbkcAAB9WAAAAAAAAAANRBBZE6D1qyGjISUGLY5Ldvp31PwAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAP1qe44j+i4uIT+arbD4QDQBt8ryEeJd7a0jskQ3nwDeAAAAAAAAAADA7RnarSzCwj3OT+M2btCMFpVBdqxJS+Sr00qBjtFv7gAAAABLCs/QAAAAAAAAAAEaGCfrAAAAQG/56Cj2J8W/KCZr+oC4sWND1CTGWfaccHNtuibQH8kZIb+qBSDY94g7hiaAXrlIeg9b7oz/XuP3x9MWYw2jtwM=\",\n" +
           "  \"result_xdr\": \"AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=\",\n" +
@@ -123,7 +125,8 @@ public class TransactionDeserializerTest extends TestCase {
           "  \"created_at\": \"2015-11-20T17:01:28Z\",\n" +
           "  \"source_account\": \"GCUB7JL4APK7LKJ6MZF7Q2JTLHAGNBIUA7XIXD5SQTG52GQ2DAT6XZMK\",\n" +
           "  \"source_account_sequence\": 2373051035426646,\n" +
-          "  \"fee_paid\": 100,\n" +
+          "  \"max_fee\": 200,\n" +
+          "  \"fee_charged\": 100,\n" +
           "  \"operation_count\": 1,\n" +
           "  \"envelope_xdr\": \"AAAAAKgfpXwD1fWpPmZL+GkzWcBmhRQH7ouPsoTN3RoaGCfrAAAAZAAIbkcAAB9WAAAAAAAAAANRBBZE6D1qyGjISUGLY5Ldvp31PwAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAP1qe44j+i4uIT+arbD4QDQBt8ryEeJd7a0jskQ3nwDeAAAAAAAAAADA7RnarSzCwj3OT+M2btCMFpVBdqxJS+Sr00qBjtFv7gAAAABLCs/QAAAAAAAAAAEaGCfrAAAAQG/56Cj2J8W/KCZr+oC4sWND1CTGWfaccHNtuibQH8kZIb+qBSDY94g7hiaAXrlIeg9b7oz/XuP3x9MWYw2jtwM=\",\n" +
           "  \"result_xdr\": \"AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=\",\n" +


### PR DESCRIPTION
Fixes https://github.com/stellar/java-stellar-sdk/issues/248

>The `fee_paid` field in the Horizon transaction response will be removed when [Horizon 0.25](https://github.com/stellar/go/issues/1812) is released.  The `fee_paid` field has been replaced by `max_fee`, which defines the maximum fee the source account is willing to pay, and fee_charged, which defines the fee that was actually paid for a transaction. See CAP-0005 for more information.
