### PR TITLE
Fix /operations/<id> request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ## 0.11.0
 
+* Fix bug in `org.stellar.sdk.requests.OperationsRequestBuilder.operation(long operationId)`. The method submitted an HTTP request to Horizon with the following path, /operation/<id> , but the correct path is /operations/<id>
 * Rename `org.stellar.sdk.requests.PathsRequestBuilder` to `org.stellar.sdk.requests.StrictReceivePathsRequestBuilder`
 * Add `sourceAssets()` to `org.stellar.sdk.requests.StrictReceivePathsRequestBuilder` which allows a list of assets to be provided instead of a source account
 * Add `org.stellar.sdk.requests.StrictSendPathsRequestBuilder` which is the request builder for the /paths/strict-send endpoint

--- a/src/main/java/org/stellar/sdk/requests/OperationsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/OperationsRequestBuilder.java
@@ -48,7 +48,7 @@ public class OperationsRequestBuilder extends RequestBuilder {
    * @throws IOException
    */
   public OperationResponse operation(long operationId) throws IOException {
-    this.setSegments("operation", String.valueOf(operationId));
+    this.setSegments("operations", String.valueOf(operationId));
     return this.operation(this.buildUri());
   }
 

--- a/src/test/java/org/stellar/sdk/requests/OperationsRequestBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/requests/OperationsRequestBuilderTest.java
@@ -1,14 +1,52 @@
 package org.stellar.sdk.requests;
 
 import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.Network;
 import org.stellar.sdk.Server;
+import org.stellar.sdk.responses.operations.OperationResponse;
+
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 
 public class OperationsRequestBuilderTest {
+
+  private static final String operationResponse = "{\n" +
+      "  \"_links\": {\n" +
+      "    \"self\": {\n" +
+      "      \"href\": \"https://horizon-testnet.stellar.org/operations/438086668289\"\n" +
+      "    },\n" +
+      "    \"transaction\": {\n" +
+      "      \"href\": \"https://horizon-testnet.stellar.org/transactions/749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e\"\n" +
+      "    },\n" +
+      "    \"effects\": {\n" +
+      "      \"href\": \"https://horizon-testnet.stellar.org/operations/438086668289/effects\"\n" +
+      "    },\n" +
+      "    \"succeeds\": {\n" +
+      "      \"href\": \"https://horizon-testnet.stellar.org/effects?order=desc\\u0026cursor=438086668289\"\n" +
+      "    },\n" +
+      "    \"precedes\": {\n" +
+      "      \"href\": \"https://horizon-testnet.stellar.org/effects?order=asc\\u0026cursor=438086668289\"\n" +
+      "    }\n" +
+      "  },\n" +
+      "  \"id\": \"438086668289\",\n" +
+      "  \"paging_token\": \"438086668289\",\n" +
+      "  \"transaction_successful\": true,\n" +
+      "  \"source_account\": \"GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H\",\n" +
+      "  \"type\": \"create_account\",\n" +
+      "  \"type_i\": 0,\n" +
+      "  \"created_at\": \"2019-10-30T09:34:07Z\",\n" +
+      "  \"transaction_hash\": \"749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e\",\n" +
+      "  \"starting_balance\": \"10000000000.0000000\",\n" +
+      "  \"funder\": \"GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H\",\n" +
+      "  \"account\": \"GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR\"\n" +
+      "}";
+
   @Test
   public void testOperations() {
     Server server = new Server("https://horizon-testnet.stellar.org");
@@ -17,6 +55,22 @@ public class OperationsRequestBuilderTest {
             .order(RequestBuilder.Order.DESC)
             .buildUri();
     assertEquals("https://horizon-testnet.stellar.org/operations?limit=200&order=desc", uri.toString());
+  }
+
+  @Test
+  public void testOperationById() throws IOException, InterruptedException {
+    MockWebServer mockWebServer = new MockWebServer();
+    mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody(operationResponse));
+    mockWebServer.start();
+    Server server = new Server(mockWebServer.url("").toString());
+    OperationResponse response = server.operations()
+        .operation(438086668289l) ;
+    assertEquals(response.getType(), "create_account");
+    assertEquals(response.getId(), new Long(438086668289l));
+    assertEquals(response.getSourceAccount(), "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H");
+    RecordedRequest request = mockWebServer.takeRequest();
+    assertEquals(request.getMethod(), "GET");
+    assertEquals(request.getPath(), "/operations/438086668289");
   }
 
   @Test


### PR DESCRIPTION
There was a typo which resulted in an HTTP request with path /operation/<id> instead of /operations/<id>

fixes https://github.com/stellar/java-stellar-sdk/issues/253