### PR TITLE
[#257] Fixed failures on decoding ASCII text memos

### DIFF
--- a/src/main/java/org/stellar/sdk/Memo.java
+++ b/src/main/java/org/stellar/sdk/Memo.java
@@ -2,6 +2,8 @@ package org.stellar.sdk;
 
 import com.google.common.io.BaseEncoding;
 
+import java.nio.charset.Charset;
+
 /**
  * <p>The memo contains optional extra information. It is the responsibility of the client to interpret this value. Memos can be one of the following types:</p>
  * <ul>
@@ -24,10 +26,18 @@ public abstract class Memo {
 
     /**
      * Creates new {@link MemoText} instance.
-     * @param text
+     * @param text test in utf8 encoding
      */
     public static MemoText text(String text) {
-        return new MemoText(text);
+        return new MemoText(text, Charset.forName("UTF8"));
+    }
+
+    /**
+     * Creates new {@link MemoText} instance.
+     * @param text test in unknown encoding
+     */
+    public static MemoText textUnknownEncoding(String text) {
+        return new MemoText(text,null);
     }
 
     /**

--- a/src/main/java/org/stellar/sdk/Memo.java
+++ b/src/main/java/org/stellar/sdk/Memo.java
@@ -26,7 +26,7 @@ public abstract class Memo {
 
     /**
      * Creates new {@link MemoText} instance.
-     * @param text test in utf8 encoding
+     * @param text text in utf8 encoding
      */
     public static MemoText text(String text) {
         return new MemoText(text, Charset.forName("UTF8"));
@@ -34,7 +34,7 @@ public abstract class Memo {
 
     /**
      * Creates new {@link MemoText} instance.
-     * @param text test in unknown encoding
+     * @param text text in unknown encoding
      */
     public static MemoText textUnknownEncoding(String text) {
         return new MemoText(text,null);

--- a/src/main/java/org/stellar/sdk/MemoText.java
+++ b/src/main/java/org/stellar/sdk/MemoText.java
@@ -3,6 +3,7 @@ package org.stellar.sdk;
 import com.google.common.base.Objects;
 import org.stellar.sdk.xdr.MemoType;
 
+import javax.annotation.Nullable;
 import java.nio.charset.Charset;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -13,12 +14,19 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class MemoText extends Memo {
   private String text;
 
-  public MemoText(String text) {
+  public MemoText(String text, @Nullable Charset encoding) {
     this.text = checkNotNull(text, "text cannot be null");
 
-    int length = text.getBytes((Charset.forName("UTF-8"))).length;
+    int length;
+    if (encoding != null) {
+      length = text.getBytes(encoding).length;
+    } else {
+      int lengthUtf8 = text.getBytes((Charset.forName("UTF-8"))).length;
+      int lengthAscii = text.getBytes((Charset.forName("ASCII"))).length;
+      length = Math.min(lengthUtf8, lengthAscii);
+    }
     if (length > 28) {
-      throw new MemoTooLongException("text must be <= 28 bytes. length=" + String.valueOf(length));
+      throw new MemoTooLongException("text must be <= 28 bytes. length=" + length);
     }
   }
 

--- a/src/main/java/org/stellar/sdk/responses/TransactionDeserializer.java
+++ b/src/main/java/org/stellar/sdk/responses/TransactionDeserializer.java
@@ -33,7 +33,7 @@ public class TransactionDeserializer implements JsonDeserializer<TransactionResp
       if (memoType.equals("text")) {
         JsonElement memoField = json.getAsJsonObject().get("memo");
         if (memoField != null) {
-          memo = Memo.text(memoField.getAsString());
+          memo = Memo.textUnknownEncoding(memoField.getAsString());
         } else {
           memo = Memo.text("");
         }

--- a/src/test/java/org/stellar/sdk/MemoTest.java
+++ b/src/test/java/org/stellar/sdk/MemoTest.java
@@ -9,6 +9,7 @@ import org.stellar.sdk.MemoId;
 import org.stellar.sdk.responses.TransactionDeserializer;
 import org.stellar.sdk.responses.TransactionResponse;
 
+import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import static org.junit.Assert.*;
@@ -50,7 +51,7 @@ public class MemoTest {
     @Test
     public void testMemoTextTooLongUtf8() {
         try {
-            Memo.text("价值交易的开源协议!!");
+            new MemoText("价值交易的开源协议!!", Charset.forName("UTF8"));
             fail();
         } catch (RuntimeException exception) {
             assertTrue(exception.getMessage().contains("text must be <= 28 bytes."));
@@ -135,5 +136,25 @@ public class MemoTest {
         assertNull(memoXdr.getHash());
         assertEquals("4142434445464748494a4b4c0000000000000000000000000000000000000000", BaseEncoding.base16().lowerCase().encode(memoXdr.getRetHash().getHash()));
         assertEquals("4142434445464748494a4b4c", memo.getTrimmedHexValue());
+    }
+
+    @Test
+    public void testMemoTextAscii() {
+        String asciiStr = "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u0020\u0021\u0222\u0023\u0024\u0025\u0026\u0027";
+        MemoText memo = Memo.text(asciiStr);
+        assertEquals(asciiStr, memo.getText());
+        assertEquals(asciiStr, memo.toString());
+    }
+
+    @Test
+    public void testMemoTextAsciiTooLong() {
+        String longStr = "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u0020\u0021\u0222\u0023\u0024\u0025\u0026\u0027\u0028\u0029";
+
+        try {
+            Memo.text(longStr);
+            fail();
+        } catch (RuntimeException exception) {
+            assertTrue(exception.getMessage().contains("text must be <= 28 bytes."));
+        }
     }
 }

--- a/src/test/java/org/stellar/sdk/MemoTest.java
+++ b/src/test/java/org/stellar/sdk/MemoTest.java
@@ -140,20 +140,25 @@ public class MemoTest {
 
     @Test
     public void testMemoTextAscii() {
-        String asciiStr = "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u0020\u0021\u0222\u0023\u0024\u0025\u0026\u0027";
-        MemoText memo = Memo.text(asciiStr);
+        String asciiStr = "\u0223\u0025\ufffd\u0060\ufffd\ufffd\ufffd\u006d\u005a\u0041\u0076\u000e\ufffd\ufffd\u0002\u0049\u0004\ufffd\ufffd\ufffd\ufffd\ufffd\u0062\ufffd\u0031\ufffd\u0010";
+        try {
+            Memo.text(asciiStr);
+            fail(); // More then 28 bytes in UTF8 encoding
+        } catch (MemoTooLongException e) {
+        }
+        MemoText memo = Memo.textUnknownEncoding(asciiStr);
         assertEquals(asciiStr, memo.getText());
         assertEquals(asciiStr, memo.toString());
     }
 
     @Test
     public void testMemoTextAsciiTooLong() {
-        String longStr = "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u0020\u0021\u0222\u0023\u0024\u0025\u0026\u0027\u0028\u0029";
+        String longStr = "\u0223\u0025\ufffd\u0060\ufffd\ufffd\ufffd\u006d\u005a\u0041\u0076\u000e\ufffd\ufffd\u0002\u0049\u0004\ufffd\ufffd\ufffd\ufffd\ufffd\u0062\ufffd\u0031\ufffd\u0010\u0028\u0029";
 
         try {
-            Memo.text(longStr);
+            Memo.textUnknownEncoding(longStr);
             fail();
-        } catch (RuntimeException exception) {
+        } catch (MemoTooLongException exception) {
             assertTrue(exception.getMessage().contains("text must be <= 28 bytes."));
         }
     }


### PR DESCRIPTION
Added fixes for issue #257 only to JSON transaction deserializer, which is now get length as minimum of UTF8 and ASCII (under assumption that data from the network is correct)
All other places use old code, which was left untouched.