### PR TITLE
Update FeeStatsResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
+## 0.13.0
+
+* Horizon v0.24.0 added a `fee_charged` and `max_fee` object with information about max bid and actual fee paid for each transaction.
+* We are removing ``*_all_accepted_fee` fields in favor of the new keys, making it easier for people to understand the meaning the fields.
+
 ## 0.12.0
 
 * Represent memo text contents as bytes because a memo text may not be valid UTF-8 string (https://github.com/stellar/java-stellar-sdk/issues/257).

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'com.github.ben-manes.versions' // gradle dependencyUpdates -Drevi
 apply plugin: 'project-report' // gradle htmlDependencyReport
 
 sourceCompatibility = 1.6
-version = '0.12.0'
+version = '0.13.0'
 group = 'stellar'
 
 jar {

--- a/src/main/java/org/stellar/sdk/responses/FeeDistribution.java
+++ b/src/main/java/org/stellar/sdk/responses/FeeDistribution.java
@@ -1,0 +1,107 @@
+package org.stellar.sdk.responses;
+
+import com.google.gson.annotations.SerializedName;
+
+public class FeeDistribution {
+  @SerializedName("min")
+  private final Long min;
+  @SerializedName("max")
+  private final Long max;
+  @SerializedName("mode")
+  private final Long mode;
+  @SerializedName("p10")
+  private final Long p10;
+  @SerializedName("p20")
+  private final Long p20;
+  @SerializedName("p30")
+  private final Long p30;
+  @SerializedName("p40")
+  private final Long p40;
+  @SerializedName("p50")
+  private final Long p50;
+  @SerializedName("p60")
+  private final Long p60;
+  @SerializedName("p70")
+  private final Long p70;
+  @SerializedName("p80")
+  private final Long p80;
+  @SerializedName("p90")
+  private final Long p90;
+  @SerializedName("p95")
+  private final Long p95;
+  @SerializedName("p99")
+  private final Long p99;
+
+  public FeeDistribution(Long min, Long max, Long mode, Long p10, Long p20, Long p30, Long p40, Long p50, Long p60, Long p70, Long p80, Long p90, Long p95, Long p99) {
+    this.min = min;
+    this.max = max;
+    this.mode = mode;
+    this.p10 = p10;
+    this.p20 = p20;
+    this.p30 = p30;
+    this.p40 = p40;
+    this.p50 = p50;
+    this.p60 = p60;
+    this.p70 = p70;
+    this.p80 = p80;
+    this.p90 = p90;
+    this.p95 = p95;
+    this.p99 = p99;
+  }
+
+  public Long getMin() {
+    return min;
+  }
+
+  public Long getMax() {
+    return max;
+  }
+
+  public Long getMode() {
+    return mode;
+  }
+
+  public Long getP10() {
+    return p10;
+  }
+
+  public Long getP20() {
+    return p20;
+  }
+
+  public Long getP30() {
+    return p30;
+  }
+
+  public Long getP40() {
+    return p40;
+  }
+
+  public Long getP50() {
+    return p50;
+  }
+
+  public Long getP60() {
+    return p60;
+  }
+
+  public Long getP70() {
+    return p70;
+  }
+
+  public Long getP80() {
+    return p80;
+  }
+
+  public Long getP90() {
+    return p90;
+  }
+
+  public Long getP95() {
+    return p95;
+  }
+
+  public Long getP99() {
+    return p99;
+  }
+}

--- a/src/main/java/org/stellar/sdk/responses/FeeStatsResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/FeeStatsResponse.java
@@ -3,108 +3,23 @@ package org.stellar.sdk.responses;
 import com.google.gson.annotations.SerializedName;
 
 public class FeeStatsResponse extends Response {
-    @SerializedName("min_accepted_fee")
-    private final Long min;
-    @SerializedName("mode_accepted_fee")
-    private final Long mode;
-    @SerializedName("p10_accepted_fee")
-    private final Long p10;
-    @SerializedName("p20_accepted_fee")
-    private final Long p20;
-    @SerializedName("p30_accepted_fee")
-    private final Long p30;
-    @SerializedName("p40_accepted_fee")
-    private final Long p40;
-    @SerializedName("p50_accepted_fee")
-    private final Long p50;
-    @SerializedName("p60_accepted_fee")
-    private final Long p60;
-    @SerializedName("p70_accepted_fee")
-    private final Long p70;
-    @SerializedName("p80_accepted_fee")
-    private final Long p80;
-    @SerializedName("p90_accepted_fee")
-    private final Long p90;
-    @SerializedName("p95_accepted_fee")
-    private final Long p95;
-    @SerializedName("p99_accepted_fee")
-    private final Long p99;
     @SerializedName("ledger_capacity_usage")
     private final Float ledgerCapacityUsage;
     @SerializedName("last_ledger_base_fee")
     private final Long lastLedgerBaseFee;
     @SerializedName("last_ledger")
     private final Long lastLedger;
+    @SerializedName("fee_charged")
+    private final FeeDistribution feeCharged;
+    @SerializedName("max_fee")
+    private final FeeDistribution maxFee;
 
-    public FeeStatsResponse(Long min, Long mode, Long p10, Long p20, Long p30, Long p40, Long p50, Long p60, Long p70, Long p80, Long p90, Long p95, Long p99, Float ledgerCapacityUsage, Long lastLedgerBaseFee, Long lastLedger) {
-        this.min = min;
-        this.mode = mode;
-        this.p10 = p10;
-        this.p20 = p20;
-        this.p30 = p30;
-        this.p40 = p40;
-        this.p50 = p50;
-        this.p60 = p60;
-        this.p70 = p70;
-        this.p80 = p80;
-        this.p90 = p90;
-        this.p95 = p95;
-        this.p99 = p99;
+    public FeeStatsResponse(Float ledgerCapacityUsage, Long lastLedgerBaseFee, Long lastLedger, FeeDistribution feeCharged, FeeDistribution maxFee) {
         this.ledgerCapacityUsage = ledgerCapacityUsage;
         this.lastLedgerBaseFee = lastLedgerBaseFee;
         this.lastLedger = lastLedger;
-    }
-
-    public Long getMin() {
-        return min;
-    }
-
-    public Long getMode() {
-        return mode;
-    }
-
-    public Long getP10() {
-        return p10;
-    }
-
-    public Long getP20() {
-        return p20;
-    }
-
-    public Long getP30() {
-        return p30;
-    }
-
-    public Long getP40() {
-        return p40;
-    }
-
-    public Long getP50() {
-        return p50;
-    }
-
-    public Long getP60() {
-        return p60;
-    }
-
-    public Long getP70() {
-        return p70;
-    }
-
-    public Long getP80() {
-        return p80;
-    }
-
-    public Long getP90() {
-        return p90;
-    }
-
-    public Long getP95() {
-        return p95;
-    }
-
-    public Long getP99() {
-        return p99;
+        this.feeCharged = feeCharged;
+        this.maxFee = maxFee;
     }
 
     public Float getLedgerCapacityUsage() {
@@ -119,4 +34,11 @@ public class FeeStatsResponse extends Response {
         return lastLedger;
     }
 
+    public FeeDistribution getFeeCharged() {
+        return feeCharged;
+    }
+
+    public FeeDistribution getMaxFee() {
+        return maxFee;
+    }
 }

--- a/src/test/java/org/stellar/sdk/responses/FeeStatsDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/FeeStatsDeserializerTest.java
@@ -7,40 +7,78 @@ public class FeeStatsDeserializerTest extends TestCase {
     @Test
     public void testDeserialize() {
         String json = "{\n" +
-                "  \"last_ledger\": \"20882791\",\n" +
-                "  \"last_ledger_base_fee\": \"100\",\n" +
-                "  \"ledger_capacity_usage\": \"0.97\"," +
-                "  \"min_accepted_fee\": \"101\",\n" +
-                "  \"mode_accepted_fee\": \"102\",\n" +
-                "  \"p10_accepted_fee\": \"103\",\n" +
-                "  \"p20_accepted_fee\": \"104\",\n" +
-                "  \"p30_accepted_fee\": \"105\",\n" +
-                "  \"p40_accepted_fee\": \"106\",\n" +
-                "  \"p50_accepted_fee\": \"107\",\n" +
-                "  \"p60_accepted_fee\": \"108\",\n" +
-                "  \"p70_accepted_fee\": \"109\",\n" +
-                "  \"p80_accepted_fee\": \"110\",\n" +
-                "  \"p90_accepted_fee\": \"111\",\n" +
-                "  \"p95_accepted_fee\": \"112\",\n" +
-                "  \"p99_accepted_fee\": \"113\"" +
-                "}";
+            "  \"last_ledger\": \"22606298\",\n" +
+            "  \"last_ledger_base_fee\": \"100\",\n" +
+            "  \"ledger_capacity_usage\": \"0.97\",\n" +
+            "  \"max_fee\": {\n" +
+            "    \"min\": \"130\",\n" +
+            "    \"max\": \"8000\",\n" +
+            "    \"mode\": \"250\",\n" +
+            "    \"p10\": \"150\",\n" +
+            "    \"p20\": \"200\",\n" +
+            "    \"p30\": \"300\",\n" +
+            "    \"p40\": \"400\",\n" +
+            "    \"p50\": \"500\",\n" +
+            "    \"p60\": \"1000\",\n" +
+            "    \"p70\": \"2000\",\n" +
+            "    \"p80\": \"3000\",\n" +
+            "    \"p90\": \"4000\",\n" +
+            "    \"p95\": \"5000\",\n" +
+            "    \"p99\": \"8000\"\n" +
+            "  },\n" +
+            "  \"fee_charged\": {\n" +
+            "    \"min\": \"100\",\n" +
+            "    \"max\": \"102\",\n" +
+            "    \"mode\": \"101\",\n" +
+            "    \"p10\": \"103\",\n" +
+            "    \"p20\": \"104\",\n" +
+            "    \"p30\": \"105\",\n" +
+            "    \"p40\": \"106\",\n" +
+            "    \"p50\": \"107\",\n" +
+            "    \"p60\": \"108\",\n" +
+            "    \"p70\": \"109\",\n" +
+            "    \"p80\": \"110\",\n" +
+            "    \"p90\": \"111\",\n" +
+            "    \"p95\": \"112\",\n" +
+            "    \"p99\": \"113\"\n" +
+            "  }\n" +
+            "}";
 
         FeeStatsResponse stats = GsonSingleton.getInstance().fromJson(json, FeeStatsResponse.class);
-        assertEquals(new Long(20882791), stats.getLastLedger());
+        assertEquals(new Long(22606298), stats.getLastLedger());
         assertEquals(new Long(100), stats.getLastLedgerBaseFee());
         assertEquals(new Float(0.97), stats.getLedgerCapacityUsage());
-        assertEquals(new Long(101), stats.getMin());
-        assertEquals(new Long(102), stats.getMode());
-        assertEquals(new Long(103), stats.getP10());
-        assertEquals(new Long(104), stats.getP20());
-        assertEquals(new Long(105), stats.getP30());
-        assertEquals(new Long(106), stats.getP40());
-        assertEquals(new Long(107), stats.getP50());
-        assertEquals(new Long(108), stats.getP60());
-        assertEquals(new Long(109), stats.getP70());
-        assertEquals(new Long(110), stats.getP80());
-        assertEquals(new Long(111), stats.getP90());
-        assertEquals(new Long(112), stats.getP95());
-        assertEquals(new Long(113), stats.getP99());
+
+        FeeDistribution maxFee = stats.getMaxFee();
+        assertEquals(new Long(130), maxFee.getMin());
+        assertEquals(new Long(8000), maxFee.getMax());
+        assertEquals(new Long(250), maxFee.getMode());
+        assertEquals(new Long(150), maxFee.getP10());
+        assertEquals(new Long(200), maxFee.getP20());
+        assertEquals(new Long(300), maxFee.getP30());
+        assertEquals(new Long(400), maxFee.getP40());
+        assertEquals(new Long(500), maxFee.getP50());
+        assertEquals(new Long(1000), maxFee.getP60());
+        assertEquals(new Long(2000), maxFee.getP70());
+        assertEquals(new Long(3000), maxFee.getP80());
+        assertEquals(new Long(4000), maxFee.getP90());
+        assertEquals(new Long(5000), maxFee.getP95());
+        assertEquals(new Long(8000), maxFee.getP99());
+
+        FeeDistribution feeCharged = stats.getFeeCharged();
+        assertEquals(new Long(100), feeCharged.getMin());
+        assertEquals(new Long(102), feeCharged.getMax());
+        assertEquals(new Long(101), feeCharged.getMode());
+        assertEquals(new Long(103), feeCharged.getP10());
+        assertEquals(new Long(104), feeCharged.getP20());
+        assertEquals(new Long(105), feeCharged.getP30());
+        assertEquals(new Long(106), feeCharged.getP40());
+        assertEquals(new Long(107), feeCharged.getP50());
+        assertEquals(new Long(108), feeCharged.getP60());
+        assertEquals(new Long(109), feeCharged.getP70());
+        assertEquals(new Long(110), feeCharged.getP80());
+        assertEquals(new Long(111), feeCharged.getP90());
+        assertEquals(new Long(112), feeCharged.getP95());
+        assertEquals(new Long(113), feeCharged.getP99());
     }
 }


### PR DESCRIPTION
* Horizon v0.24.0 added a `fee_charged` and `max_fee` object with information about max bid and actual fee paid for each transaction.
* We are removing ``*_all_accepted_fee` fields in favor of the new keys, making it easier for people to understand the meaning the fields.

addresses stellar/go#2014