### PR TITLE
Fix bug in Revoke Sponsorship Operation response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
+## 0.21.1
+- Fix NullPointerException in `org.stellar.sdk.responses.operations.RevokeSponsorshipOperationResponse` accessor methods.
+
 ## 0.21.0
 
 ### Breaking change

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'com.github.ben-manes.versions' // gradle dependencyUpdates -Drevi
 apply plugin: 'project-report' // gradle htmlDependencyReport
 
 sourceCompatibility = 1.6
-version = '0.19.0'
+version = '0.21.1'
 group = 'stellar'
 
 jar {

--- a/src/main/java/org/stellar/sdk/responses/operations/RevokeSponsorshipOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/RevokeSponsorshipOperationResponse.java
@@ -50,39 +50,39 @@ public class RevokeSponsorshipOperationResponse extends OperationResponse {
   }
 
   public Optional<String> getAccountId() {
-    return Optional.of(accountId);
+    return Optional.fromNullable(accountId);
   }
 
   public Optional<String> getClaimableBalanceId() {
-    return Optional.of(claimableBalanceId);
+    return Optional.fromNullable(claimableBalanceId);
   }
 
   public Optional<String> getDataAccountId() {
-    return Optional.of(dataAccountId);
+    return Optional.fromNullable(dataAccountId);
   }
 
   public Optional<String> getDataName() {
-    return Optional.of(dataName);
+    return Optional.fromNullable(dataName);
   }
 
   public Optional<String> getOfferId() {
-    return Optional.of(offerId);
+    return Optional.fromNullable(offerId);
   }
 
   public Optional<String> getTrustlineAccountId() {
-    return Optional.of(trustlineAccountId);
+    return Optional.fromNullable(trustlineAccountId);
   }
 
   public Optional<String> getTrustlineAsset() {
-    return Optional.of(trustlineAsset);
+    return Optional.fromNullable(trustlineAsset);
   }
 
   public Optional<String> getSignerAccountId() {
-    return Optional.of(signerAccountId);
+    return Optional.fromNullable(signerAccountId);
   }
 
   public Optional<String> getSignerKey() {
-    return Optional.of(signerKey);
+    return Optional.fromNullable(signerKey);
   }
 
 }

--- a/src/test/java/org/stellar/sdk/responses/OperationsPageDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/OperationsPageDeserializerTest.java
@@ -10,6 +10,7 @@ import org.stellar.sdk.Memo;
 import org.stellar.sdk.responses.operations.CreateAccountOperationResponse;
 import org.stellar.sdk.responses.operations.OperationResponse;
 import org.stellar.sdk.responses.operations.PaymentOperationResponse;
+import org.stellar.sdk.responses.operations.RevokeSponsorshipOperationResponse;
 
 public class OperationsPageDeserializerTest extends TestCase {
   @Test
@@ -53,6 +54,68 @@ public class OperationsPageDeserializerTest extends TestCase {
     assertEquals(transaction.getMemo(), Memo.none());
   }
 
+  @Test
+  public void testDeserializeRevokeSponsorship() {
+    Page<OperationResponse> operationsPage = GsonSingleton.getInstance().fromJson(revokeSponsorshipJSON, new TypeToken<Page<OperationResponse>>() {}.getType());
+    RevokeSponsorshipOperationResponse revokeOp = ((RevokeSponsorshipOperationResponse) operationsPage.getRecords().get(0));
+
+    assertFalse(revokeOp.getAccountId().isPresent());
+    assertFalse(revokeOp.getClaimableBalanceId().isPresent());
+    assertFalse(revokeOp.getDataAccountId().isPresent());
+    assertFalse(revokeOp.getDataName().isPresent());
+    assertFalse(revokeOp.getSignerAccountId().isPresent());
+    assertFalse(revokeOp.getSignerKey().isPresent());
+    assertFalse(revokeOp.getTrustlineAccountId().isPresent());
+    assertFalse(revokeOp.getTrustlineAsset().isPresent());
+    assertEquals(revokeOp.getOfferId().get(), "8822470");
+    assertEquals(revokeOp.getSourceAccount(), "GB6QDNU47MYBR4NDTRP7M3FW27DAFOEADN5KDQI2DAVWW6YVKKG4QJS7");
+  }
+
+  String revokeSponsorshipJSON = "{\n" +
+      "  \"_links\": {\n" +
+      "    \"self\": {\n" +
+      "      \"href\": \"https://horizon-testnet.stellar.org/transactions/02a69bb0dc83d004ae918aab2d10c9dbc2cbf4451ab12927a691b87e5c6c5079/operations?cursor=\\u0026limit=10\\u0026order=asc\"\n" +
+      "    },\n" +
+      "    \"next\": {\n" +
+      "      \"href\": \"https://horizon-testnet.stellar.org/transactions/02a69bb0dc83d004ae918aab2d10c9dbc2cbf4451ab12927a691b87e5c6c5079/operations?cursor=4458463816060929\\u0026limit=10\\u0026order=asc\"\n" +
+      "    },\n" +
+      "    \"prev\": {\n" +
+      "      \"href\": \"https://horizon-testnet.stellar.org/transactions/02a69bb0dc83d004ae918aab2d10c9dbc2cbf4451ab12927a691b87e5c6c5079/operations?cursor=4458463816060929\\u0026limit=10\\u0026order=desc\"\n" +
+      "    }\n" +
+      "  },\n" +
+      "  \"_embedded\": {\n" +
+      "    \"records\": [\n" +
+      "      {\n" +
+      "        \"_links\": {\n" +
+      "          \"self\": {\n" +
+      "            \"href\": \"https://horizon-testnet.stellar.org/operations/4458463816060929\"\n" +
+      "          },\n" +
+      "          \"transaction\": {\n" +
+      "            \"href\": \"https://horizon-testnet.stellar.org/transactions/02a69bb0dc83d004ae918aab2d10c9dbc2cbf4451ab12927a691b87e5c6c5079\"\n" +
+      "          },\n" +
+      "          \"effects\": {\n" +
+      "            \"href\": \"https://horizon-testnet.stellar.org/operations/4458463816060929/effects\"\n" +
+      "          },\n" +
+      "          \"succeeds\": {\n" +
+      "            \"href\": \"https://horizon-testnet.stellar.org/effects?order=desc\\u0026cursor=4458463816060929\"\n" +
+      "          },\n" +
+      "          \"precedes\": {\n" +
+      "            \"href\": \"https://horizon-testnet.stellar.org/effects?order=asc\\u0026cursor=4458463816060929\"\n" +
+      "          }\n" +
+      "        },\n" +
+      "        \"id\": \"4458463816060929\",\n" +
+      "        \"paging_token\": \"4458463816060929\",\n" +
+      "        \"transaction_successful\": true,\n" +
+      "        \"source_account\": \"GB6QDNU47MYBR4NDTRP7M3FW27DAFOEADN5KDQI2DAVWW6YVKKG4QJS7\",\n" +
+      "        \"type\": \"revoke_sponsorship\",\n" +
+      "        \"type_i\": 18,\n" +
+      "        \"created_at\": \"2020-10-02T20:35:22Z\",\n" +
+      "        \"transaction_hash\": \"02a69bb0dc83d004ae918aab2d10c9dbc2cbf4451ab12927a691b87e5c6c5079\",\n" +
+      "        \"offer_id\": \"8822470\"\n" +
+      "      }\n" +
+      "    ]\n" +
+      "  }\n" +
+      "}";
 
   String json = "{\n" +
           "  \"_links\": {\n" +


### PR DESCRIPTION
Fixes https://github.com/stellar/java-stellar-sdk/issues/304

The Revoke Sponsorship Operation revokes the sponsorship for a given ledger entry. A ledger entry can be an account, an account signer, an account data entry, a claimable balance, an offer, or a trustline. In the `RevokeSponsorshipOperationResponse` class, the ledger entry is represented as an Optional type for each ledger entry type. The ledger entry type which is actually revoked will have an Optional type with a value and the remaining accessors will have an absent Optional value.

The `Optional.of()` constructor was used in all the ledger entry accessor functions. But, I should have used `Optional.fromNullable()` because `Optional.of()` expects a non-null value where as `Optional.fromNullable()` can take either null or a non-null value. Only one of the ledger entry type accessors will be non-null and the rest will be null.
