### PR TITLE
Use bytes to represent memo text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
+## 0.12.0
+
+* Represent memo text contents as bytes because a memo text may not be valid UTF-8 string.
+
 ## 0.11.0
 
 * Fix bug in `org.stellar.sdk.requests.OperationsRequestBuilder.operation(long operationId)`. The method submitted an HTTP request to Horizon with the following path, /operation/<id> , but the correct path is /operations/<id>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 ## 0.12.0
 
 * Represent memo text contents as bytes because a memo text may not be valid UTF-8 string (https://github.com/stellar/java-stellar-sdk/issues/257).
+* Validate name length when constructing org.stellar.sdk.ManageDataOperation instances.
+* Validate home domain length when constructing org.stellar.sdk.SetOptionsOperation instances.
 
 ## 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ## 0.12.0
 
-* Represent memo text contents as bytes because a memo text may not be valid UTF-8 string.
+* Represent memo text contents as bytes because a memo text may not be valid UTF-8 string (https://github.com/stellar/java-stellar-sdk/issues/257).
 
 ## 0.11.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'com.github.ben-manes.versions' // gradle dependencyUpdates -Drevi
 apply plugin: 'project-report' // gradle htmlDependencyReport
 
 sourceCompatibility = 1.6
-version = '0.11.0'
+version = '0.12.0'
 group = 'stellar'
 
 jar {

--- a/src/main/java/org/stellar/sdk/ManageDataOperation.java
+++ b/src/main/java/org/stellar/sdk/ManageDataOperation.java
@@ -3,8 +3,6 @@ package org.stellar.sdk;
 import com.google.common.base.Objects;
 import org.stellar.sdk.xdr.*;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/src/main/java/org/stellar/sdk/ManageDataOperation.java
+++ b/src/main/java/org/stellar/sdk/ManageDataOperation.java
@@ -1,10 +1,7 @@
 package org.stellar.sdk;
 
 import com.google.common.base.Objects;
-import org.stellar.sdk.xdr.DataValue;
-import org.stellar.sdk.xdr.ManageDataOp;
-import org.stellar.sdk.xdr.OperationType;
-import org.stellar.sdk.xdr.String64;
+import org.stellar.sdk.xdr.*;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
@@ -43,7 +40,7 @@ public class ManageDataOperation extends Operation {
   org.stellar.sdk.xdr.Operation.OperationBody toOperationBody() {
     ManageDataOp op = new ManageDataOp();
     String64 name = new String64();
-    name.setString64(this.name.getBytes(Charset.forName("UTF-8")));
+    name.setString64(new XdrString(this.name));
     op.setDataName(name);
 
     if (value != null) {
@@ -70,7 +67,7 @@ public class ManageDataOperation extends Operation {
      * @param op {@link ManageDataOp}
      */
     Builder(ManageDataOp op) {
-      name = new String(op.getDataName().getString64(), Charset.forName("UTF-8"));
+      name = op.getDataName().getString64().toString();
       if (op.getDataValue() != null) {
         value = op.getDataValue().getDataValue();
       } else {

--- a/src/main/java/org/stellar/sdk/ManageDataOperation.java
+++ b/src/main/java/org/stellar/sdk/ManageDataOperation.java
@@ -6,6 +6,8 @@ import org.stellar.sdk.xdr.ManageDataOp;
 import org.stellar.sdk.xdr.OperationType;
 import org.stellar.sdk.xdr.String64;
 
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -41,7 +43,7 @@ public class ManageDataOperation extends Operation {
   org.stellar.sdk.xdr.Operation.OperationBody toOperationBody() {
     ManageDataOp op = new ManageDataOp();
     String64 name = new String64();
-    name.setString64(this.name);
+    name.setString64(this.name.getBytes(Charset.forName("UTF-8")));
     op.setDataName(name);
 
     if (value != null) {
@@ -68,7 +70,7 @@ public class ManageDataOperation extends Operation {
      * @param op {@link ManageDataOp}
      */
     Builder(ManageDataOp op) {
-      name = op.getDataName().getString64();
+      name = new String(op.getDataName().getString64(), Charset.forName("UTF-8"));
       if (op.getDataValue() != null) {
         value = op.getDataValue().getDataValue();
       } else {

--- a/src/main/java/org/stellar/sdk/ManageDataOperation.java
+++ b/src/main/java/org/stellar/sdk/ManageDataOperation.java
@@ -20,6 +20,10 @@ public class ManageDataOperation extends Operation {
   private ManageDataOperation(String name, byte[] value) {
     this.name = checkNotNull(name, "name cannot be null");
     this.value = value;
+
+    if (new XdrString(this.name).getBytes().length > 64) {
+      throw new IllegalArgumentException("name cannot exceed 64 bytes");
+    }
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/Memo.java
+++ b/src/main/java/org/stellar/sdk/Memo.java
@@ -87,7 +87,7 @@ public abstract class Memo {
             case MEMO_ID:
                 return id(memo.getId().getUint64().longValue());
             case MEMO_TEXT:
-                return text(memo.getText());
+                return text(memo.getText().getBytes());
             case MEMO_HASH:
                 return hash(memo.getHash().getHash());
             case MEMO_RETURN:

--- a/src/main/java/org/stellar/sdk/Memo.java
+++ b/src/main/java/org/stellar/sdk/Memo.java
@@ -31,6 +31,15 @@ public abstract class Memo {
     }
 
     /**
+     * Creates new {@link MemoText} instance.
+     * @param text
+     */
+    public static MemoText text(byte[] text) {
+        return new MemoText(text);
+    }
+
+
+    /**
      * Creates new {@link MemoId} instance.
      * @param id
      */

--- a/src/main/java/org/stellar/sdk/MemoText.java
+++ b/src/main/java/org/stellar/sdk/MemoText.java
@@ -26,7 +26,7 @@ public class MemoText extends Memo {
   }
 
   public String getText() {
-    return new String(text, Charset.forName("UTF-8"));
+    return new String(this.text, Charset.forName("UTF-8"));
   }
 
   public byte[] getBytes() {

--- a/src/main/java/org/stellar/sdk/MemoText.java
+++ b/src/main/java/org/stellar/sdk/MemoText.java
@@ -4,6 +4,7 @@ import com.google.common.base.Objects;
 import org.stellar.sdk.xdr.MemoType;
 
 import java.nio.charset.Charset;
+import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -11,19 +12,25 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Represents MEMO_TEXT.
  */
 public class MemoText extends Memo {
-  private String text;
+  private byte[] text;
 
   public MemoText(String text) {
-    this.text = checkNotNull(text, "text cannot be null");
+    this(checkNotNull(text, "text cannot be null").getBytes((Charset.forName("UTF-8"))));
+  }
 
-    int length = text.getBytes((Charset.forName("UTF-8"))).length;
-    if (length > 28) {
-      throw new MemoTooLongException("text must be <= 28 bytes. length=" + String.valueOf(length));
+  public MemoText(byte[] text) {
+    this.text = checkNotNull(text, "text cannot be null");
+    if (this.text.length > 28) {
+      throw new MemoTooLongException("text must be <= 28 bytes. length=" + String.valueOf(this.text.length));
     }
   }
 
   public String getText() {
-    return text;
+    return new String(text, Charset.forName("UTF-8"));
+  }
+
+  public byte[] getBytes() {
+    return this.text;
   }
 
   @Override
@@ -36,7 +43,7 @@ public class MemoText extends Memo {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.text);
+    return Arrays.hashCode(this.text);
   }
 
   @Override
@@ -44,11 +51,11 @@ public class MemoText extends Memo {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     MemoText memoText = (MemoText) o;
-    return Objects.equal(this.text, memoText.text);
+    return Arrays.equals(this.text, memoText.text);
   }
 
     @Override
     public String toString() {
-        return text == null ? "" : text;
+        return text == null ? "" : this.getText();
     }
 }

--- a/src/main/java/org/stellar/sdk/MemoText.java
+++ b/src/main/java/org/stellar/sdk/MemoText.java
@@ -15,7 +15,7 @@ public class MemoText extends Memo {
   private byte[] text;
 
   public MemoText(String text) {
-    this(checkNotNull(text, "text cannot be null").getBytes((Charset.forName("UTF-8"))));
+    this(checkNotNull(text, "text cannot be null").getBytes(Charset.forName("UTF-8")));
   }
 
   public MemoText(byte[] text) {

--- a/src/main/java/org/stellar/sdk/MemoText.java
+++ b/src/main/java/org/stellar/sdk/MemoText.java
@@ -2,6 +2,7 @@ package org.stellar.sdk;
 
 import com.google.common.base.Objects;
 import org.stellar.sdk.xdr.MemoType;
+import org.stellar.sdk.xdr.XdrString;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -37,7 +38,7 @@ public class MemoText extends Memo {
   org.stellar.sdk.xdr.Memo toXdr() {
     org.stellar.sdk.xdr.Memo memo = new org.stellar.sdk.xdr.Memo();
     memo.setDiscriminant(MemoType.MEMO_TEXT);
-    memo.setText(text);
+    memo.setText(new XdrString(text));
     return memo;
   }
 

--- a/src/main/java/org/stellar/sdk/MemoText.java
+++ b/src/main/java/org/stellar/sdk/MemoText.java
@@ -1,11 +1,7 @@
 package org.stellar.sdk;
 
-import com.google.common.base.Objects;
 import org.stellar.sdk.xdr.MemoType;
 import org.stellar.sdk.xdr.XdrString;
-
-import java.nio.charset.Charset;
-import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -13,38 +9,43 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Represents MEMO_TEXT.
  */
 public class MemoText extends Memo {
-  private byte[] text;
+  private XdrString text;
 
   public MemoText(String text) {
-    this(checkNotNull(text, "text cannot be null").getBytes(Charset.forName("UTF-8")));
+    this(new XdrString(checkNotNull(text, "text cannot be null")));
   }
 
   public MemoText(byte[] text) {
+    this(new XdrString(checkNotNull(text, "text cannot be null")));
+  }
+
+  public MemoText(XdrString text) {
     this.text = checkNotNull(text, "text cannot be null");
-    if (this.text.length > 28) {
-      throw new MemoTooLongException("text must be <= 28 bytes. length=" + String.valueOf(this.text.length));
+    int length = this.text.getBytes().length;
+    if (length > 28) {
+      throw new MemoTooLongException("text must be <= 28 bytes. length=" + String.valueOf(length));
     }
   }
 
   public String getText() {
-    return new String(this.text, Charset.forName("UTF-8"));
+    return this.text.toString();
   }
 
   public byte[] getBytes() {
-    return this.text;
+    return this.text.getBytes();
   }
 
   @Override
   org.stellar.sdk.xdr.Memo toXdr() {
     org.stellar.sdk.xdr.Memo memo = new org.stellar.sdk.xdr.Memo();
     memo.setDiscriminant(MemoType.MEMO_TEXT);
-    memo.setText(new XdrString(text));
+    memo.setText(this.text);
     return memo;
   }
 
   @Override
   public int hashCode() {
-    return Arrays.hashCode(this.text);
+    return this.text.hashCode();
   }
 
   @Override
@@ -52,7 +53,7 @@ public class MemoText extends Memo {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     MemoText memoText = (MemoText) o;
-    return Arrays.equals(this.text, memoText.text);
+    return this.text.equals(memoText.text);
   }
 
     @Override

--- a/src/main/java/org/stellar/sdk/SetOptionsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetOptionsOperation.java
@@ -37,7 +37,7 @@ public class SetOptionsOperation extends Operation {
     this.signer = signer;
     this.signerWeight = signerWeight;
 
-    if (new XdrString(this.homeDomain).getBytes().length > 32) {
+    if (this.homeDomain != null && new XdrString(this.homeDomain).getBytes().length > 32) {
       throw new IllegalArgumentException("home domain cannot exceed 32 bytes");
     }
 

--- a/src/main/java/org/stellar/sdk/SetOptionsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetOptionsOperation.java
@@ -4,6 +4,8 @@ import com.google.common.base.Objects;
 import org.stellar.sdk.xdr.*;
 
 
+import java.nio.charset.Charset;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -148,7 +150,7 @@ public class SetOptionsOperation extends Operation {
     }
     if (homeDomain != null) {
       String32 homeDomain = new String32();
-      homeDomain.setString32(this.homeDomain);
+      homeDomain.setString32(this.homeDomain.getBytes(Charset.forName("UTF-8")));
       op.setHomeDomain(homeDomain);
     }
     if (signer != null) {
@@ -206,7 +208,7 @@ public class SetOptionsOperation extends Operation {
         highThreshold = op.getHighThreshold().getUint32().intValue();
       }
       if (op.getHomeDomain() != null) {
-        homeDomain = op.getHomeDomain().getString32();
+        homeDomain = new String(op.getHomeDomain().getString32(), Charset.forName("UTF-8"));
       }
       if (op.getSigner() != null) {
         signer = op.getSigner().getKey();

--- a/src/main/java/org/stellar/sdk/SetOptionsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetOptionsOperation.java
@@ -4,8 +4,6 @@ import com.google.common.base.Objects;
 import org.stellar.sdk.xdr.*;
 
 
-import java.nio.charset.Charset;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**

--- a/src/main/java/org/stellar/sdk/SetOptionsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetOptionsOperation.java
@@ -38,6 +38,11 @@ public class SetOptionsOperation extends Operation {
     this.homeDomain = homeDomain;
     this.signer = signer;
     this.signerWeight = signerWeight;
+
+    if (new XdrString(this.homeDomain).getBytes().length > 32) {
+      throw new IllegalArgumentException("home domain cannot exceed 32 bytes");
+    }
+
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/SetOptionsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetOptionsOperation.java
@@ -150,7 +150,7 @@ public class SetOptionsOperation extends Operation {
     }
     if (homeDomain != null) {
       String32 homeDomain = new String32();
-      homeDomain.setString32(this.homeDomain.getBytes(Charset.forName("UTF-8")));
+      homeDomain.setString32(new XdrString(this.homeDomain));
       op.setHomeDomain(homeDomain);
     }
     if (signer != null) {
@@ -208,7 +208,7 @@ public class SetOptionsOperation extends Operation {
         highThreshold = op.getHighThreshold().getUint32().intValue();
       }
       if (op.getHomeDomain() != null) {
-        homeDomain = new String(op.getHomeDomain().getString32(), Charset.forName("UTF-8"));
+        homeDomain = op.getHomeDomain().getString32().toString();
       }
       if (op.getSigner() != null) {
         signer = op.getSigner().getKey();

--- a/src/main/java/org/stellar/sdk/responses/TransactionDeserializer.java
+++ b/src/main/java/org/stellar/sdk/responses/TransactionDeserializer.java
@@ -47,7 +47,7 @@ public class TransactionDeserializer implements JsonDeserializer<TransactionResp
           // so we must throw it as a runtime exception
           throw new RuntimeException(e);
         }
-        memo = Memo.text(transactionEnvelope.getTx().getMemo().getText());
+        memo = Memo.text(transactionEnvelope.getTx().getMemo().getText().getBytes());
       } else {
         String memoValue = json.getAsJsonObject().get("memo").getAsString();
         BaseEncoding base64Encoding = BaseEncoding.base64();

--- a/src/main/java/org/stellar/sdk/xdr/Error.java
+++ b/src/main/java/org/stellar/sdk/xdr/Error.java
@@ -7,7 +7,6 @@ package org.stellar.sdk.xdr;
 import java.io.IOException;
 
 import com.google.common.base.Objects;
-import java.util.Arrays;
 
 // === xdr source ============================================================
 
@@ -27,18 +26,16 @@ public class Error implements XdrElement {
   public void setCode(ErrorCode value) {
     this.code = value;
   }
-  private byte[] msg;
-  public byte[] getMsg() {
+  private XdrString msg;
+  public XdrString getMsg() {
     return this.msg;
   }
-  public void setMsg(byte[] value) {
+  public void setMsg(XdrString value) {
     this.msg = value;
   }
   public static void encode(XdrDataOutputStream stream, Error encodedError) throws IOException{
     ErrorCode.encode(stream, encodedError.code);
-    int msgsize = encodedError.msg.length;
-    stream.writeInt(msgsize);
-    stream.write(encodedError.getMsg(), 0, msgsize);
+    encodedError.msg.encode(stream);
   }
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
@@ -46,14 +43,12 @@ public class Error implements XdrElement {
   public static Error decode(XdrDataInputStream stream) throws IOException {
     Error decodedError = new Error();
     decodedError.code = ErrorCode.decode(stream);
-    int msgsize = stream.readInt();
-    decodedError.msg = new byte[msgsize];
-    stream.read(decodedError.msg, 0, msgsize);
+    decodedError.msg = XdrString.decode(stream);
     return decodedError;
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.code, Arrays.hashCode(this.msg));
+    return Objects.hashCode(this.code, this.msg);
   }
   @Override
   public boolean equals(Object object) {
@@ -62,6 +57,6 @@ public class Error implements XdrElement {
     }
 
     Error other = (Error) object;
-    return Objects.equal(this.code, other.code) && Arrays.equals(this.msg, other.msg);
+    return Objects.equal(this.code, other.code) && Objects.equal(this.msg, other.msg);
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Error.java
+++ b/src/main/java/org/stellar/sdk/xdr/Error.java
@@ -43,7 +43,7 @@ public class Error implements XdrElement {
   public static Error decode(XdrDataInputStream stream) throws IOException {
     Error decodedError = new Error();
     decodedError.code = ErrorCode.decode(stream);
-    decodedError.msg = XdrString.decode(stream);
+    decodedError.msg = XdrString.decode(stream, 100);
     return decodedError;
   }
   @Override

--- a/src/main/java/org/stellar/sdk/xdr/Error.java
+++ b/src/main/java/org/stellar/sdk/xdr/Error.java
@@ -7,6 +7,7 @@ package org.stellar.sdk.xdr;
 import java.io.IOException;
 
 import com.google.common.base.Objects;
+import java.util.Arrays;
 
 // === xdr source ============================================================
 
@@ -26,16 +27,18 @@ public class Error implements XdrElement {
   public void setCode(ErrorCode value) {
     this.code = value;
   }
-  private String msg;
-  public String getMsg() {
+  private byte[] msg;
+  public byte[] getMsg() {
     return this.msg;
   }
-  public void setMsg(String value) {
+  public void setMsg(byte[] value) {
     this.msg = value;
   }
   public static void encode(XdrDataOutputStream stream, Error encodedError) throws IOException{
     ErrorCode.encode(stream, encodedError.code);
-    stream.writeString(encodedError.msg);
+    int msgsize = encodedError.msg.length;
+    stream.writeInt(msgsize);
+    stream.write(encodedError.getMsg(), 0, msgsize);
   }
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
@@ -43,12 +46,14 @@ public class Error implements XdrElement {
   public static Error decode(XdrDataInputStream stream) throws IOException {
     Error decodedError = new Error();
     decodedError.code = ErrorCode.decode(stream);
-    decodedError.msg = stream.readString();
+    int msgsize = stream.readInt();
+    decodedError.msg = new byte[msgsize];
+    stream.read(decodedError.msg, 0, msgsize);
     return decodedError;
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.code, this.msg);
+    return Objects.hashCode(this.code, Arrays.hashCode(this.msg));
   }
   @Override
   public boolean equals(Object object) {
@@ -57,6 +62,6 @@ public class Error implements XdrElement {
     }
 
     Error other = (Error) object;
-    return Objects.equal(this.code, other.code) && Objects.equal(this.msg, other.msg);
+    return Objects.equal(this.code, other.code) && Arrays.equals(this.msg, other.msg);
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Hello.java
+++ b/src/main/java/org/stellar/sdk/xdr/Hello.java
@@ -7,6 +7,7 @@ package org.stellar.sdk.xdr;
 import java.io.IOException;
 
 import com.google.common.base.Objects;
+import java.util.Arrays;
 
 // === xdr source ============================================================
 
@@ -54,11 +55,11 @@ public class Hello implements XdrElement {
   public void setNetworkID(Hash value) {
     this.networkID = value;
   }
-  private String versionStr;
-  public String getVersionStr() {
+  private byte[] versionStr;
+  public byte[] getVersionStr() {
     return this.versionStr;
   }
-  public void setVersionStr(String value) {
+  public void setVersionStr(byte[] value) {
     this.versionStr = value;
   }
   private Integer listeningPort;
@@ -94,7 +95,9 @@ public class Hello implements XdrElement {
     Uint32.encode(stream, encodedHello.overlayVersion);
     Uint32.encode(stream, encodedHello.overlayMinVersion);
     Hash.encode(stream, encodedHello.networkID);
-    stream.writeString(encodedHello.versionStr);
+    int versionStrsize = encodedHello.versionStr.length;
+    stream.writeInt(versionStrsize);
+    stream.write(encodedHello.getVersionStr(), 0, versionStrsize);
     stream.writeInt(encodedHello.listeningPort);
     NodeID.encode(stream, encodedHello.peerID);
     AuthCert.encode(stream, encodedHello.cert);
@@ -109,7 +112,9 @@ public class Hello implements XdrElement {
     decodedHello.overlayVersion = Uint32.decode(stream);
     decodedHello.overlayMinVersion = Uint32.decode(stream);
     decodedHello.networkID = Hash.decode(stream);
-    decodedHello.versionStr = stream.readString();
+    int versionStrsize = stream.readInt();
+    decodedHello.versionStr = new byte[versionStrsize];
+    stream.read(decodedHello.versionStr, 0, versionStrsize);
     decodedHello.listeningPort = stream.readInt();
     decodedHello.peerID = NodeID.decode(stream);
     decodedHello.cert = AuthCert.decode(stream);
@@ -118,7 +123,7 @@ public class Hello implements XdrElement {
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.ledgerVersion, this.overlayVersion, this.overlayMinVersion, this.networkID, this.versionStr, this.listeningPort, this.peerID, this.cert, this.nonce);
+    return Objects.hashCode(this.ledgerVersion, this.overlayVersion, this.overlayMinVersion, this.networkID, Arrays.hashCode(this.versionStr), this.listeningPort, this.peerID, this.cert, this.nonce);
   }
   @Override
   public boolean equals(Object object) {
@@ -127,6 +132,6 @@ public class Hello implements XdrElement {
     }
 
     Hello other = (Hello) object;
-    return Objects.equal(this.ledgerVersion, other.ledgerVersion) && Objects.equal(this.overlayVersion, other.overlayVersion) && Objects.equal(this.overlayMinVersion, other.overlayMinVersion) && Objects.equal(this.networkID, other.networkID) && Objects.equal(this.versionStr, other.versionStr) && Objects.equal(this.listeningPort, other.listeningPort) && Objects.equal(this.peerID, other.peerID) && Objects.equal(this.cert, other.cert) && Objects.equal(this.nonce, other.nonce);
+    return Objects.equal(this.ledgerVersion, other.ledgerVersion) && Objects.equal(this.overlayVersion, other.overlayVersion) && Objects.equal(this.overlayMinVersion, other.overlayMinVersion) && Objects.equal(this.networkID, other.networkID) && Arrays.equals(this.versionStr, other.versionStr) && Objects.equal(this.listeningPort, other.listeningPort) && Objects.equal(this.peerID, other.peerID) && Objects.equal(this.cert, other.cert) && Objects.equal(this.nonce, other.nonce);
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Hello.java
+++ b/src/main/java/org/stellar/sdk/xdr/Hello.java
@@ -109,7 +109,7 @@ public class Hello implements XdrElement {
     decodedHello.overlayVersion = Uint32.decode(stream);
     decodedHello.overlayMinVersion = Uint32.decode(stream);
     decodedHello.networkID = Hash.decode(stream);
-    decodedHello.versionStr = XdrString.decode(stream);
+    decodedHello.versionStr = XdrString.decode(stream, 100);
     decodedHello.listeningPort = stream.readInt();
     decodedHello.peerID = NodeID.decode(stream);
     decodedHello.cert = AuthCert.decode(stream);

--- a/src/main/java/org/stellar/sdk/xdr/Hello.java
+++ b/src/main/java/org/stellar/sdk/xdr/Hello.java
@@ -7,7 +7,6 @@ package org.stellar.sdk.xdr;
 import java.io.IOException;
 
 import com.google.common.base.Objects;
-import java.util.Arrays;
 
 // === xdr source ============================================================
 
@@ -55,11 +54,11 @@ public class Hello implements XdrElement {
   public void setNetworkID(Hash value) {
     this.networkID = value;
   }
-  private byte[] versionStr;
-  public byte[] getVersionStr() {
+  private XdrString versionStr;
+  public XdrString getVersionStr() {
     return this.versionStr;
   }
-  public void setVersionStr(byte[] value) {
+  public void setVersionStr(XdrString value) {
     this.versionStr = value;
   }
   private Integer listeningPort;
@@ -95,9 +94,7 @@ public class Hello implements XdrElement {
     Uint32.encode(stream, encodedHello.overlayVersion);
     Uint32.encode(stream, encodedHello.overlayMinVersion);
     Hash.encode(stream, encodedHello.networkID);
-    int versionStrsize = encodedHello.versionStr.length;
-    stream.writeInt(versionStrsize);
-    stream.write(encodedHello.getVersionStr(), 0, versionStrsize);
+    encodedHello.versionStr.encode(stream);
     stream.writeInt(encodedHello.listeningPort);
     NodeID.encode(stream, encodedHello.peerID);
     AuthCert.encode(stream, encodedHello.cert);
@@ -112,9 +109,7 @@ public class Hello implements XdrElement {
     decodedHello.overlayVersion = Uint32.decode(stream);
     decodedHello.overlayMinVersion = Uint32.decode(stream);
     decodedHello.networkID = Hash.decode(stream);
-    int versionStrsize = stream.readInt();
-    decodedHello.versionStr = new byte[versionStrsize];
-    stream.read(decodedHello.versionStr, 0, versionStrsize);
+    decodedHello.versionStr = XdrString.decode(stream);
     decodedHello.listeningPort = stream.readInt();
     decodedHello.peerID = NodeID.decode(stream);
     decodedHello.cert = AuthCert.decode(stream);
@@ -123,7 +118,7 @@ public class Hello implements XdrElement {
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.ledgerVersion, this.overlayVersion, this.overlayMinVersion, this.networkID, Arrays.hashCode(this.versionStr), this.listeningPort, this.peerID, this.cert, this.nonce);
+    return Objects.hashCode(this.ledgerVersion, this.overlayVersion, this.overlayMinVersion, this.networkID, this.versionStr, this.listeningPort, this.peerID, this.cert, this.nonce);
   }
   @Override
   public boolean equals(Object object) {
@@ -132,6 +127,6 @@ public class Hello implements XdrElement {
     }
 
     Hello other = (Hello) object;
-    return Objects.equal(this.ledgerVersion, other.ledgerVersion) && Objects.equal(this.overlayVersion, other.overlayVersion) && Objects.equal(this.overlayMinVersion, other.overlayMinVersion) && Objects.equal(this.networkID, other.networkID) && Arrays.equals(this.versionStr, other.versionStr) && Objects.equal(this.listeningPort, other.listeningPort) && Objects.equal(this.peerID, other.peerID) && Objects.equal(this.cert, other.cert) && Objects.equal(this.nonce, other.nonce);
+    return Objects.equal(this.ledgerVersion, other.ledgerVersion) && Objects.equal(this.overlayVersion, other.overlayVersion) && Objects.equal(this.overlayMinVersion, other.overlayMinVersion) && Objects.equal(this.networkID, other.networkID) && Objects.equal(this.versionStr, other.versionStr) && Objects.equal(this.listeningPort, other.listeningPort) && Objects.equal(this.peerID, other.peerID) && Objects.equal(this.cert, other.cert) && Objects.equal(this.nonce, other.nonce);
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Memo.java
+++ b/src/main/java/org/stellar/sdk/xdr/Memo.java
@@ -16,7 +16,7 @@ import java.util.Arrays;
 //  case MEMO_NONE:
 //      void;
 //  case MEMO_TEXT:
-//      opaque text<28>;
+//      string text<28>;
 //  case MEMO_ID:
 //      uint64 id;
 //  case MEMO_HASH:

--- a/src/main/java/org/stellar/sdk/xdr/Memo.java
+++ b/src/main/java/org/stellar/sdk/xdr/Memo.java
@@ -7,6 +7,7 @@ package org.stellar.sdk.xdr;
 import java.io.IOException;
 
 import com.google.common.base.Objects;
+import java.util.Arrays;
 
 // === xdr source ============================================================
 
@@ -15,7 +16,7 @@ import com.google.common.base.Objects;
 //  case MEMO_NONE:
 //      void;
 //  case MEMO_TEXT:
-//      string text<28>;
+//      opaque text<28>;
 //  case MEMO_ID:
 //      uint64 id;
 //  case MEMO_HASH:
@@ -34,11 +35,11 @@ public class Memo implements XdrElement {
   public void setDiscriminant(MemoType value) {
     this.type = value;
   }
-  private String text;
-  public String getText() {
+  private byte[] text;
+  public byte[] getText() {
     return this.text;
   }
-  public void setText(String value) {
+  public void setText(byte[] value) {
     this.text = value;
   }
   private Uint64 id;
@@ -70,7 +71,9 @@ public class Memo implements XdrElement {
   case MEMO_NONE:
   break;
   case MEMO_TEXT:
-  stream.writeString(encodedMemo.text);
+  int textsize = encodedMemo.text.length;
+  stream.writeInt(textsize);
+  stream.write(encodedMemo.getText(), 0, textsize);
   break;
   case MEMO_ID:
   Uint64.encode(stream, encodedMemo.id);
@@ -94,7 +97,9 @@ public class Memo implements XdrElement {
   case MEMO_NONE:
   break;
   case MEMO_TEXT:
-  decodedMemo.text = stream.readString();
+  int textsize = stream.readInt();
+  decodedMemo.text = new byte[textsize];
+  stream.read(decodedMemo.text, 0, textsize);
   break;
   case MEMO_ID:
   decodedMemo.id = Uint64.decode(stream);
@@ -110,7 +115,7 @@ public class Memo implements XdrElement {
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.text, this.id, this.hash, this.retHash, this.type);
+    return Objects.hashCode(Arrays.hashCode(this.text), this.id, this.hash, this.retHash, this.type);
   }
   @Override
   public boolean equals(Object object) {
@@ -119,6 +124,6 @@ public class Memo implements XdrElement {
     }
 
     Memo other = (Memo) object;
-    return Objects.equal(this.text, other.text) && Objects.equal(this.id, other.id) && Objects.equal(this.hash, other.hash) && Objects.equal(this.retHash, other.retHash) && Objects.equal(this.type, other.type);
+    return Arrays.equals(this.text, other.text) && Objects.equal(this.id, other.id) && Objects.equal(this.hash, other.hash) && Objects.equal(this.retHash, other.retHash) && Objects.equal(this.type, other.type);
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Memo.java
+++ b/src/main/java/org/stellar/sdk/xdr/Memo.java
@@ -94,7 +94,7 @@ public class Memo implements XdrElement {
   case MEMO_NONE:
   break;
   case MEMO_TEXT:
-  decodedMemo.text = XdrString.decode(stream);
+  decodedMemo.text = XdrString.decode(stream, 28);
   break;
   case MEMO_ID:
   decodedMemo.id = Uint64.decode(stream);

--- a/src/main/java/org/stellar/sdk/xdr/Memo.java
+++ b/src/main/java/org/stellar/sdk/xdr/Memo.java
@@ -7,7 +7,6 @@ package org.stellar.sdk.xdr;
 import java.io.IOException;
 
 import com.google.common.base.Objects;
-import java.util.Arrays;
 
 // === xdr source ============================================================
 
@@ -35,11 +34,11 @@ public class Memo implements XdrElement {
   public void setDiscriminant(MemoType value) {
     this.type = value;
   }
-  private byte[] text;
-  public byte[] getText() {
+  private XdrString text;
+  public XdrString getText() {
     return this.text;
   }
-  public void setText(byte[] value) {
+  public void setText(XdrString value) {
     this.text = value;
   }
   private Uint64 id;
@@ -71,9 +70,7 @@ public class Memo implements XdrElement {
   case MEMO_NONE:
   break;
   case MEMO_TEXT:
-  int textsize = encodedMemo.text.length;
-  stream.writeInt(textsize);
-  stream.write(encodedMemo.getText(), 0, textsize);
+  encodedMemo.text.encode(stream);
   break;
   case MEMO_ID:
   Uint64.encode(stream, encodedMemo.id);
@@ -97,9 +94,7 @@ public class Memo implements XdrElement {
   case MEMO_NONE:
   break;
   case MEMO_TEXT:
-  int textsize = stream.readInt();
-  decodedMemo.text = new byte[textsize];
-  stream.read(decodedMemo.text, 0, textsize);
+  decodedMemo.text = XdrString.decode(stream);
   break;
   case MEMO_ID:
   decodedMemo.id = Uint64.decode(stream);
@@ -115,7 +110,7 @@ public class Memo implements XdrElement {
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(Arrays.hashCode(this.text), this.id, this.hash, this.retHash, this.type);
+    return Objects.hashCode(this.text, this.id, this.hash, this.retHash, this.type);
   }
   @Override
   public boolean equals(Object object) {
@@ -124,6 +119,6 @@ public class Memo implements XdrElement {
     }
 
     Memo other = (Memo) object;
-    return Arrays.equals(this.text, other.text) && Objects.equal(this.id, other.id) && Objects.equal(this.hash, other.hash) && Objects.equal(this.retHash, other.retHash) && Objects.equal(this.type, other.type);
+    return Objects.equal(this.text, other.text) && Objects.equal(this.id, other.id) && Objects.equal(this.hash, other.hash) && Objects.equal(this.retHash, other.retHash) && Objects.equal(this.type, other.type);
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/String32.java
+++ b/src/main/java/org/stellar/sdk/xdr/String32.java
@@ -29,7 +29,7 @@ public class String32 implements XdrElement {
   }
   public static String32 decode(XdrDataInputStream stream) throws IOException {
     String32 decodedString32 = new String32();
-  decodedString32.string32 = XdrString.decode(stream);
+  decodedString32.string32 = XdrString.decode(stream, 32);
     return decodedString32;
   }
   @Override

--- a/src/main/java/org/stellar/sdk/xdr/String32.java
+++ b/src/main/java/org/stellar/sdk/xdr/String32.java
@@ -6,7 +6,7 @@ package org.stellar.sdk.xdr;
 
 import java.io.IOException;
 
-import com.google.common.base.Objects;
+import java.util.Arrays;
 
 // === xdr source ============================================================
 
@@ -14,27 +14,31 @@ import com.google.common.base.Objects;
 
 //  ===========================================================================
 public class String32 implements XdrElement {
-  private String string32;
-  public String getString32() {
+  private byte[] string32;
+  public byte[] getString32() {
     return this.string32;
   }
-  public void setString32(String value) {
+  public void setString32(byte[] value) {
     this.string32 = value;
   }
   public static void encode(XdrDataOutputStream stream, String32  encodedString32) throws IOException {
-  stream.writeString(encodedString32.string32);
+  int string32size = encodedString32.string32.length;
+  stream.writeInt(string32size);
+  stream.write(encodedString32.getString32(), 0, string32size);
   }
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static String32 decode(XdrDataInputStream stream) throws IOException {
     String32 decodedString32 = new String32();
-  decodedString32.string32 = stream.readString();
+  int string32size = stream.readInt();
+  decodedString32.string32 = new byte[string32size];
+  stream.read(decodedString32.string32, 0, string32size);
     return decodedString32;
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.string32);
+    return Arrays.hashCode(this.string32);
   }
   @Override
   public boolean equals(Object object) {
@@ -43,6 +47,6 @@ public class String32 implements XdrElement {
     }
 
     String32 other = (String32) object;
-    return Objects.equal(this.string32, other.string32);
+    return Arrays.equals(this.string32, other.string32);
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/String32.java
+++ b/src/main/java/org/stellar/sdk/xdr/String32.java
@@ -6,7 +6,7 @@ package org.stellar.sdk.xdr;
 
 import java.io.IOException;
 
-import java.util.Arrays;
+import com.google.common.base.Objects;
 
 // === xdr source ============================================================
 
@@ -14,31 +14,27 @@ import java.util.Arrays;
 
 //  ===========================================================================
 public class String32 implements XdrElement {
-  private byte[] string32;
-  public byte[] getString32() {
+  private XdrString string32;
+  public XdrString getString32() {
     return this.string32;
   }
-  public void setString32(byte[] value) {
+  public void setString32(XdrString value) {
     this.string32 = value;
   }
   public static void encode(XdrDataOutputStream stream, String32  encodedString32) throws IOException {
-  int string32size = encodedString32.string32.length;
-  stream.writeInt(string32size);
-  stream.write(encodedString32.getString32(), 0, string32size);
+  encodedString32.string32.encode(stream);
   }
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static String32 decode(XdrDataInputStream stream) throws IOException {
     String32 decodedString32 = new String32();
-  int string32size = stream.readInt();
-  decodedString32.string32 = new byte[string32size];
-  stream.read(decodedString32.string32, 0, string32size);
+  decodedString32.string32 = XdrString.decode(stream);
     return decodedString32;
   }
   @Override
   public int hashCode() {
-    return Arrays.hashCode(this.string32);
+    return Objects.hashCode(this.string32);
   }
   @Override
   public boolean equals(Object object) {
@@ -47,6 +43,6 @@ public class String32 implements XdrElement {
     }
 
     String32 other = (String32) object;
-    return Arrays.equals(this.string32, other.string32);
+    return Objects.equal(this.string32, other.string32);
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/String64.java
+++ b/src/main/java/org/stellar/sdk/xdr/String64.java
@@ -6,7 +6,7 @@ package org.stellar.sdk.xdr;
 
 import java.io.IOException;
 
-import com.google.common.base.Objects;
+import java.util.Arrays;
 
 // === xdr source ============================================================
 
@@ -14,27 +14,31 @@ import com.google.common.base.Objects;
 
 //  ===========================================================================
 public class String64 implements XdrElement {
-  private String string64;
-  public String getString64() {
+  private byte[] string64;
+  public byte[] getString64() {
     return this.string64;
   }
-  public void setString64(String value) {
+  public void setString64(byte[] value) {
     this.string64 = value;
   }
   public static void encode(XdrDataOutputStream stream, String64  encodedString64) throws IOException {
-  stream.writeString(encodedString64.string64);
+  int string64size = encodedString64.string64.length;
+  stream.writeInt(string64size);
+  stream.write(encodedString64.getString64(), 0, string64size);
   }
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static String64 decode(XdrDataInputStream stream) throws IOException {
     String64 decodedString64 = new String64();
-  decodedString64.string64 = stream.readString();
+  int string64size = stream.readInt();
+  decodedString64.string64 = new byte[string64size];
+  stream.read(decodedString64.string64, 0, string64size);
     return decodedString64;
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.string64);
+    return Arrays.hashCode(this.string64);
   }
   @Override
   public boolean equals(Object object) {
@@ -43,6 +47,6 @@ public class String64 implements XdrElement {
     }
 
     String64 other = (String64) object;
-    return Objects.equal(this.string64, other.string64);
+    return Arrays.equals(this.string64, other.string64);
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/String64.java
+++ b/src/main/java/org/stellar/sdk/xdr/String64.java
@@ -29,7 +29,7 @@ public class String64 implements XdrElement {
   }
   public static String64 decode(XdrDataInputStream stream) throws IOException {
     String64 decodedString64 = new String64();
-  decodedString64.string64 = XdrString.decode(stream);
+  decodedString64.string64 = XdrString.decode(stream, 64);
     return decodedString64;
   }
   @Override

--- a/src/main/java/org/stellar/sdk/xdr/String64.java
+++ b/src/main/java/org/stellar/sdk/xdr/String64.java
@@ -6,7 +6,7 @@ package org.stellar.sdk.xdr;
 
 import java.io.IOException;
 
-import java.util.Arrays;
+import com.google.common.base.Objects;
 
 // === xdr source ============================================================
 
@@ -14,31 +14,27 @@ import java.util.Arrays;
 
 //  ===========================================================================
 public class String64 implements XdrElement {
-  private byte[] string64;
-  public byte[] getString64() {
+  private XdrString string64;
+  public XdrString getString64() {
     return this.string64;
   }
-  public void setString64(byte[] value) {
+  public void setString64(XdrString value) {
     this.string64 = value;
   }
   public static void encode(XdrDataOutputStream stream, String64  encodedString64) throws IOException {
-  int string64size = encodedString64.string64.length;
-  stream.writeInt(string64size);
-  stream.write(encodedString64.getString64(), 0, string64size);
+  encodedString64.string64.encode(stream);
   }
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static String64 decode(XdrDataInputStream stream) throws IOException {
     String64 decodedString64 = new String64();
-  int string64size = stream.readInt();
-  decodedString64.string64 = new byte[string64size];
-  stream.read(decodedString64.string64, 0, string64size);
+  decodedString64.string64 = XdrString.decode(stream);
     return decodedString64;
   }
   @Override
   public int hashCode() {
-    return Arrays.hashCode(this.string64);
+    return Objects.hashCode(this.string64);
   }
   @Override
   public boolean equals(Object object) {
@@ -47,6 +43,6 @@ public class String64 implements XdrElement {
     }
 
     String64 other = (String64) object;
-    return Arrays.equals(this.string64, other.string64);
+    return Objects.equal(this.string64, other.string64);
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/XdrDataInputStream.java
+++ b/src/main/java/org/stellar/sdk/xdr/XdrDataInputStream.java
@@ -21,13 +21,6 @@ public class XdrDataInputStream extends DataInputStream {
         mIn = (XdrInputStream) super.in;
     }
 
-    public String readString() throws IOException {
-        int l = readInt();
-        byte[] bytes = new byte[l];
-        read(bytes);
-        return new String(bytes, Charset.forName("UTF-8"));
-    }
-
     public int[] readIntArray() throws IOException {
         int l = readInt();
         return readIntArray(l);

--- a/src/main/java/org/stellar/sdk/xdr/XdrDataOutputStream.java
+++ b/src/main/java/org/stellar/sdk/xdr/XdrDataOutputStream.java
@@ -14,12 +14,6 @@ public class XdrDataOutputStream extends DataOutputStream {
         mOut = (XdrOutputStream) super.out;
     }
 
-    public void writeString(String s) throws IOException {
-        byte[] chars = s.getBytes(Charset.forName("UTF-8"));
-        writeInt(chars.length);
-        write(chars);
-    }
-
     public void writeIntArray(int[] a) throws IOException {
         writeInt(a.length);
         writeIntArray(a, a.length);

--- a/src/main/java/org/stellar/sdk/xdr/XdrString.java
+++ b/src/main/java/org/stellar/sdk/xdr/XdrString.java
@@ -1,0 +1,57 @@
+package org.stellar.sdk.xdr;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+public class XdrString implements XdrElement {
+    private byte[] bytes;
+    private String text;
+
+    public XdrString(byte[] bytes) {
+        this.bytes = bytes;
+        this.text = new String(bytes, Charset.forName("UTF-8"));
+    }
+
+    public XdrString(String text) {
+        this.bytes = text.getBytes(Charset.forName("UTF-8"));
+        this.text = text;
+    }
+
+    @Override
+    public void encode(XdrDataOutputStream stream) throws IOException {
+        stream.writeInt(this.bytes.length);
+        stream.write(this.bytes, 0, this.bytes.length);
+    }
+
+    public static XdrString decode(XdrDataInputStream stream) throws IOException {
+        int size = stream.readInt();
+        byte[] bytes = new byte[size];
+        stream.read(bytes);
+        return new XdrString(bytes);
+    }
+
+    public byte[] getBytes() {
+        return this.bytes;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(this.bytes);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object == null || !(object instanceof XdrString)) {
+          return false;
+        }
+
+        XdrString other = (XdrString) object;
+        return Arrays.equals(this.bytes, other.bytes);
+    }
+
+    @Override
+    public String toString() {
+        return this.text;
+    }
+}

--- a/src/main/java/org/stellar/sdk/xdr/XdrString.java
+++ b/src/main/java/org/stellar/sdk/xdr/XdrString.java
@@ -1,21 +1,19 @@
 package org.stellar.sdk.xdr;
 
 import java.io.IOException;
+import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
-    private String text;
 
     public XdrString(byte[] bytes) {
         this.bytes = bytes;
-        this.text = new String(bytes, Charset.forName("UTF-8"));
     }
 
     public XdrString(String text) {
         this.bytes = text.getBytes(Charset.forName("UTF-8"));
-        this.text = text;
     }
 
     @Override
@@ -24,8 +22,11 @@ public class XdrString implements XdrElement {
         stream.write(this.bytes, 0, this.bytes.length);
     }
 
-    public static XdrString decode(XdrDataInputStream stream) throws IOException {
+    public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
         int size = stream.readInt();
+        if (size > maxSize) {
+            throw new InvalidClassException("String length "+size+" exceeds max size "+maxSize);
+        }
         byte[] bytes = new byte[size];
         stream.read(bytes);
         return new XdrString(bytes);
@@ -52,6 +53,6 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toString() {
-        return this.text;
+        return new String(bytes, Charset.forName("UTF-8"));
     }
 }

--- a/src/test/java/org/stellar/sdk/XdrDataStreamTest.java
+++ b/src/test/java/org/stellar/sdk/XdrDataStreamTest.java
@@ -1,12 +1,13 @@
 
-package org.stellar.sdk.xdr;
+package org.stellar.sdk;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
+import org.stellar.sdk.xdr.XdrDataInputStream;
+import org.stellar.sdk.xdr.XdrDataOutputStream;
 
 
 public class XdrDataStreamTest {
@@ -16,15 +17,17 @@ public class XdrDataStreamTest {
         //String to XDR
         ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
         XdrDataOutputStream xdrOutputStream = new XdrDataOutputStream(byteOutputStream);
-        xdrOutputStream.writeString(inputString);
+
+        org.stellar.sdk.xdr.Memo xdrMemo = Memo.text(inputString).toXdr();
+        xdrMemo.encode(xdrOutputStream);
 
         byte[] xdrByteOutput = byteOutputStream.toByteArray();
 
         //XDR back to String
         XdrDataInputStream xdrInputStream = new XdrDataInputStream(new ByteArrayInputStream(xdrByteOutput));
-        String outputString = xdrInputStream.readString();
+        xdrMemo = org.stellar.sdk.xdr.Memo.decode(xdrInputStream);
 
-        return outputString;
+        return Memo.text(xdrMemo.getText()).getText();
 
     }
 
@@ -43,7 +46,7 @@ public class XdrDataStreamTest {
     
      @Test
     public void backAndForthXdrStreamingWithAllNonStandardAscii() throws IOException {
-        String memo = "øûý™€♠♣♥†‡µ¢£€";
+        String memo = "øûý™€♠♣♥†‡";
         assertEquals(memo, backAndForthXdrStreaming(memo));
     }
 }

--- a/src/test/java/org/stellar/sdk/XdrDataStreamTest.java
+++ b/src/test/java/org/stellar/sdk/XdrDataStreamTest.java
@@ -27,8 +27,7 @@ public class XdrDataStreamTest {
         XdrDataInputStream xdrInputStream = new XdrDataInputStream(new ByteArrayInputStream(xdrByteOutput));
         xdrMemo = org.stellar.sdk.xdr.Memo.decode(xdrInputStream);
 
-        return Memo.text(xdrMemo.getText()).getText();
-
+        return xdrMemo.getText().toString();
     }
 
     @Test

--- a/src/test/java/org/stellar/sdk/xdr/TransactionDecodeTest.java
+++ b/src/test/java/org/stellar/sdk/xdr/TransactionDecodeTest.java
@@ -73,7 +73,6 @@ public class TransactionDecodeTest {
 
         transactionEnvelope.encode(new XdrDataOutputStream(byteOutputStream));
         String serialized = base64Encoding.encode(byteOutputStream.toByteArray());
-        // fails here
         assertEquals(serialized, txBody);
     }
 

--- a/src/test/java/org/stellar/sdk/xdr/TransactionDecodeTest.java
+++ b/src/test/java/org/stellar/sdk/xdr/TransactionDecodeTest.java
@@ -2,8 +2,6 @@ package org.stellar.sdk.xdr;
 
 import com.google.common.io.BaseEncoding;
 import org.junit.Test;
-import org.stellar.sdk.Memo;
-import org.stellar.sdk.MemoText;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/org/stellar/sdk/xdr/TransactionDecodeTest.java
+++ b/src/test/java/org/stellar/sdk/xdr/TransactionDecodeTest.java
@@ -2,8 +2,11 @@ package org.stellar.sdk.xdr;
 
 import com.google.common.io.BaseEncoding;
 import org.junit.Test;
+import org.stellar.sdk.Memo;
+import org.stellar.sdk.MemoText;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
@@ -57,6 +60,21 @@ public class TransactionDecodeTest {
         TransactionEnvelope transactionEnvelope = TransactionEnvelope.decode(new XdrDataInputStream(new ByteArrayInputStream(bytes)));
         assertEquals(1, transactionEnvelope.getTx().getOperations().length);
         assertTrue(Arrays.equals(new byte[]{'G', 'O', 'L', 'D'}, transactionEnvelope.getTx().getOperations()[0].getBody().getPaymentOp().getAsset().getAlphaNum4().getAssetCode().getAssetCode4()));
+    }
+
+    @Test
+    public void testRoundtrip() throws IOException {
+        String txBody = "AAAAAM6jLgjKjuXxWkir4M7v0NqoOfODXcFnn6AGlP+d4RxAAAAAZAAIiE4AAAABAAAAAAAAAAEAAAAcyKMl+WDSzuttWkF2DvzKAkkEqeSZ4cZihjGJEAAAAAEAAAAAAAAAAQAAAAAgECmBaDwiRPE1z2vAE36J+45toU/ZxdvpR38tc0HvmgAAAAAAAAAAAJiWgAAAAAAAAAABneEcQAAAAECeXDKebJoAbST1T2AbDBui9K0TbSM8sfbhXUAZ2ROAoCRs5cG1pRvY+ityyPWFEKPd7+3qEupavkAZ/+L7/28G";
+        BaseEncoding base64Encoding = BaseEncoding.base64();
+        byte[] bytes = base64Encoding.decode(txBody);
+
+        TransactionEnvelope transactionEnvelope = TransactionEnvelope.decode(new XdrDataInputStream(new ByteArrayInputStream(bytes)));
+        ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+
+        transactionEnvelope.encode(new XdrDataOutputStream(byteOutputStream));
+        String serialized = base64Encoding.encode(byteOutputStream.toByteArray());
+        // fails here
+        assertEquals(serialized, txBody);
     }
 
 }

--- a/xdr/Stellar-transaction.x
+++ b/xdr/Stellar-transaction.x
@@ -335,7 +335,7 @@ union Memo switch (MemoType type)
 case MEMO_NONE:
     void;
 case MEMO_TEXT:
-    string text<28>;
+    opaque text<28>;
 case MEMO_ID:
     uint64 id;
 case MEMO_HASH:

--- a/xdr/Stellar-transaction.x
+++ b/xdr/Stellar-transaction.x
@@ -335,7 +335,7 @@ union Memo switch (MemoType type)
 case MEMO_NONE:
     void;
 case MEMO_TEXT:
-    opaque text<28>;
+    string text<28>;
 case MEMO_ID:
     uint64 id;
 case MEMO_HASH:


### PR DESCRIPTION
Fixes https://github.com/stellar/java-stellar-sdk/issues/257

The Java SDK assumes that all memo texts must be valid UTF 8 strings. However, that assumption is not valid. It turns out that any sequence of bytes is allowed to appear in the memo field (see https://github.com/stellar/go/issues/2022 ).

Therefore, the correct representation for the memo field is a byte array.