### PR TITLE
Bump version in gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'com.github.ben-manes.versions' // gradle dependencyUpdates -Drevi
 apply plugin: 'project-report' // gradle htmlDependencyReport
 
 sourceCompatibility = 1.6
-version = '0.21.1'
+version = '0.21.2'
 group = 'stellar'
 
 jar {


### PR DESCRIPTION
After merging https://github.com/stellar/java-stellar-sdk/pull/310 we need to bump the version of gradle before we can create the 0.21.2 release.