### PR TITLE
Add support for CAP 18 trustline flags in effects and account response

### DIFF
--- a/src/main/java/org/stellar/sdk/responses/AccountResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/AccountResponse.java
@@ -193,10 +193,12 @@ public class AccountResponse extends Response implements org.stellar.sdk.Transac
     private final String sellingLiabilities;
     @SerializedName("is_authorized")
     private final Boolean isAuthorized;
+    @SerializedName("is_authorized_to_maintain_liabilities")
+    private final Boolean isAuthorizedToMaintainLiabilities;
     @SerializedName("last_modified_ledger")
     private final Integer lastModifiedLedger;
 
-    Balance(String assetType, String assetCode, String assetIssuer, String balance, String limit, String buyingLiabilities, String sellingLiabilities, Boolean isAuthorized, Integer lastModifiedLedger) {
+    Balance(String assetType, String assetCode, String assetIssuer, String balance, String limit, String buyingLiabilities, String sellingLiabilities, Boolean isAuthorized, Boolean isAuthorizedToMaintainLiabilities, Integer lastModifiedLedger) {
       this.assetType = checkNotNull(assetType, "assertType cannot be null");
       this.balance = checkNotNull(balance, "balance cannot be null");
       this.limit = limit;
@@ -205,6 +207,7 @@ public class AccountResponse extends Response implements org.stellar.sdk.Transac
       this.buyingLiabilities = checkNotNull(buyingLiabilities, "buyingLiabilities cannot be null");
       this.sellingLiabilities = checkNotNull(sellingLiabilities, "sellingLiabilities cannot be null");
       this.isAuthorized = isAuthorized;
+      this.isAuthorizedToMaintainLiabilities = isAuthorizedToMaintainLiabilities;
       this.lastModifiedLedger = lastModifiedLedger;
     }
 
@@ -246,6 +249,10 @@ public class AccountResponse extends Response implements org.stellar.sdk.Transac
 
     public Boolean getAuthorized() {
       return isAuthorized;
+    }
+
+    public Boolean getAuthorizedToMaintainLiabilities() {
+      return isAuthorizedToMaintainLiabilities;
     }
 
     public Integer getLastModifiedLedger() {

--- a/src/main/java/org/stellar/sdk/responses/EffectDeserializer.java
+++ b/src/main/java/org/stellar/sdk/responses/EffectDeserializer.java
@@ -55,6 +55,8 @@ class EffectDeserializer implements JsonDeserializer<EffectResponse> {
         return gson.fromJson(json, TrustlineAuthorizedEffectResponse.class);
       case 24:
         return gson.fromJson(json, TrustlineDeauthorizedEffectResponse.class);
+      case 25:
+        return gson.fromJson(json, TrustlineAuthorizedToMaintainLiabilitiesEffectResponse.class);
       // Trading effects
       case 30:
         return gson.fromJson(json, OfferCreatedEffectResponse.class);

--- a/src/main/java/org/stellar/sdk/responses/effects/EffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/EffectResponse.java
@@ -52,6 +52,7 @@ public abstract class EffectResponse extends Response implements Pageable {
    *   <li>trustline_removed</li>
    *   <li>trustline_updated</li>
    *   <li>trustline_authorized</li>
+   *   <li>trustline_authorized_to_maintain_liabilities</li>
    *   <li>trustline_deauthorized</li>
    *   <li>offer_created</li>
    *   <li>offer_removed</li>

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineAuthorizedToMaintainLiabilitiesEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineAuthorizedToMaintainLiabilitiesEffectResponse.java
@@ -1,0 +1,13 @@
+package org.stellar.sdk.responses.effects;
+
+/**
+ * Represents trustline_authorized_to_maintain_liabilities effect response.
+ * @see <a href="https://www.stellar.org/developers/horizon/reference/resources/effect.html" target="_blank">Effect documentation</a>
+ * @see org.stellar.sdk.requests.EffectsRequestBuilder
+ * @see org.stellar.sdk.Server#effects()
+ */
+public class TrustlineAuthorizedToMaintainLiabilitiesEffectResponse extends TrustlineAuthorizationResponse {
+  TrustlineAuthorizedToMaintainLiabilitiesEffectResponse(String trustor, String assetType, String assetCode) {
+    super(trustor, assetType, assetCode);
+  }
+}

--- a/src/test/java/org/stellar/sdk/responses/AccountDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/AccountDeserializerTest.java
@@ -8,6 +8,27 @@ import java.util.Arrays;
 
 public class AccountDeserializerTest extends TestCase {
   @Test
+  public void testDeserializeBalanceAuth() {
+    AccountResponse account = GsonSingleton.getInstance().fromJson(jsonAuthorizedToMaintainLiabilities, AccountResponse.class);
+
+    assertEquals(account.getBalances()[0].getAssetType(), "credit_alphanum4");
+    assertEquals(account.getBalances()[0].getAssetCode(), "ABC");
+    assertEquals(account.getBalances()[0].getAssetIssuer(), "GCRA6COW27CY5MTKIA7POQ2326C5ABYCXODBN4TFF5VL4FMBRHOT3YHU");
+    assertEquals(account.getBalances()[0].getBalance(), "1001.0000000");
+    assertEquals(account.getBalances()[0].getLimit(), "12000.4775807");
+    assertEquals(account.getBalances()[0].getBuyingLiabilities(), "100.1234567");
+    assertEquals(account.getBalances()[0].getSellingLiabilities(), "100.7654321");
+    assertEquals(account.getBalances()[0].getAuthorized(), Boolean.FALSE);
+    assertEquals(account.getBalances()[0].getAuthorizedToMaintainLiabilities(), Boolean.TRUE);
+
+    assertEquals(account.getBalances()[1].getAssetType(), "native");
+    assertEquals(account.getBalances()[1].getBalance(), "20.0000300");
+    assertEquals(account.getBalances()[1].getBuyingLiabilities(), "5.1234567");
+    assertEquals(account.getBalances()[1].getSellingLiabilities(), "1.7654321");
+    assertEquals(account.getBalances()[1].getLimit(), null);
+  }
+
+  @Test
   public void testDeserialize() {
     AccountResponse account = GsonSingleton.getInstance().fromJson(json, AccountResponse.class);
       assertEquals(account.getAccountId(), "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7");
@@ -76,6 +97,84 @@ public class AccountDeserializerTest extends TestCase {
     assertEquals(account.getBalances()[1].getSellingLiabilities(), null);
     assertEquals(account.getBalances()[1].getLimit(), null);
   }
+
+  String jsonAuthorizedToMaintainLiabilities = "{\n" +
+      "  \"_links\": {\n" +
+      "    \"effects\": {\n" +
+      "      \"href\": \"/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7/effects{?cursor,limit,order}\",\n" +
+      "      \"templated\": true\n" +
+      "    },\n" +
+      "    \"offers\": {\n" +
+      "      \"href\": \"/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7/offers{?cursor,limit,order}\",\n" +
+      "      \"templated\": true\n" +
+      "    },\n" +
+      "    \"operations\": {\n" +
+      "      \"href\": \"/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7/operations{?cursor,limit,order}\",\n" +
+      "      \"templated\": true\n" +
+      "    },\n" +
+      "    \"self\": {\n" +
+      "      \"href\": \"/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7\"\n" +
+      "    },\n" +
+      "    \"transactions\": {\n" +
+      "      \"href\": \"/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7/transactions{?cursor,limit,order}\",\n" +
+      "      \"templated\": true\n" +
+      "    }\n" +
+      "  },"+
+      "  \"id\": \"GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7\",\n" +
+      "  \"paging_token\": \"1\",\n" +
+      "  \"account_id\": \"GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7\",\n" +
+      "  \"sequence\": 2319149195853854,\n" +
+      "  \"subentry_count\": 0,\n" +
+      "  \"inflation_destination\": \"GAGRSA6QNQJN2OQYCBNQGMFLO4QLZFNEHIFXOMTQVSUTWVTWT66TOFSC\",\n" +
+      "  \"home_domain\": \"stellar.org\",\n" +
+      "  \"thresholds\": {\n" +
+      "    \"low_threshold\": 10,\n" +
+      "    \"med_threshold\": 20,\n" +
+      "    \"high_threshold\": 30\n" +
+      "  },\n" +
+      "  \"flags\": {\n" +
+      "    \"auth_required\": false,\n" +
+      "    \"auth_revocable\": true,\n" +
+      "    \"auth_immutable\": true\n" +
+      "  },\n" +
+      "  \"balances\": [\n" +
+      "    {\n" +
+      "      \"balance\": \"1001.0000000\",\n" +
+      "      \"buying_liabilities\": \"100.1234567\",\n" +
+      "      \"selling_liabilities\": \"100.7654321\",\n" +
+      "      \"limit\": \"12000.4775807\",\n" +
+      "      \"asset_type\": \"credit_alphanum4\",\n" +
+      "      \"asset_code\": \"ABC\",\n" +
+      "      \"asset_issuer\": \"GCRA6COW27CY5MTKIA7POQ2326C5ABYCXODBN4TFF5VL4FMBRHOT3YHU\",\n" +
+      "      \"is_authorized\": false,\n" +
+      "      \"is_authorized_to_maintain_liabilities\": true\n" +
+      "    },"+
+      "    {\n" +
+      "      \"asset_type\": \"native\",\n" +
+      "      \"balance\": \"20.0000300\",\n" +
+      "      \"buying_liabilities\": \"5.1234567\",\n" +
+      "      \"selling_liabilities\": \"1.7654321\"\n" +
+      "    }\n" +
+      "  ],\n" +
+      "  \"signers\": [\n" +
+      "    {\n" +
+      "      \"public_key\": \"GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7\",\n" +
+      "      \"key\": \"GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7\",\n" +
+      "      \"weight\": 0,\n" +
+      "      \"type\": \"ed25519_public_key\"\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"public_key\": \"GCR2KBCIU6KQXSQY5F5GZYC4WLNHCHCKW4NEGXNEZRYWLTNZIRJJY7D2\",\n" +
+      "      \"key\": \"GCR2KBCIU6KQXSQY5F5GZYC4WLNHCHCKW4NEGXNEZRYWLTNZIRJJY7D2\",\n" +
+      "      \"weight\": 1,\n" +
+      "      \"type\": \"ed25519_public_key\"\n" +
+      "    }\n" +
+      "  ],\n" +
+      "  \"data\": {\n" +
+      "    \"entry1\": \"dGVzdA==\",\n" +
+      "    \"entry2\": \"dGVzdDI=\"\n" +
+      "  }" +
+      "}";
 
   String json = "{\n" +
           "  \"_links\": {\n" +

--- a/src/test/java/org/stellar/sdk/responses/EffectDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/EffectDeserializerTest.java
@@ -517,6 +517,43 @@ public class EffectDeserializerTest extends TestCase {
   }
 
   @Test
+  public void testDeserializeTrustlineAuthorizedToMaintainLiabilitiesEffect() {
+    String json = "{\n" +
+        "        \"_links\": {\n" +
+        "          \"operation\": {\n" +
+        "            \"href\": \"http://horizon-testnet.stellar.org/operations/33788507721730\"\n" +
+        "          },\n" +
+        "          \"succeeds\": {\n" +
+        "            \"href\": \"http://horizon-testnet.stellar.org/effects?order=desc\\u0026cursor=33788507721730-2\"\n" +
+        "          },\n" +
+        "          \"precedes\": {\n" +
+        "            \"href\": \"http://horizon-testnet.stellar.org/effects?order=asc\\u0026cursor=33788507721730-2\"\n" +
+        "          }\n" +
+        "        },\n" +
+        "        \"id\": \"0000033788507721730-0000000002\",\n" +
+        "        \"paging_token\": \"33788507721730-2\",\n" +
+        "        \"account\": \"GA6U5X6WOPNKKDKQULBR7IDHDBAQKOWPHYEC7WSXHZBFEYFD3XVZAKOO\",\n" +
+        "        \"type\": \"trustline_authorized_to_maintain_liabilities\",\n" +
+        "        \"type_i\": 25,\n" +
+        "        \"asset_type\": \"credit_alphanum12\",\n" +
+        "        \"asset_code\": \"TESTTEST\",\n" +
+        "        \"trustor\": \"GB3E4AB4VWXJDUVN4Z3CPBU5HTMWVEQXONZYVDFMHQD6333KHCOL3UBR\"\n" +
+        "      }";
+
+    TrustlineAuthorizedToMaintainLiabilitiesEffectResponse effect = (TrustlineAuthorizedToMaintainLiabilitiesEffectResponse) GsonSingleton.getInstance().fromJson(json, EffectResponse.class);
+
+    assertEquals(effect.getAccount(), "GA6U5X6WOPNKKDKQULBR7IDHDBAQKOWPHYEC7WSXHZBFEYFD3XVZAKOO");
+    assertEquals(effect.getAssetType(), "credit_alphanum12");
+    assertEquals(effect.getAssetCode(), "TESTTEST");
+    assertEquals(effect.getTrustor(), "GB3E4AB4VWXJDUVN4Z3CPBU5HTMWVEQXONZYVDFMHQD6333KHCOL3UBR");
+
+    assertEquals(effect.getLinks().getOperation().getHref(), "http://horizon-testnet.stellar.org/operations/33788507721730");
+    assertEquals(effect.getLinks().getSucceeds().getHref(), "http://horizon-testnet.stellar.org/effects?order=desc&cursor=33788507721730-2");
+    assertEquals(effect.getLinks().getPrecedes().getHref(), "http://horizon-testnet.stellar.org/effects?order=asc&cursor=33788507721730-2");
+  }
+
+
+  @Test
   public void testDeserializeTrustlineDeauthorizedEffect() {
     String json = "{\n" +
             "        \"_links\": {\n" +


### PR DESCRIPTION
The upcoming `stellar-core` [protocol 13 release](https://github.com/stellar/stellar-core/projects/18) will add support for [CAP 18](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0018.md) ("Fine-Grained Control of Authorization").

Horizon has added a `is_authorized_to_maintain_liabilities` field to the account balance attributes. Also, there is now a new effect which indicates a trustline was authorized to maintain liabilities.
See https://github.com/stellar/go/issues/2357 for more details.

This PR updates the java SDK so that it's able to parse the new Horizon account balance and effects responses.