### PR TITLE
Regenerate XDR types using latest version of xdrgen

### DIFF
--- a/src/main/java/org/stellar/sdk/xdr/AccountEntry.java
+++ b/src/main/java/org/stellar/sdk/xdr/AccountEntry.java
@@ -164,12 +164,90 @@ public class AccountEntry implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof AccountEntry)) {
+    if (!(object instanceof AccountEntry)) {
       return false;
     }
 
     AccountEntry other = (AccountEntry) object;
     return Objects.equal(this.accountID, other.accountID) && Objects.equal(this.balance, other.balance) && Objects.equal(this.seqNum, other.seqNum) && Objects.equal(this.numSubEntries, other.numSubEntries) && Objects.equal(this.inflationDest, other.inflationDest) && Objects.equal(this.flags, other.flags) && Objects.equal(this.homeDomain, other.homeDomain) && Objects.equal(this.thresholds, other.thresholds) && Arrays.equals(this.signers, other.signers) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private AccountID accountID;
+    private Int64 balance;
+    private SequenceNumber seqNum;
+    private Uint32 numSubEntries;
+    private AccountID inflationDest;
+    private Uint32 flags;
+    private String32 homeDomain;
+    private Thresholds thresholds;
+    private Signer[] signers;
+    private AccountEntryExt ext;
+
+    public Builder accountID(AccountID accountID) {
+      this.accountID = accountID;
+      return this;
+    }
+
+    public Builder balance(Int64 balance) {
+      this.balance = balance;
+      return this;
+    }
+
+    public Builder seqNum(SequenceNumber seqNum) {
+      this.seqNum = seqNum;
+      return this;
+    }
+
+    public Builder numSubEntries(Uint32 numSubEntries) {
+      this.numSubEntries = numSubEntries;
+      return this;
+    }
+
+    public Builder inflationDest(AccountID inflationDest) {
+      this.inflationDest = inflationDest;
+      return this;
+    }
+
+    public Builder flags(Uint32 flags) {
+      this.flags = flags;
+      return this;
+    }
+
+    public Builder homeDomain(String32 homeDomain) {
+      this.homeDomain = homeDomain;
+      return this;
+    }
+
+    public Builder thresholds(Thresholds thresholds) {
+      this.thresholds = thresholds;
+      return this;
+    }
+
+    public Builder signers(Signer[] signers) {
+      this.signers = signers;
+      return this;
+    }
+
+    public Builder ext(AccountEntryExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public AccountEntry build() {
+      AccountEntry val = new AccountEntry();
+      val.setAccountID(accountID);
+      val.setBalance(balance);
+      val.setSeqNum(seqNum);
+      val.setNumSubEntries(numSubEntries);
+      val.setInflationDest(inflationDest);
+      val.setFlags(flags);
+      val.setHomeDomain(homeDomain);
+      val.setThresholds(thresholds);
+      val.setSigners(signers);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class AccountEntryExt {
@@ -188,6 +266,29 @@ public class AccountEntry implements XdrElement {
     public void setV1(AccountEntryExtensionV1 value) {
       this.v1 = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+      private AccountEntryExtensionV1 v1;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder v1(AccountEntryExtensionV1 v1) {
+        this.v1 = v1;
+        return this;
+      }
+
+      public AccountEntryExt build() {
+        AccountEntryExt val = new AccountEntryExt();
+        val.setDiscriminant(discriminant);
+        val.setV1(v1);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, AccountEntryExt encodedAccountEntryExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -222,7 +323,7 @@ public class AccountEntry implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof AccountEntryExt)) {
+      if (!(object instanceof AccountEntryExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/AccountEntryExtensionV1.java
+++ b/src/main/java/org/stellar/sdk/xdr/AccountEntryExtensionV1.java
@@ -60,12 +60,34 @@ public class AccountEntryExtensionV1 implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof AccountEntryExtensionV1)) {
+    if (!(object instanceof AccountEntryExtensionV1)) {
       return false;
     }
 
     AccountEntryExtensionV1 other = (AccountEntryExtensionV1) object;
     return Objects.equal(this.liabilities, other.liabilities) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private Liabilities liabilities;
+    private AccountEntryExtensionV1Ext ext;
+
+    public Builder liabilities(Liabilities liabilities) {
+      this.liabilities = liabilities;
+      return this;
+    }
+
+    public Builder ext(AccountEntryExtensionV1Ext ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public AccountEntryExtensionV1 build() {
+      AccountEntryExtensionV1 val = new AccountEntryExtensionV1();
+      val.setLiabilities(liabilities);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class AccountEntryExtensionV1Ext {
@@ -84,6 +106,29 @@ public class AccountEntryExtensionV1 implements XdrElement {
     public void setV2(AccountEntryExtensionV2 value) {
       this.v2 = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+      private AccountEntryExtensionV2 v2;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder v2(AccountEntryExtensionV2 v2) {
+        this.v2 = v2;
+        return this;
+      }
+
+      public AccountEntryExtensionV1Ext build() {
+        AccountEntryExtensionV1Ext val = new AccountEntryExtensionV1Ext();
+        val.setDiscriminant(discriminant);
+        val.setV2(v2);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, AccountEntryExtensionV1Ext encodedAccountEntryExtensionV1Ext) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -118,7 +163,7 @@ public class AccountEntryExtensionV1 implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof AccountEntryExtensionV1Ext)) {
+      if (!(object instanceof AccountEntryExtensionV1Ext)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/AccountEntryExtensionV2.java
+++ b/src/main/java/org/stellar/sdk/xdr/AccountEntryExtensionV2.java
@@ -87,12 +87,48 @@ public class AccountEntryExtensionV2 implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof AccountEntryExtensionV2)) {
+    if (!(object instanceof AccountEntryExtensionV2)) {
       return false;
     }
 
     AccountEntryExtensionV2 other = (AccountEntryExtensionV2) object;
     return Objects.equal(this.numSponsored, other.numSponsored) && Objects.equal(this.numSponsoring, other.numSponsoring) && Arrays.equals(this.signerSponsoringIDs, other.signerSponsoringIDs) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private Uint32 numSponsored;
+    private Uint32 numSponsoring;
+    private SponsorshipDescriptor[] signerSponsoringIDs;
+    private AccountEntryExtensionV2Ext ext;
+
+    public Builder numSponsored(Uint32 numSponsored) {
+      this.numSponsored = numSponsored;
+      return this;
+    }
+
+    public Builder numSponsoring(Uint32 numSponsoring) {
+      this.numSponsoring = numSponsoring;
+      return this;
+    }
+
+    public Builder signerSponsoringIDs(SponsorshipDescriptor[] signerSponsoringIDs) {
+      this.signerSponsoringIDs = signerSponsoringIDs;
+      return this;
+    }
+
+    public Builder ext(AccountEntryExtensionV2Ext ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public AccountEntryExtensionV2 build() {
+      AccountEntryExtensionV2 val = new AccountEntryExtensionV2();
+      val.setNumSponsored(numSponsored);
+      val.setNumSponsoring(numSponsoring);
+      val.setSignerSponsoringIDs(signerSponsoringIDs);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class AccountEntryExtensionV2Ext {
@@ -104,6 +140,22 @@ public class AccountEntryExtensionV2 implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public AccountEntryExtensionV2Ext build() {
+        AccountEntryExtensionV2Ext val = new AccountEntryExtensionV2Ext();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, AccountEntryExtensionV2Ext encodedAccountEntryExtensionV2Ext) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -132,7 +184,7 @@ public class AccountEntryExtensionV2 implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof AccountEntryExtensionV2Ext)) {
+      if (!(object instanceof AccountEntryExtensionV2Ext)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/AccountID.java
+++ b/src/main/java/org/stellar/sdk/xdr/AccountID.java
@@ -15,30 +15,42 @@ import com.google.common.base.Objects;
 //  ===========================================================================
 public class AccountID implements XdrElement {
   private PublicKey AccountID;
+
+  public AccountID() {}
+
+  public AccountID(PublicKey AccountID) {
+    this.AccountID = AccountID;
+  }
+
   public PublicKey getAccountID() {
     return this.AccountID;
   }
+
   public void setAccountID(PublicKey value) {
     this.AccountID = value;
   }
+
   public static void encode(XdrDataOutputStream stream, AccountID  encodedAccountID) throws IOException {
-  PublicKey.encode(stream, encodedAccountID.AccountID);
+    PublicKey.encode(stream, encodedAccountID.AccountID);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static AccountID decode(XdrDataInputStream stream) throws IOException {
     AccountID decodedAccountID = new AccountID();
-  decodedAccountID.AccountID = PublicKey.decode(stream);
+    decodedAccountID.AccountID = PublicKey.decode(stream);
     return decodedAccountID;
   }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(this.AccountID);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof AccountID)) {
+    if (!(object instanceof AccountID)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/AccountMergeResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/AccountMergeResult.java
@@ -35,6 +35,29 @@ public class AccountMergeResult implements XdrElement {
   public void setSourceAccountBalance(Int64 value) {
     this.sourceAccountBalance = value;
   }
+
+  public static final class Builder {
+    private AccountMergeResultCode discriminant;
+    private Int64 sourceAccountBalance;
+
+    public Builder discriminant(AccountMergeResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder sourceAccountBalance(Int64 sourceAccountBalance) {
+      this.sourceAccountBalance = sourceAccountBalance;
+      return this;
+    }
+
+    public AccountMergeResult build() {
+      AccountMergeResult val = new AccountMergeResult();
+      val.setDiscriminant(discriminant);
+      val.setSourceAccountBalance(sourceAccountBalance);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, AccountMergeResult encodedAccountMergeResult) throws IOException {
   //Xdrgen::AST::Identifier
   //AccountMergeResultCode
@@ -69,7 +92,7 @@ public class AccountMergeResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof AccountMergeResult)) {
+    if (!(object instanceof AccountMergeResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/AllowTrustOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/AllowTrustOp.java
@@ -75,12 +75,41 @@ public class AllowTrustOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof AllowTrustOp)) {
+    if (!(object instanceof AllowTrustOp)) {
       return false;
     }
 
     AllowTrustOp other = (AllowTrustOp) object;
     return Objects.equal(this.trustor, other.trustor) && Objects.equal(this.asset, other.asset) && Objects.equal(this.authorize, other.authorize);
+  }
+
+  public static final class Builder {
+    private AccountID trustor;
+    private AllowTrustOpAsset asset;
+    private Uint32 authorize;
+
+    public Builder trustor(AccountID trustor) {
+      this.trustor = trustor;
+      return this;
+    }
+
+    public Builder asset(AllowTrustOpAsset asset) {
+      this.asset = asset;
+      return this;
+    }
+
+    public Builder authorize(Uint32 authorize) {
+      this.authorize = authorize;
+      return this;
+    }
+
+    public AllowTrustOp build() {
+      AllowTrustOp val = new AllowTrustOp();
+      val.setTrustor(trustor);
+      val.setAsset(asset);
+      val.setAuthorize(authorize);
+      return val;
+    }
   }
 
   public static class AllowTrustOpAsset {
@@ -106,6 +135,36 @@ public class AllowTrustOp implements XdrElement {
     public void setAssetCode12(AssetCode12 value) {
       this.assetCode12 = value;
     }
+
+    public static final class Builder {
+      private AssetType discriminant;
+      private AssetCode4 assetCode4;
+      private AssetCode12 assetCode12;
+
+      public Builder discriminant(AssetType discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder assetCode4(AssetCode4 assetCode4) {
+        this.assetCode4 = assetCode4;
+        return this;
+      }
+
+      public Builder assetCode12(AssetCode12 assetCode12) {
+        this.assetCode12 = assetCode12;
+        return this;
+      }
+
+      public AllowTrustOpAsset build() {
+        AllowTrustOpAsset val = new AllowTrustOpAsset();
+        val.setDiscriminant(discriminant);
+        val.setAssetCode4(assetCode4);
+        val.setAssetCode12(assetCode12);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, AllowTrustOpAsset encodedAllowTrustOpAsset) throws IOException {
     //Xdrgen::AST::Identifier
     //AssetType
@@ -142,7 +201,7 @@ public class AllowTrustOp implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof AllowTrustOpAsset)) {
+      if (!(object instanceof AllowTrustOpAsset)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/AllowTrustResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/AllowTrustResult.java
@@ -28,6 +28,22 @@ public class AllowTrustResult implements XdrElement {
   public void setDiscriminant(AllowTrustResultCode value) {
     this.code = value;
   }
+
+  public static final class Builder {
+    private AllowTrustResultCode discriminant;
+
+    public Builder discriminant(AllowTrustResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public AllowTrustResult build() {
+      AllowTrustResult val = new AllowTrustResult();
+      val.setDiscriminant(discriminant);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, AllowTrustResult encodedAllowTrustResult) throws IOException {
   //Xdrgen::AST::Identifier
   //AllowTrustResultCode
@@ -60,7 +76,7 @@ public class AllowTrustResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof AllowTrustResult)) {
+    if (!(object instanceof AllowTrustResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/Asset.java
+++ b/src/main/java/org/stellar/sdk/xdr/Asset.java
@@ -56,6 +56,36 @@ public class Asset implements XdrElement {
   public void setAlphaNum12(AssetAlphaNum12 value) {
     this.alphaNum12 = value;
   }
+
+  public static final class Builder {
+    private AssetType discriminant;
+    private AssetAlphaNum4 alphaNum4;
+    private AssetAlphaNum12 alphaNum12;
+
+    public Builder discriminant(AssetType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder alphaNum4(AssetAlphaNum4 alphaNum4) {
+      this.alphaNum4 = alphaNum4;
+      return this;
+    }
+
+    public Builder alphaNum12(AssetAlphaNum12 alphaNum12) {
+      this.alphaNum12 = alphaNum12;
+      return this;
+    }
+
+    public Asset build() {
+      Asset val = new Asset();
+      val.setDiscriminant(discriminant);
+      val.setAlphaNum4(alphaNum4);
+      val.setAlphaNum12(alphaNum12);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, Asset encodedAsset) throws IOException {
   //Xdrgen::AST::Identifier
   //AssetType
@@ -96,7 +126,7 @@ public class Asset implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Asset)) {
+    if (!(object instanceof Asset)) {
       return false;
     }
 
@@ -139,12 +169,34 @@ public class Asset implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof AssetAlphaNum4)) {
+      if (!(object instanceof AssetAlphaNum4)) {
         return false;
       }
 
       AssetAlphaNum4 other = (AssetAlphaNum4) object;
       return Objects.equal(this.assetCode, other.assetCode) && Objects.equal(this.issuer, other.issuer);
+    }
+
+    public static final class Builder {
+      private AssetCode4 assetCode;
+      private AccountID issuer;
+
+      public Builder assetCode(AssetCode4 assetCode) {
+        this.assetCode = assetCode;
+        return this;
+      }
+
+      public Builder issuer(AccountID issuer) {
+        this.issuer = issuer;
+        return this;
+      }
+
+      public AssetAlphaNum4 build() {
+        AssetAlphaNum4 val = new AssetAlphaNum4();
+        val.setAssetCode(assetCode);
+        val.setIssuer(issuer);
+        return val;
+      }
     }
 
   }
@@ -183,12 +235,34 @@ public class Asset implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof AssetAlphaNum12)) {
+      if (!(object instanceof AssetAlphaNum12)) {
         return false;
       }
 
       AssetAlphaNum12 other = (AssetAlphaNum12) object;
       return Objects.equal(this.assetCode, other.assetCode) && Objects.equal(this.issuer, other.issuer);
+    }
+
+    public static final class Builder {
+      private AssetCode12 assetCode;
+      private AccountID issuer;
+
+      public Builder assetCode(AssetCode12 assetCode) {
+        this.assetCode = assetCode;
+        return this;
+      }
+
+      public Builder issuer(AccountID issuer) {
+        this.issuer = issuer;
+        return this;
+      }
+
+      public AssetAlphaNum12 build() {
+        AssetAlphaNum12 val = new AssetAlphaNum12();
+        val.setAssetCode(assetCode);
+        val.setIssuer(issuer);
+        return val;
+      }
     }
 
   }

--- a/src/main/java/org/stellar/sdk/xdr/AssetCode12.java
+++ b/src/main/java/org/stellar/sdk/xdr/AssetCode12.java
@@ -15,33 +15,45 @@ import java.util.Arrays;
 //  ===========================================================================
 public class AssetCode12 implements XdrElement {
   private byte[] AssetCode12;
+
+  public AssetCode12() {}
+
+  public AssetCode12(byte[] AssetCode12) {
+    this.AssetCode12 = AssetCode12;
+  }
+
   public byte[] getAssetCode12() {
     return this.AssetCode12;
   }
+
   public void setAssetCode12(byte[] value) {
     this.AssetCode12 = value;
   }
+
   public static void encode(XdrDataOutputStream stream, AssetCode12  encodedAssetCode12) throws IOException {
-  int AssetCode12size = encodedAssetCode12.AssetCode12.length;
-  stream.write(encodedAssetCode12.getAssetCode12(), 0, AssetCode12size);
+    int AssetCode12size = encodedAssetCode12.AssetCode12.length;
+    stream.write(encodedAssetCode12.getAssetCode12(), 0, AssetCode12size);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static AssetCode12 decode(XdrDataInputStream stream) throws IOException {
     AssetCode12 decodedAssetCode12 = new AssetCode12();
-  int AssetCode12size = 12;
-  decodedAssetCode12.AssetCode12 = new byte[AssetCode12size];
-  stream.read(decodedAssetCode12.AssetCode12, 0, AssetCode12size);
+    int AssetCode12size = 12;
+    decodedAssetCode12.AssetCode12 = new byte[AssetCode12size];
+    stream.read(decodedAssetCode12.AssetCode12, 0, AssetCode12size);
     return decodedAssetCode12;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.AssetCode12);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof AssetCode12)) {
+    if (!(object instanceof AssetCode12)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/AssetCode4.java
+++ b/src/main/java/org/stellar/sdk/xdr/AssetCode4.java
@@ -15,33 +15,45 @@ import java.util.Arrays;
 //  ===========================================================================
 public class AssetCode4 implements XdrElement {
   private byte[] AssetCode4;
+
+  public AssetCode4() {}
+
+  public AssetCode4(byte[] AssetCode4) {
+    this.AssetCode4 = AssetCode4;
+  }
+
   public byte[] getAssetCode4() {
     return this.AssetCode4;
   }
+
   public void setAssetCode4(byte[] value) {
     this.AssetCode4 = value;
   }
+
   public static void encode(XdrDataOutputStream stream, AssetCode4  encodedAssetCode4) throws IOException {
-  int AssetCode4size = encodedAssetCode4.AssetCode4.length;
-  stream.write(encodedAssetCode4.getAssetCode4(), 0, AssetCode4size);
+    int AssetCode4size = encodedAssetCode4.AssetCode4.length;
+    stream.write(encodedAssetCode4.getAssetCode4(), 0, AssetCode4size);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static AssetCode4 decode(XdrDataInputStream stream) throws IOException {
     AssetCode4 decodedAssetCode4 = new AssetCode4();
-  int AssetCode4size = 4;
-  decodedAssetCode4.AssetCode4 = new byte[AssetCode4size];
-  stream.read(decodedAssetCode4.AssetCode4, 0, AssetCode4size);
+    int AssetCode4size = 4;
+    decodedAssetCode4.AssetCode4 = new byte[AssetCode4size];
+    stream.read(decodedAssetCode4.AssetCode4, 0, AssetCode4size);
     return decodedAssetCode4;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.AssetCode4);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof AssetCode4)) {
+    if (!(object instanceof AssetCode4)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/Auth.java
+++ b/src/main/java/org/stellar/sdk/xdr/Auth.java
@@ -44,11 +44,26 @@ public class Auth implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Auth)) {
+    if (!(object instanceof Auth)) {
       return false;
     }
 
     Auth other = (Auth) object;
     return Objects.equal(this.unused, other.unused);
+  }
+
+  public static final class Builder {
+    private Integer unused;
+
+    public Builder unused(Integer unused) {
+      this.unused = unused;
+      return this;
+    }
+
+    public Auth build() {
+      Auth val = new Auth();
+      val.setUnused(unused);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/AuthCert.java
+++ b/src/main/java/org/stellar/sdk/xdr/AuthCert.java
@@ -62,11 +62,40 @@ public class AuthCert implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof AuthCert)) {
+    if (!(object instanceof AuthCert)) {
       return false;
     }
 
     AuthCert other = (AuthCert) object;
     return Objects.equal(this.pubkey, other.pubkey) && Objects.equal(this.expiration, other.expiration) && Objects.equal(this.sig, other.sig);
+  }
+
+  public static final class Builder {
+    private Curve25519Public pubkey;
+    private Uint64 expiration;
+    private Signature sig;
+
+    public Builder pubkey(Curve25519Public pubkey) {
+      this.pubkey = pubkey;
+      return this;
+    }
+
+    public Builder expiration(Uint64 expiration) {
+      this.expiration = expiration;
+      return this;
+    }
+
+    public Builder sig(Signature sig) {
+      this.sig = sig;
+      return this;
+    }
+
+    public AuthCert build() {
+      AuthCert val = new AuthCert();
+      val.setPubkey(pubkey);
+      val.setExpiration(expiration);
+      val.setSig(sig);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/AuthenticatedMessage.java
+++ b/src/main/java/org/stellar/sdk/xdr/AuthenticatedMessage.java
@@ -38,6 +38,29 @@ public class AuthenticatedMessage implements XdrElement {
   public void setV0(AuthenticatedMessageV0 value) {
     this.v0 = value;
   }
+
+  public static final class Builder {
+    private Uint32 discriminant;
+    private AuthenticatedMessageV0 v0;
+
+    public Builder discriminant(Uint32 discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder v0(AuthenticatedMessageV0 v0) {
+      this.v0 = v0;
+      return this;
+    }
+
+    public AuthenticatedMessage build() {
+      AuthenticatedMessage val = new AuthenticatedMessage();
+      val.setDiscriminant(discriminant);
+      val.setV0(v0);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, AuthenticatedMessage encodedAuthenticatedMessage) throws IOException {
   //Xdrgen::AST::Identifier
   //Uint32
@@ -68,7 +91,7 @@ public class AuthenticatedMessage implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof AuthenticatedMessage)) {
+    if (!(object instanceof AuthenticatedMessage)) {
       return false;
     }
 
@@ -120,12 +143,41 @@ public class AuthenticatedMessage implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof AuthenticatedMessageV0)) {
+      if (!(object instanceof AuthenticatedMessageV0)) {
         return false;
       }
 
       AuthenticatedMessageV0 other = (AuthenticatedMessageV0) object;
       return Objects.equal(this.sequence, other.sequence) && Objects.equal(this.message, other.message) && Objects.equal(this.mac, other.mac);
+    }
+
+    public static final class Builder {
+      private Uint64 sequence;
+      private StellarMessage message;
+      private HmacSha256Mac mac;
+
+      public Builder sequence(Uint64 sequence) {
+        this.sequence = sequence;
+        return this;
+      }
+
+      public Builder message(StellarMessage message) {
+        this.message = message;
+        return this;
+      }
+
+      public Builder mac(HmacSha256Mac mac) {
+        this.mac = mac;
+        return this;
+      }
+
+      public AuthenticatedMessageV0 build() {
+        AuthenticatedMessageV0 val = new AuthenticatedMessageV0();
+        val.setSequence(sequence);
+        val.setMessage(message);
+        val.setMac(mac);
+        return val;
+      }
     }
 
   }

--- a/src/main/java/org/stellar/sdk/xdr/BeginSponsoringFutureReservesOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/BeginSponsoringFutureReservesOp.java
@@ -42,11 +42,26 @@ public class BeginSponsoringFutureReservesOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof BeginSponsoringFutureReservesOp)) {
+    if (!(object instanceof BeginSponsoringFutureReservesOp)) {
       return false;
     }
 
     BeginSponsoringFutureReservesOp other = (BeginSponsoringFutureReservesOp) object;
     return Objects.equal(this.sponsoredID, other.sponsoredID);
+  }
+
+  public static final class Builder {
+    private AccountID sponsoredID;
+
+    public Builder sponsoredID(AccountID sponsoredID) {
+      this.sponsoredID = sponsoredID;
+      return this;
+    }
+
+    public BeginSponsoringFutureReservesOp build() {
+      BeginSponsoringFutureReservesOp val = new BeginSponsoringFutureReservesOp();
+      val.setSponsoredID(sponsoredID);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/BeginSponsoringFutureReservesResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/BeginSponsoringFutureReservesResult.java
@@ -28,6 +28,22 @@ public class BeginSponsoringFutureReservesResult implements XdrElement {
   public void setDiscriminant(BeginSponsoringFutureReservesResultCode value) {
     this.code = value;
   }
+
+  public static final class Builder {
+    private BeginSponsoringFutureReservesResultCode discriminant;
+
+    public Builder discriminant(BeginSponsoringFutureReservesResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public BeginSponsoringFutureReservesResult build() {
+      BeginSponsoringFutureReservesResult val = new BeginSponsoringFutureReservesResult();
+      val.setDiscriminant(discriminant);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, BeginSponsoringFutureReservesResult encodedBeginSponsoringFutureReservesResult) throws IOException {
   //Xdrgen::AST::Identifier
   //BeginSponsoringFutureReservesResultCode
@@ -60,7 +76,7 @@ public class BeginSponsoringFutureReservesResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof BeginSponsoringFutureReservesResult)) {
+    if (!(object instanceof BeginSponsoringFutureReservesResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/BucketEntry.java
+++ b/src/main/java/org/stellar/sdk/xdr/BucketEntry.java
@@ -53,6 +53,43 @@ public class BucketEntry implements XdrElement {
   public void setMetaEntry(BucketMetadata value) {
     this.metaEntry = value;
   }
+
+  public static final class Builder {
+    private BucketEntryType discriminant;
+    private LedgerEntry liveEntry;
+    private LedgerKey deadEntry;
+    private BucketMetadata metaEntry;
+
+    public Builder discriminant(BucketEntryType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder liveEntry(LedgerEntry liveEntry) {
+      this.liveEntry = liveEntry;
+      return this;
+    }
+
+    public Builder deadEntry(LedgerKey deadEntry) {
+      this.deadEntry = deadEntry;
+      return this;
+    }
+
+    public Builder metaEntry(BucketMetadata metaEntry) {
+      this.metaEntry = metaEntry;
+      return this;
+    }
+
+    public BucketEntry build() {
+      BucketEntry val = new BucketEntry();
+      val.setDiscriminant(discriminant);
+      val.setLiveEntry(liveEntry);
+      val.setDeadEntry(deadEntry);
+      val.setMetaEntry(metaEntry);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, BucketEntry encodedBucketEntry) throws IOException {
   //Xdrgen::AST::Identifier
   //BucketEntryType
@@ -97,7 +134,7 @@ public class BucketEntry implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof BucketEntry)) {
+    if (!(object instanceof BucketEntry)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/BucketMetadata.java
+++ b/src/main/java/org/stellar/sdk/xdr/BucketMetadata.java
@@ -60,12 +60,34 @@ public class BucketMetadata implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof BucketMetadata)) {
+    if (!(object instanceof BucketMetadata)) {
       return false;
     }
 
     BucketMetadata other = (BucketMetadata) object;
     return Objects.equal(this.ledgerVersion, other.ledgerVersion) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private Uint32 ledgerVersion;
+    private BucketMetadataExt ext;
+
+    public Builder ledgerVersion(Uint32 ledgerVersion) {
+      this.ledgerVersion = ledgerVersion;
+      return this;
+    }
+
+    public Builder ext(BucketMetadataExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public BucketMetadata build() {
+      BucketMetadata val = new BucketMetadata();
+      val.setLedgerVersion(ledgerVersion);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class BucketMetadataExt {
@@ -77,6 +99,22 @@ public class BucketMetadata implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public BucketMetadataExt build() {
+        BucketMetadataExt val = new BucketMetadataExt();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, BucketMetadataExt encodedBucketMetadataExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -105,7 +143,7 @@ public class BucketMetadata implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof BucketMetadataExt)) {
+      if (!(object instanceof BucketMetadataExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/BumpSequenceOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/BumpSequenceOp.java
@@ -42,11 +42,26 @@ public class BumpSequenceOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof BumpSequenceOp)) {
+    if (!(object instanceof BumpSequenceOp)) {
       return false;
     }
 
     BumpSequenceOp other = (BumpSequenceOp) object;
     return Objects.equal(this.bumpTo, other.bumpTo);
+  }
+
+  public static final class Builder {
+    private SequenceNumber bumpTo;
+
+    public Builder bumpTo(SequenceNumber bumpTo) {
+      this.bumpTo = bumpTo;
+      return this;
+    }
+
+    public BumpSequenceOp build() {
+      BumpSequenceOp val = new BumpSequenceOp();
+      val.setBumpTo(bumpTo);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/BumpSequenceResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/BumpSequenceResult.java
@@ -28,6 +28,22 @@ public class BumpSequenceResult implements XdrElement {
   public void setDiscriminant(BumpSequenceResultCode value) {
     this.code = value;
   }
+
+  public static final class Builder {
+    private BumpSequenceResultCode discriminant;
+
+    public Builder discriminant(BumpSequenceResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public BumpSequenceResult build() {
+      BumpSequenceResult val = new BumpSequenceResult();
+      val.setDiscriminant(discriminant);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, BumpSequenceResult encodedBumpSequenceResult) throws IOException {
   //Xdrgen::AST::Identifier
   //BumpSequenceResultCode
@@ -60,7 +76,7 @@ public class BumpSequenceResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof BumpSequenceResult)) {
+    if (!(object instanceof BumpSequenceResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/ChangeTrustOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/ChangeTrustOp.java
@@ -54,11 +54,33 @@ public class ChangeTrustOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ChangeTrustOp)) {
+    if (!(object instanceof ChangeTrustOp)) {
       return false;
     }
 
     ChangeTrustOp other = (ChangeTrustOp) object;
     return Objects.equal(this.line, other.line) && Objects.equal(this.limit, other.limit);
+  }
+
+  public static final class Builder {
+    private Asset line;
+    private Int64 limit;
+
+    public Builder line(Asset line) {
+      this.line = line;
+      return this;
+    }
+
+    public Builder limit(Int64 limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public ChangeTrustOp build() {
+      ChangeTrustOp val = new ChangeTrustOp();
+      val.setLine(line);
+      val.setLimit(limit);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/ChangeTrustResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/ChangeTrustResult.java
@@ -28,6 +28,22 @@ public class ChangeTrustResult implements XdrElement {
   public void setDiscriminant(ChangeTrustResultCode value) {
     this.code = value;
   }
+
+  public static final class Builder {
+    private ChangeTrustResultCode discriminant;
+
+    public Builder discriminant(ChangeTrustResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public ChangeTrustResult build() {
+      ChangeTrustResult val = new ChangeTrustResult();
+      val.setDiscriminant(discriminant);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, ChangeTrustResult encodedChangeTrustResult) throws IOException {
   //Xdrgen::AST::Identifier
   //ChangeTrustResultCode
@@ -60,7 +76,7 @@ public class ChangeTrustResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ChangeTrustResult)) {
+    if (!(object instanceof ChangeTrustResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/ClaimClaimableBalanceOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/ClaimClaimableBalanceOp.java
@@ -42,11 +42,26 @@ public class ClaimClaimableBalanceOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ClaimClaimableBalanceOp)) {
+    if (!(object instanceof ClaimClaimableBalanceOp)) {
       return false;
     }
 
     ClaimClaimableBalanceOp other = (ClaimClaimableBalanceOp) object;
     return Objects.equal(this.balanceID, other.balanceID);
+  }
+
+  public static final class Builder {
+    private ClaimableBalanceID balanceID;
+
+    public Builder balanceID(ClaimableBalanceID balanceID) {
+      this.balanceID = balanceID;
+      return this;
+    }
+
+    public ClaimClaimableBalanceOp build() {
+      ClaimClaimableBalanceOp val = new ClaimClaimableBalanceOp();
+      val.setBalanceID(balanceID);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/ClaimClaimableBalanceResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/ClaimClaimableBalanceResult.java
@@ -28,6 +28,22 @@ public class ClaimClaimableBalanceResult implements XdrElement {
   public void setDiscriminant(ClaimClaimableBalanceResultCode value) {
     this.code = value;
   }
+
+  public static final class Builder {
+    private ClaimClaimableBalanceResultCode discriminant;
+
+    public Builder discriminant(ClaimClaimableBalanceResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public ClaimClaimableBalanceResult build() {
+      ClaimClaimableBalanceResult val = new ClaimClaimableBalanceResult();
+      val.setDiscriminant(discriminant);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, ClaimClaimableBalanceResult encodedClaimClaimableBalanceResult) throws IOException {
   //Xdrgen::AST::Identifier
   //ClaimClaimableBalanceResultCode
@@ -60,7 +76,7 @@ public class ClaimClaimableBalanceResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ClaimClaimableBalanceResult)) {
+    if (!(object instanceof ClaimClaimableBalanceResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/ClaimOfferAtom.java
+++ b/src/main/java/org/stellar/sdk/xdr/ClaimOfferAtom.java
@@ -97,11 +97,61 @@ public class ClaimOfferAtom implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ClaimOfferAtom)) {
+    if (!(object instanceof ClaimOfferAtom)) {
       return false;
     }
 
     ClaimOfferAtom other = (ClaimOfferAtom) object;
     return Objects.equal(this.sellerID, other.sellerID) && Objects.equal(this.offerID, other.offerID) && Objects.equal(this.assetSold, other.assetSold) && Objects.equal(this.amountSold, other.amountSold) && Objects.equal(this.assetBought, other.assetBought) && Objects.equal(this.amountBought, other.amountBought);
+  }
+
+  public static final class Builder {
+    private AccountID sellerID;
+    private Int64 offerID;
+    private Asset assetSold;
+    private Int64 amountSold;
+    private Asset assetBought;
+    private Int64 amountBought;
+
+    public Builder sellerID(AccountID sellerID) {
+      this.sellerID = sellerID;
+      return this;
+    }
+
+    public Builder offerID(Int64 offerID) {
+      this.offerID = offerID;
+      return this;
+    }
+
+    public Builder assetSold(Asset assetSold) {
+      this.assetSold = assetSold;
+      return this;
+    }
+
+    public Builder amountSold(Int64 amountSold) {
+      this.amountSold = amountSold;
+      return this;
+    }
+
+    public Builder assetBought(Asset assetBought) {
+      this.assetBought = assetBought;
+      return this;
+    }
+
+    public Builder amountBought(Int64 amountBought) {
+      this.amountBought = amountBought;
+      return this;
+    }
+
+    public ClaimOfferAtom build() {
+      ClaimOfferAtom val = new ClaimOfferAtom();
+      val.setSellerID(sellerID);
+      val.setOfferID(offerID);
+      val.setAssetSold(assetSold);
+      val.setAmountSold(amountSold);
+      val.setAssetBought(assetBought);
+      val.setAmountBought(amountBought);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/ClaimPredicate.java
+++ b/src/main/java/org/stellar/sdk/xdr/ClaimPredicate.java
@@ -73,6 +73,57 @@ public class ClaimPredicate implements XdrElement {
   public void setRelBefore(Int64 value) {
     this.relBefore = value;
   }
+
+  public static final class Builder {
+    private ClaimPredicateType discriminant;
+    private ClaimPredicate[] andPredicates;
+    private ClaimPredicate[] orPredicates;
+    private ClaimPredicate notPredicate;
+    private Int64 absBefore;
+    private Int64 relBefore;
+
+    public Builder discriminant(ClaimPredicateType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder andPredicates(ClaimPredicate[] andPredicates) {
+      this.andPredicates = andPredicates;
+      return this;
+    }
+
+    public Builder orPredicates(ClaimPredicate[] orPredicates) {
+      this.orPredicates = orPredicates;
+      return this;
+    }
+
+    public Builder notPredicate(ClaimPredicate notPredicate) {
+      this.notPredicate = notPredicate;
+      return this;
+    }
+
+    public Builder absBefore(Int64 absBefore) {
+      this.absBefore = absBefore;
+      return this;
+    }
+
+    public Builder relBefore(Int64 relBefore) {
+      this.relBefore = relBefore;
+      return this;
+    }
+
+    public ClaimPredicate build() {
+      ClaimPredicate val = new ClaimPredicate();
+      val.setDiscriminant(discriminant);
+      val.setAndPredicates(andPredicates);
+      val.setOrPredicates(orPredicates);
+      val.setNotPredicate(notPredicate);
+      val.setAbsBefore(absBefore);
+      val.setRelBefore(relBefore);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, ClaimPredicate encodedClaimPredicate) throws IOException {
   //Xdrgen::AST::Identifier
   //ClaimPredicateType
@@ -155,7 +206,7 @@ public class ClaimPredicate implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ClaimPredicate)) {
+    if (!(object instanceof ClaimPredicate)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/ClaimableBalanceEntry.java
+++ b/src/main/java/org/stellar/sdk/xdr/ClaimableBalanceEntry.java
@@ -105,12 +105,55 @@ public class ClaimableBalanceEntry implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ClaimableBalanceEntry)) {
+    if (!(object instanceof ClaimableBalanceEntry)) {
       return false;
     }
 
     ClaimableBalanceEntry other = (ClaimableBalanceEntry) object;
     return Objects.equal(this.balanceID, other.balanceID) && Arrays.equals(this.claimants, other.claimants) && Objects.equal(this.asset, other.asset) && Objects.equal(this.amount, other.amount) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private ClaimableBalanceID balanceID;
+    private Claimant[] claimants;
+    private Asset asset;
+    private Int64 amount;
+    private ClaimableBalanceEntryExt ext;
+
+    public Builder balanceID(ClaimableBalanceID balanceID) {
+      this.balanceID = balanceID;
+      return this;
+    }
+
+    public Builder claimants(Claimant[] claimants) {
+      this.claimants = claimants;
+      return this;
+    }
+
+    public Builder asset(Asset asset) {
+      this.asset = asset;
+      return this;
+    }
+
+    public Builder amount(Int64 amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    public Builder ext(ClaimableBalanceEntryExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public ClaimableBalanceEntry build() {
+      ClaimableBalanceEntry val = new ClaimableBalanceEntry();
+      val.setBalanceID(balanceID);
+      val.setClaimants(claimants);
+      val.setAsset(asset);
+      val.setAmount(amount);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class ClaimableBalanceEntryExt {
@@ -122,6 +165,22 @@ public class ClaimableBalanceEntry implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public ClaimableBalanceEntryExt build() {
+        ClaimableBalanceEntryExt val = new ClaimableBalanceEntryExt();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, ClaimableBalanceEntryExt encodedClaimableBalanceEntryExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -150,7 +209,7 @@ public class ClaimableBalanceEntry implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof ClaimableBalanceEntryExt)) {
+      if (!(object instanceof ClaimableBalanceEntryExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/ClaimableBalanceID.java
+++ b/src/main/java/org/stellar/sdk/xdr/ClaimableBalanceID.java
@@ -33,6 +33,29 @@ public class ClaimableBalanceID implements XdrElement {
   public void setV0(Hash value) {
     this.v0 = value;
   }
+
+  public static final class Builder {
+    private ClaimableBalanceIDType discriminant;
+    private Hash v0;
+
+    public Builder discriminant(ClaimableBalanceIDType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder v0(Hash v0) {
+      this.v0 = v0;
+      return this;
+    }
+
+    public ClaimableBalanceID build() {
+      ClaimableBalanceID val = new ClaimableBalanceID();
+      val.setDiscriminant(discriminant);
+      val.setV0(v0);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, ClaimableBalanceID encodedClaimableBalanceID) throws IOException {
   //Xdrgen::AST::Identifier
   //ClaimableBalanceIDType
@@ -63,7 +86,7 @@ public class ClaimableBalanceID implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ClaimableBalanceID)) {
+    if (!(object instanceof ClaimableBalanceID)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/Claimant.java
+++ b/src/main/java/org/stellar/sdk/xdr/Claimant.java
@@ -37,6 +37,29 @@ public class Claimant implements XdrElement {
   public void setV0(ClaimantV0 value) {
     this.v0 = value;
   }
+
+  public static final class Builder {
+    private ClaimantType discriminant;
+    private ClaimantV0 v0;
+
+    public Builder discriminant(ClaimantType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder v0(ClaimantV0 v0) {
+      this.v0 = v0;
+      return this;
+    }
+
+    public Claimant build() {
+      Claimant val = new Claimant();
+      val.setDiscriminant(discriminant);
+      val.setV0(v0);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, Claimant encodedClaimant) throws IOException {
   //Xdrgen::AST::Identifier
   //ClaimantType
@@ -67,7 +90,7 @@ public class Claimant implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Claimant)) {
+    if (!(object instanceof Claimant)) {
       return false;
     }
 
@@ -110,12 +133,34 @@ public class Claimant implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof ClaimantV0)) {
+      if (!(object instanceof ClaimantV0)) {
         return false;
       }
 
       ClaimantV0 other = (ClaimantV0) object;
       return Objects.equal(this.destination, other.destination) && Objects.equal(this.predicate, other.predicate);
+    }
+
+    public static final class Builder {
+      private AccountID destination;
+      private ClaimPredicate predicate;
+
+      public Builder destination(AccountID destination) {
+        this.destination = destination;
+        return this;
+      }
+
+      public Builder predicate(ClaimPredicate predicate) {
+        this.predicate = predicate;
+        return this;
+      }
+
+      public ClaimantV0 build() {
+        ClaimantV0 val = new ClaimantV0();
+        val.setDestination(destination);
+        val.setPredicate(predicate);
+        return val;
+      }
     }
 
   }

--- a/src/main/java/org/stellar/sdk/xdr/CreateAccountOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/CreateAccountOp.java
@@ -52,11 +52,33 @@ public class CreateAccountOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof CreateAccountOp)) {
+    if (!(object instanceof CreateAccountOp)) {
       return false;
     }
 
     CreateAccountOp other = (CreateAccountOp) object;
     return Objects.equal(this.destination, other.destination) && Objects.equal(this.startingBalance, other.startingBalance);
+  }
+
+  public static final class Builder {
+    private AccountID destination;
+    private Int64 startingBalance;
+
+    public Builder destination(AccountID destination) {
+      this.destination = destination;
+      return this;
+    }
+
+    public Builder startingBalance(Int64 startingBalance) {
+      this.startingBalance = startingBalance;
+      return this;
+    }
+
+    public CreateAccountOp build() {
+      CreateAccountOp val = new CreateAccountOp();
+      val.setDestination(destination);
+      val.setStartingBalance(startingBalance);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/CreateAccountResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/CreateAccountResult.java
@@ -28,6 +28,22 @@ public class CreateAccountResult implements XdrElement {
   public void setDiscriminant(CreateAccountResultCode value) {
     this.code = value;
   }
+
+  public static final class Builder {
+    private CreateAccountResultCode discriminant;
+
+    public Builder discriminant(CreateAccountResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public CreateAccountResult build() {
+      CreateAccountResult val = new CreateAccountResult();
+      val.setDiscriminant(discriminant);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, CreateAccountResult encodedCreateAccountResult) throws IOException {
   //Xdrgen::AST::Identifier
   //CreateAccountResultCode
@@ -60,7 +76,7 @@ public class CreateAccountResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof CreateAccountResult)) {
+    if (!(object instanceof CreateAccountResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/CreateClaimableBalanceOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/CreateClaimableBalanceOp.java
@@ -71,11 +71,40 @@ public class CreateClaimableBalanceOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof CreateClaimableBalanceOp)) {
+    if (!(object instanceof CreateClaimableBalanceOp)) {
       return false;
     }
 
     CreateClaimableBalanceOp other = (CreateClaimableBalanceOp) object;
     return Objects.equal(this.asset, other.asset) && Objects.equal(this.amount, other.amount) && Arrays.equals(this.claimants, other.claimants);
+  }
+
+  public static final class Builder {
+    private Asset asset;
+    private Int64 amount;
+    private Claimant[] claimants;
+
+    public Builder asset(Asset asset) {
+      this.asset = asset;
+      return this;
+    }
+
+    public Builder amount(Int64 amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    public Builder claimants(Claimant[] claimants) {
+      this.claimants = claimants;
+      return this;
+    }
+
+    public CreateClaimableBalanceOp build() {
+      CreateClaimableBalanceOp val = new CreateClaimableBalanceOp();
+      val.setAsset(asset);
+      val.setAmount(amount);
+      val.setClaimants(claimants);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/CreateClaimableBalanceResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/CreateClaimableBalanceResult.java
@@ -35,6 +35,29 @@ public class CreateClaimableBalanceResult implements XdrElement {
   public void setBalanceID(ClaimableBalanceID value) {
     this.balanceID = value;
   }
+
+  public static final class Builder {
+    private CreateClaimableBalanceResultCode discriminant;
+    private ClaimableBalanceID balanceID;
+
+    public Builder discriminant(CreateClaimableBalanceResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder balanceID(ClaimableBalanceID balanceID) {
+      this.balanceID = balanceID;
+      return this;
+    }
+
+    public CreateClaimableBalanceResult build() {
+      CreateClaimableBalanceResult val = new CreateClaimableBalanceResult();
+      val.setDiscriminant(discriminant);
+      val.setBalanceID(balanceID);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, CreateClaimableBalanceResult encodedCreateClaimableBalanceResult) throws IOException {
   //Xdrgen::AST::Identifier
   //CreateClaimableBalanceResultCode
@@ -69,7 +92,7 @@ public class CreateClaimableBalanceResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof CreateClaimableBalanceResult)) {
+    if (!(object instanceof CreateClaimableBalanceResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/CreatePassiveSellOfferOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/CreatePassiveSellOfferOp.java
@@ -72,11 +72,47 @@ public class CreatePassiveSellOfferOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof CreatePassiveSellOfferOp)) {
+    if (!(object instanceof CreatePassiveSellOfferOp)) {
       return false;
     }
 
     CreatePassiveSellOfferOp other = (CreatePassiveSellOfferOp) object;
     return Objects.equal(this.selling, other.selling) && Objects.equal(this.buying, other.buying) && Objects.equal(this.amount, other.amount) && Objects.equal(this.price, other.price);
+  }
+
+  public static final class Builder {
+    private Asset selling;
+    private Asset buying;
+    private Int64 amount;
+    private Price price;
+
+    public Builder selling(Asset selling) {
+      this.selling = selling;
+      return this;
+    }
+
+    public Builder buying(Asset buying) {
+      this.buying = buying;
+      return this;
+    }
+
+    public Builder amount(Int64 amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    public Builder price(Price price) {
+      this.price = price;
+      return this;
+    }
+
+    public CreatePassiveSellOfferOp build() {
+      CreatePassiveSellOfferOp val = new CreatePassiveSellOfferOp();
+      val.setSelling(selling);
+      val.setBuying(buying);
+      val.setAmount(amount);
+      val.setPrice(price);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Curve25519Public.java
+++ b/src/main/java/org/stellar/sdk/xdr/Curve25519Public.java
@@ -45,11 +45,26 @@ public class Curve25519Public implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Curve25519Public)) {
+    if (!(object instanceof Curve25519Public)) {
       return false;
     }
 
     Curve25519Public other = (Curve25519Public) object;
     return Arrays.equals(this.key, other.key);
+  }
+
+  public static final class Builder {
+    private byte[] key;
+
+    public Builder key(byte[] key) {
+      this.key = key;
+      return this;
+    }
+
+    public Curve25519Public build() {
+      Curve25519Public val = new Curve25519Public();
+      val.setKey(key);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Curve25519Secret.java
+++ b/src/main/java/org/stellar/sdk/xdr/Curve25519Secret.java
@@ -45,11 +45,26 @@ public class Curve25519Secret implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Curve25519Secret)) {
+    if (!(object instanceof Curve25519Secret)) {
       return false;
     }
 
     Curve25519Secret other = (Curve25519Secret) object;
     return Arrays.equals(this.key, other.key);
+  }
+
+  public static final class Builder {
+    private byte[] key;
+
+    public Builder key(byte[] key) {
+      this.key = key;
+      return this;
+    }
+
+    public Curve25519Secret build() {
+      Curve25519Secret val = new Curve25519Secret();
+      val.setKey(key);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/DataEntry.java
+++ b/src/main/java/org/stellar/sdk/xdr/DataEntry.java
@@ -79,12 +79,48 @@ public class DataEntry implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof DataEntry)) {
+    if (!(object instanceof DataEntry)) {
       return false;
     }
 
     DataEntry other = (DataEntry) object;
     return Objects.equal(this.accountID, other.accountID) && Objects.equal(this.dataName, other.dataName) && Objects.equal(this.dataValue, other.dataValue) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private AccountID accountID;
+    private String64 dataName;
+    private DataValue dataValue;
+    private DataEntryExt ext;
+
+    public Builder accountID(AccountID accountID) {
+      this.accountID = accountID;
+      return this;
+    }
+
+    public Builder dataName(String64 dataName) {
+      this.dataName = dataName;
+      return this;
+    }
+
+    public Builder dataValue(DataValue dataValue) {
+      this.dataValue = dataValue;
+      return this;
+    }
+
+    public Builder ext(DataEntryExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public DataEntry build() {
+      DataEntry val = new DataEntry();
+      val.setAccountID(accountID);
+      val.setDataName(dataName);
+      val.setDataValue(dataValue);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class DataEntryExt {
@@ -96,6 +132,22 @@ public class DataEntry implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public DataEntryExt build() {
+        DataEntryExt val = new DataEntryExt();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, DataEntryExt encodedDataEntryExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -124,7 +176,7 @@ public class DataEntry implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof DataEntryExt)) {
+      if (!(object instanceof DataEntryExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/DataValue.java
+++ b/src/main/java/org/stellar/sdk/xdr/DataValue.java
@@ -15,34 +15,46 @@ import java.util.Arrays;
 //  ===========================================================================
 public class DataValue implements XdrElement {
   private byte[] DataValue;
+
+  public DataValue() {}
+
+  public DataValue(byte[] DataValue) {
+    this.DataValue = DataValue;
+  }
+
   public byte[] getDataValue() {
     return this.DataValue;
   }
+
   public void setDataValue(byte[] value) {
     this.DataValue = value;
   }
+
   public static void encode(XdrDataOutputStream stream, DataValue  encodedDataValue) throws IOException {
-  int DataValuesize = encodedDataValue.DataValue.length;
-  stream.writeInt(DataValuesize);
-  stream.write(encodedDataValue.getDataValue(), 0, DataValuesize);
+    int DataValuesize = encodedDataValue.DataValue.length;
+    stream.writeInt(DataValuesize);
+    stream.write(encodedDataValue.getDataValue(), 0, DataValuesize);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static DataValue decode(XdrDataInputStream stream) throws IOException {
     DataValue decodedDataValue = new DataValue();
-  int DataValuesize = stream.readInt();
-  decodedDataValue.DataValue = new byte[DataValuesize];
-  stream.read(decodedDataValue.DataValue, 0, DataValuesize);
+    int DataValuesize = stream.readInt();
+    decodedDataValue.DataValue = new byte[DataValuesize];
+    stream.read(decodedDataValue.DataValue, 0, DataValuesize);
     return decodedDataValue;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.DataValue);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof DataValue)) {
+    if (!(object instanceof DataValue)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/DecoratedSignature.java
+++ b/src/main/java/org/stellar/sdk/xdr/DecoratedSignature.java
@@ -52,11 +52,33 @@ public class DecoratedSignature implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof DecoratedSignature)) {
+    if (!(object instanceof DecoratedSignature)) {
       return false;
     }
 
     DecoratedSignature other = (DecoratedSignature) object;
     return Objects.equal(this.hint, other.hint) && Objects.equal(this.signature, other.signature);
+  }
+
+  public static final class Builder {
+    private SignatureHint hint;
+    private Signature signature;
+
+    public Builder hint(SignatureHint hint) {
+      this.hint = hint;
+      return this;
+    }
+
+    public Builder signature(Signature signature) {
+      this.signature = signature;
+      return this;
+    }
+
+    public DecoratedSignature build() {
+      DecoratedSignature val = new DecoratedSignature();
+      val.setHint(hint);
+      val.setSignature(signature);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/DontHave.java
+++ b/src/main/java/org/stellar/sdk/xdr/DontHave.java
@@ -52,11 +52,33 @@ public class DontHave implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof DontHave)) {
+    if (!(object instanceof DontHave)) {
       return false;
     }
 
     DontHave other = (DontHave) object;
     return Objects.equal(this.type, other.type) && Objects.equal(this.reqHash, other.reqHash);
+  }
+
+  public static final class Builder {
+    private MessageType type;
+    private Uint256 reqHash;
+
+    public Builder type(MessageType type) {
+      this.type = type;
+      return this;
+    }
+
+    public Builder reqHash(Uint256 reqHash) {
+      this.reqHash = reqHash;
+      return this;
+    }
+
+    public DontHave build() {
+      DontHave val = new DontHave();
+      val.setType(type);
+      val.setReqHash(reqHash);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/EncryptedBody.java
+++ b/src/main/java/org/stellar/sdk/xdr/EncryptedBody.java
@@ -15,34 +15,46 @@ import java.util.Arrays;
 //  ===========================================================================
 public class EncryptedBody implements XdrElement {
   private byte[] EncryptedBody;
+
+  public EncryptedBody() {}
+
+  public EncryptedBody(byte[] EncryptedBody) {
+    this.EncryptedBody = EncryptedBody;
+  }
+
   public byte[] getEncryptedBody() {
     return this.EncryptedBody;
   }
+
   public void setEncryptedBody(byte[] value) {
     this.EncryptedBody = value;
   }
+
   public static void encode(XdrDataOutputStream stream, EncryptedBody  encodedEncryptedBody) throws IOException {
-  int EncryptedBodysize = encodedEncryptedBody.EncryptedBody.length;
-  stream.writeInt(EncryptedBodysize);
-  stream.write(encodedEncryptedBody.getEncryptedBody(), 0, EncryptedBodysize);
+    int EncryptedBodysize = encodedEncryptedBody.EncryptedBody.length;
+    stream.writeInt(EncryptedBodysize);
+    stream.write(encodedEncryptedBody.getEncryptedBody(), 0, EncryptedBodysize);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static EncryptedBody decode(XdrDataInputStream stream) throws IOException {
     EncryptedBody decodedEncryptedBody = new EncryptedBody();
-  int EncryptedBodysize = stream.readInt();
-  decodedEncryptedBody.EncryptedBody = new byte[EncryptedBodysize];
-  stream.read(decodedEncryptedBody.EncryptedBody, 0, EncryptedBodysize);
+    int EncryptedBodysize = stream.readInt();
+    decodedEncryptedBody.EncryptedBody = new byte[EncryptedBodysize];
+    stream.read(decodedEncryptedBody.EncryptedBody, 0, EncryptedBodysize);
     return decodedEncryptedBody;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.EncryptedBody);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof EncryptedBody)) {
+    if (!(object instanceof EncryptedBody)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/EndSponsoringFutureReservesResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/EndSponsoringFutureReservesResult.java
@@ -28,6 +28,22 @@ public class EndSponsoringFutureReservesResult implements XdrElement {
   public void setDiscriminant(EndSponsoringFutureReservesResultCode value) {
     this.code = value;
   }
+
+  public static final class Builder {
+    private EndSponsoringFutureReservesResultCode discriminant;
+
+    public Builder discriminant(EndSponsoringFutureReservesResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public EndSponsoringFutureReservesResult build() {
+      EndSponsoringFutureReservesResult val = new EndSponsoringFutureReservesResult();
+      val.setDiscriminant(discriminant);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, EndSponsoringFutureReservesResult encodedEndSponsoringFutureReservesResult) throws IOException {
   //Xdrgen::AST::Identifier
   //EndSponsoringFutureReservesResultCode
@@ -60,7 +76,7 @@ public class EndSponsoringFutureReservesResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof EndSponsoringFutureReservesResult)) {
+    if (!(object instanceof EndSponsoringFutureReservesResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/Error.java
+++ b/src/main/java/org/stellar/sdk/xdr/Error.java
@@ -52,11 +52,33 @@ public class Error implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Error)) {
+    if (!(object instanceof Error)) {
       return false;
     }
 
     Error other = (Error) object;
     return Objects.equal(this.code, other.code) && Objects.equal(this.msg, other.msg);
+  }
+
+  public static final class Builder {
+    private ErrorCode code;
+    private XdrString msg;
+
+    public Builder code(ErrorCode code) {
+      this.code = code;
+      return this;
+    }
+
+    public Builder msg(XdrString msg) {
+      this.msg = msg;
+      return this;
+    }
+
+    public Error build() {
+      Error val = new Error();
+      val.setCode(code);
+      val.setMsg(msg);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/FeeBumpTransaction.java
+++ b/src/main/java/org/stellar/sdk/xdr/FeeBumpTransaction.java
@@ -82,12 +82,48 @@ public class FeeBumpTransaction implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof FeeBumpTransaction)) {
+    if (!(object instanceof FeeBumpTransaction)) {
       return false;
     }
 
     FeeBumpTransaction other = (FeeBumpTransaction) object;
     return Objects.equal(this.feeSource, other.feeSource) && Objects.equal(this.fee, other.fee) && Objects.equal(this.innerTx, other.innerTx) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private MuxedAccount feeSource;
+    private Int64 fee;
+    private FeeBumpTransactionInnerTx innerTx;
+    private FeeBumpTransactionExt ext;
+
+    public Builder feeSource(MuxedAccount feeSource) {
+      this.feeSource = feeSource;
+      return this;
+    }
+
+    public Builder fee(Int64 fee) {
+      this.fee = fee;
+      return this;
+    }
+
+    public Builder innerTx(FeeBumpTransactionInnerTx innerTx) {
+      this.innerTx = innerTx;
+      return this;
+    }
+
+    public Builder ext(FeeBumpTransactionExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public FeeBumpTransaction build() {
+      FeeBumpTransaction val = new FeeBumpTransaction();
+      val.setFeeSource(feeSource);
+      val.setFee(fee);
+      val.setInnerTx(innerTx);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class FeeBumpTransactionInnerTx {
@@ -106,6 +142,29 @@ public class FeeBumpTransaction implements XdrElement {
     public void setV1(TransactionV1Envelope value) {
       this.v1 = value;
     }
+
+    public static final class Builder {
+      private EnvelopeType discriminant;
+      private TransactionV1Envelope v1;
+
+      public Builder discriminant(EnvelopeType discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder v1(TransactionV1Envelope v1) {
+        this.v1 = v1;
+        return this;
+      }
+
+      public FeeBumpTransactionInnerTx build() {
+        FeeBumpTransactionInnerTx val = new FeeBumpTransactionInnerTx();
+        val.setDiscriminant(discriminant);
+        val.setV1(v1);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, FeeBumpTransactionInnerTx encodedFeeBumpTransactionInnerTx) throws IOException {
     //Xdrgen::AST::Identifier
     //EnvelopeType
@@ -136,7 +195,7 @@ public class FeeBumpTransaction implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof FeeBumpTransactionInnerTx)) {
+      if (!(object instanceof FeeBumpTransactionInnerTx)) {
         return false;
       }
 
@@ -154,6 +213,22 @@ public class FeeBumpTransaction implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public FeeBumpTransactionExt build() {
+        FeeBumpTransactionExt val = new FeeBumpTransactionExt();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, FeeBumpTransactionExt encodedFeeBumpTransactionExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -182,7 +257,7 @@ public class FeeBumpTransaction implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof FeeBumpTransactionExt)) {
+      if (!(object instanceof FeeBumpTransactionExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/FeeBumpTransactionEnvelope.java
+++ b/src/main/java/org/stellar/sdk/xdr/FeeBumpTransactionEnvelope.java
@@ -63,11 +63,33 @@ public class FeeBumpTransactionEnvelope implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof FeeBumpTransactionEnvelope)) {
+    if (!(object instanceof FeeBumpTransactionEnvelope)) {
       return false;
     }
 
     FeeBumpTransactionEnvelope other = (FeeBumpTransactionEnvelope) object;
     return Objects.equal(this.tx, other.tx) && Arrays.equals(this.signatures, other.signatures);
+  }
+
+  public static final class Builder {
+    private FeeBumpTransaction tx;
+    private DecoratedSignature[] signatures;
+
+    public Builder tx(FeeBumpTransaction tx) {
+      this.tx = tx;
+      return this;
+    }
+
+    public Builder signatures(DecoratedSignature[] signatures) {
+      this.signatures = signatures;
+      return this;
+    }
+
+    public FeeBumpTransactionEnvelope build() {
+      FeeBumpTransactionEnvelope val = new FeeBumpTransactionEnvelope();
+      val.setTx(tx);
+      val.setSignatures(signatures);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Hash.java
+++ b/src/main/java/org/stellar/sdk/xdr/Hash.java
@@ -15,33 +15,45 @@ import java.util.Arrays;
 //  ===========================================================================
 public class Hash implements XdrElement {
   private byte[] Hash;
+
+  public Hash() {}
+
+  public Hash(byte[] Hash) {
+    this.Hash = Hash;
+  }
+
   public byte[] getHash() {
     return this.Hash;
   }
+
   public void setHash(byte[] value) {
     this.Hash = value;
   }
+
   public static void encode(XdrDataOutputStream stream, Hash  encodedHash) throws IOException {
-  int Hashsize = encodedHash.Hash.length;
-  stream.write(encodedHash.getHash(), 0, Hashsize);
+    int Hashsize = encodedHash.Hash.length;
+    stream.write(encodedHash.getHash(), 0, Hashsize);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static Hash decode(XdrDataInputStream stream) throws IOException {
     Hash decodedHash = new Hash();
-  int Hashsize = 32;
-  decodedHash.Hash = new byte[Hashsize];
-  stream.read(decodedHash.Hash, 0, Hashsize);
+    int Hashsize = 32;
+    decodedHash.Hash = new byte[Hashsize];
+    stream.read(decodedHash.Hash, 0, Hashsize);
     return decodedHash;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.Hash);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Hash)) {
+    if (!(object instanceof Hash)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/Hello.java
+++ b/src/main/java/org/stellar/sdk/xdr/Hello.java
@@ -122,11 +122,82 @@ public class Hello implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Hello)) {
+    if (!(object instanceof Hello)) {
       return false;
     }
 
     Hello other = (Hello) object;
     return Objects.equal(this.ledgerVersion, other.ledgerVersion) && Objects.equal(this.overlayVersion, other.overlayVersion) && Objects.equal(this.overlayMinVersion, other.overlayMinVersion) && Objects.equal(this.networkID, other.networkID) && Objects.equal(this.versionStr, other.versionStr) && Objects.equal(this.listeningPort, other.listeningPort) && Objects.equal(this.peerID, other.peerID) && Objects.equal(this.cert, other.cert) && Objects.equal(this.nonce, other.nonce);
+  }
+
+  public static final class Builder {
+    private Uint32 ledgerVersion;
+    private Uint32 overlayVersion;
+    private Uint32 overlayMinVersion;
+    private Hash networkID;
+    private XdrString versionStr;
+    private Integer listeningPort;
+    private NodeID peerID;
+    private AuthCert cert;
+    private Uint256 nonce;
+
+    public Builder ledgerVersion(Uint32 ledgerVersion) {
+      this.ledgerVersion = ledgerVersion;
+      return this;
+    }
+
+    public Builder overlayVersion(Uint32 overlayVersion) {
+      this.overlayVersion = overlayVersion;
+      return this;
+    }
+
+    public Builder overlayMinVersion(Uint32 overlayMinVersion) {
+      this.overlayMinVersion = overlayMinVersion;
+      return this;
+    }
+
+    public Builder networkID(Hash networkID) {
+      this.networkID = networkID;
+      return this;
+    }
+
+    public Builder versionStr(XdrString versionStr) {
+      this.versionStr = versionStr;
+      return this;
+    }
+
+    public Builder listeningPort(Integer listeningPort) {
+      this.listeningPort = listeningPort;
+      return this;
+    }
+
+    public Builder peerID(NodeID peerID) {
+      this.peerID = peerID;
+      return this;
+    }
+
+    public Builder cert(AuthCert cert) {
+      this.cert = cert;
+      return this;
+    }
+
+    public Builder nonce(Uint256 nonce) {
+      this.nonce = nonce;
+      return this;
+    }
+
+    public Hello build() {
+      Hello val = new Hello();
+      val.setLedgerVersion(ledgerVersion);
+      val.setOverlayVersion(overlayVersion);
+      val.setOverlayMinVersion(overlayMinVersion);
+      val.setNetworkID(networkID);
+      val.setVersionStr(versionStr);
+      val.setListeningPort(listeningPort);
+      val.setPeerID(peerID);
+      val.setCert(cert);
+      val.setNonce(nonce);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/HmacSha256Key.java
+++ b/src/main/java/org/stellar/sdk/xdr/HmacSha256Key.java
@@ -45,11 +45,26 @@ public class HmacSha256Key implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof HmacSha256Key)) {
+    if (!(object instanceof HmacSha256Key)) {
       return false;
     }
 
     HmacSha256Key other = (HmacSha256Key) object;
     return Arrays.equals(this.key, other.key);
+  }
+
+  public static final class Builder {
+    private byte[] key;
+
+    public Builder key(byte[] key) {
+      this.key = key;
+      return this;
+    }
+
+    public HmacSha256Key build() {
+      HmacSha256Key val = new HmacSha256Key();
+      val.setKey(key);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/HmacSha256Mac.java
+++ b/src/main/java/org/stellar/sdk/xdr/HmacSha256Mac.java
@@ -45,11 +45,26 @@ public class HmacSha256Mac implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof HmacSha256Mac)) {
+    if (!(object instanceof HmacSha256Mac)) {
       return false;
     }
 
     HmacSha256Mac other = (HmacSha256Mac) object;
     return Arrays.equals(this.mac, other.mac);
+  }
+
+  public static final class Builder {
+    private byte[] mac;
+
+    public Builder mac(byte[] mac) {
+      this.mac = mac;
+      return this;
+    }
+
+    public HmacSha256Mac build() {
+      HmacSha256Mac val = new HmacSha256Mac();
+      val.setMac(mac);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/InflationPayout.java
+++ b/src/main/java/org/stellar/sdk/xdr/InflationPayout.java
@@ -52,11 +52,33 @@ public class InflationPayout implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof InflationPayout)) {
+    if (!(object instanceof InflationPayout)) {
       return false;
     }
 
     InflationPayout other = (InflationPayout) object;
     return Objects.equal(this.destination, other.destination) && Objects.equal(this.amount, other.amount);
+  }
+
+  public static final class Builder {
+    private AccountID destination;
+    private Int64 amount;
+
+    public Builder destination(AccountID destination) {
+      this.destination = destination;
+      return this;
+    }
+
+    public Builder amount(Int64 amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    public InflationPayout build() {
+      InflationPayout val = new InflationPayout();
+      val.setDestination(destination);
+      val.setAmount(amount);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/InflationResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/InflationResult.java
@@ -36,6 +36,29 @@ public class InflationResult implements XdrElement {
   public void setPayouts(InflationPayout[] value) {
     this.payouts = value;
   }
+
+  public static final class Builder {
+    private InflationResultCode discriminant;
+    private InflationPayout[] payouts;
+
+    public Builder discriminant(InflationResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder payouts(InflationPayout[] payouts) {
+      this.payouts = payouts;
+      return this;
+    }
+
+    public InflationResult build() {
+      InflationResult val = new InflationResult();
+      val.setDiscriminant(discriminant);
+      val.setPayouts(payouts);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, InflationResult encodedInflationResult) throws IOException {
   //Xdrgen::AST::Identifier
   //InflationResultCode
@@ -78,7 +101,7 @@ public class InflationResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof InflationResult)) {
+    if (!(object instanceof InflationResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/InnerTransactionResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/InnerTransactionResult.java
@@ -93,12 +93,41 @@ public class InnerTransactionResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof InnerTransactionResult)) {
+    if (!(object instanceof InnerTransactionResult)) {
       return false;
     }
 
     InnerTransactionResult other = (InnerTransactionResult) object;
     return Objects.equal(this.feeCharged, other.feeCharged) && Objects.equal(this.result, other.result) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private Int64 feeCharged;
+    private InnerTransactionResultResult result;
+    private InnerTransactionResultExt ext;
+
+    public Builder feeCharged(Int64 feeCharged) {
+      this.feeCharged = feeCharged;
+      return this;
+    }
+
+    public Builder result(InnerTransactionResultResult result) {
+      this.result = result;
+      return this;
+    }
+
+    public Builder ext(InnerTransactionResultExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public InnerTransactionResult build() {
+      InnerTransactionResult val = new InnerTransactionResult();
+      val.setFeeCharged(feeCharged);
+      val.setResult(result);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class InnerTransactionResultResult {
@@ -117,6 +146,29 @@ public class InnerTransactionResult implements XdrElement {
     public void setResults(OperationResult[] value) {
       this.results = value;
     }
+
+    public static final class Builder {
+      private TransactionResultCode discriminant;
+      private OperationResult[] results;
+
+      public Builder discriminant(TransactionResultCode discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder results(OperationResult[] results) {
+        this.results = results;
+        return this;
+      }
+
+      public InnerTransactionResultResult build() {
+        InnerTransactionResultResult val = new InnerTransactionResultResult();
+        val.setDiscriminant(discriminant);
+        val.setResults(results);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, InnerTransactionResultResult encodedInnerTransactionResultResult) throws IOException {
     //Xdrgen::AST::Identifier
     //TransactionResultCode
@@ -183,7 +235,7 @@ public class InnerTransactionResult implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof InnerTransactionResultResult)) {
+      if (!(object instanceof InnerTransactionResultResult)) {
         return false;
       }
 
@@ -201,6 +253,22 @@ public class InnerTransactionResult implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public InnerTransactionResultExt build() {
+        InnerTransactionResultExt val = new InnerTransactionResultExt();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, InnerTransactionResultExt encodedInnerTransactionResultExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -229,7 +297,7 @@ public class InnerTransactionResult implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof InnerTransactionResultExt)) {
+      if (!(object instanceof InnerTransactionResultExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/InnerTransactionResultPair.java
+++ b/src/main/java/org/stellar/sdk/xdr/InnerTransactionResultPair.java
@@ -52,11 +52,33 @@ public class InnerTransactionResultPair implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof InnerTransactionResultPair)) {
+    if (!(object instanceof InnerTransactionResultPair)) {
       return false;
     }
 
     InnerTransactionResultPair other = (InnerTransactionResultPair) object;
     return Objects.equal(this.transactionHash, other.transactionHash) && Objects.equal(this.result, other.result);
+  }
+
+  public static final class Builder {
+    private Hash transactionHash;
+    private InnerTransactionResult result;
+
+    public Builder transactionHash(Hash transactionHash) {
+      this.transactionHash = transactionHash;
+      return this;
+    }
+
+    public Builder result(InnerTransactionResult result) {
+      this.result = result;
+      return this;
+    }
+
+    public InnerTransactionResultPair build() {
+      InnerTransactionResultPair val = new InnerTransactionResultPair();
+      val.setTransactionHash(transactionHash);
+      val.setResult(result);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Int32.java
+++ b/src/main/java/org/stellar/sdk/xdr/Int32.java
@@ -15,30 +15,42 @@ import com.google.common.base.Objects;
 //  ===========================================================================
 public class Int32 implements XdrElement {
   private Integer int32;
+
+  public Int32() {}
+
+  public Int32(Integer int32) {
+    this.int32 = int32;
+  }
+
   public Integer getInt32() {
     return this.int32;
   }
+
   public void setInt32(Integer value) {
     this.int32 = value;
   }
+
   public static void encode(XdrDataOutputStream stream, Int32  encodedInt32) throws IOException {
-  stream.writeInt(encodedInt32.int32);
+    stream.writeInt(encodedInt32.int32);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static Int32 decode(XdrDataInputStream stream) throws IOException {
     Int32 decodedInt32 = new Int32();
-  decodedInt32.int32 = stream.readInt();
+    decodedInt32.int32 = stream.readInt();
     return decodedInt32;
   }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(this.int32);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Int32)) {
+    if (!(object instanceof Int32)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/Int64.java
+++ b/src/main/java/org/stellar/sdk/xdr/Int64.java
@@ -15,30 +15,42 @@ import com.google.common.base.Objects;
 //  ===========================================================================
 public class Int64 implements XdrElement {
   private Long int64;
+
+  public Int64() {}
+
+  public Int64(Long int64) {
+    this.int64 = int64;
+  }
+
   public Long getInt64() {
     return this.int64;
   }
+
   public void setInt64(Long value) {
     this.int64 = value;
   }
+
   public static void encode(XdrDataOutputStream stream, Int64  encodedInt64) throws IOException {
-  stream.writeLong(encodedInt64.int64);
+    stream.writeLong(encodedInt64.int64);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static Int64 decode(XdrDataInputStream stream) throws IOException {
     Int64 decodedInt64 = new Int64();
-  decodedInt64.int64 = stream.readLong();
+    decodedInt64.int64 = stream.readLong();
     return decodedInt64;
   }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(this.int64);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Int64)) {
+    if (!(object instanceof Int64)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/LedgerCloseMeta.java
+++ b/src/main/java/org/stellar/sdk/xdr/LedgerCloseMeta.java
@@ -33,6 +33,29 @@ public class LedgerCloseMeta implements XdrElement {
   public void setV0(LedgerCloseMetaV0 value) {
     this.v0 = value;
   }
+
+  public static final class Builder {
+    private Integer discriminant;
+    private LedgerCloseMetaV0 v0;
+
+    public Builder discriminant(Integer discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder v0(LedgerCloseMetaV0 v0) {
+      this.v0 = v0;
+      return this;
+    }
+
+    public LedgerCloseMeta build() {
+      LedgerCloseMeta val = new LedgerCloseMeta();
+      val.setDiscriminant(discriminant);
+      val.setV0(v0);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, LedgerCloseMeta encodedLedgerCloseMeta) throws IOException {
   //Xdrgen::AST::Typespecs::Int
   //Integer
@@ -63,7 +86,7 @@ public class LedgerCloseMeta implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof LedgerCloseMeta)) {
+    if (!(object instanceof LedgerCloseMeta)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/LedgerCloseMetaV0.java
+++ b/src/main/java/org/stellar/sdk/xdr/LedgerCloseMetaV0.java
@@ -116,11 +116,54 @@ public class LedgerCloseMetaV0 implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof LedgerCloseMetaV0)) {
+    if (!(object instanceof LedgerCloseMetaV0)) {
       return false;
     }
 
     LedgerCloseMetaV0 other = (LedgerCloseMetaV0) object;
     return Objects.equal(this.ledgerHeader, other.ledgerHeader) && Objects.equal(this.txSet, other.txSet) && Arrays.equals(this.txProcessing, other.txProcessing) && Arrays.equals(this.upgradesProcessing, other.upgradesProcessing) && Arrays.equals(this.scpInfo, other.scpInfo);
+  }
+
+  public static final class Builder {
+    private LedgerHeaderHistoryEntry ledgerHeader;
+    private TransactionSet txSet;
+    private TransactionResultMeta[] txProcessing;
+    private UpgradeEntryMeta[] upgradesProcessing;
+    private SCPHistoryEntry[] scpInfo;
+
+    public Builder ledgerHeader(LedgerHeaderHistoryEntry ledgerHeader) {
+      this.ledgerHeader = ledgerHeader;
+      return this;
+    }
+
+    public Builder txSet(TransactionSet txSet) {
+      this.txSet = txSet;
+      return this;
+    }
+
+    public Builder txProcessing(TransactionResultMeta[] txProcessing) {
+      this.txProcessing = txProcessing;
+      return this;
+    }
+
+    public Builder upgradesProcessing(UpgradeEntryMeta[] upgradesProcessing) {
+      this.upgradesProcessing = upgradesProcessing;
+      return this;
+    }
+
+    public Builder scpInfo(SCPHistoryEntry[] scpInfo) {
+      this.scpInfo = scpInfo;
+      return this;
+    }
+
+    public LedgerCloseMetaV0 build() {
+      LedgerCloseMetaV0 val = new LedgerCloseMetaV0();
+      val.setLedgerHeader(ledgerHeader);
+      val.setTxSet(txSet);
+      val.setTxProcessing(txProcessing);
+      val.setUpgradesProcessing(upgradesProcessing);
+      val.setScpInfo(scpInfo);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/LedgerCloseValueSignature.java
+++ b/src/main/java/org/stellar/sdk/xdr/LedgerCloseValueSignature.java
@@ -52,11 +52,33 @@ public class LedgerCloseValueSignature implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof LedgerCloseValueSignature)) {
+    if (!(object instanceof LedgerCloseValueSignature)) {
       return false;
     }
 
     LedgerCloseValueSignature other = (LedgerCloseValueSignature) object;
     return Objects.equal(this.nodeID, other.nodeID) && Objects.equal(this.signature, other.signature);
+  }
+
+  public static final class Builder {
+    private NodeID nodeID;
+    private Signature signature;
+
+    public Builder nodeID(NodeID nodeID) {
+      this.nodeID = nodeID;
+      return this;
+    }
+
+    public Builder signature(Signature signature) {
+      this.signature = signature;
+      return this;
+    }
+
+    public LedgerCloseValueSignature build() {
+      LedgerCloseValueSignature val = new LedgerCloseValueSignature();
+      val.setNodeID(nodeID);
+      val.setSignature(signature);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/LedgerEntry.java
+++ b/src/main/java/org/stellar/sdk/xdr/LedgerEntry.java
@@ -85,12 +85,41 @@ public class LedgerEntry implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof LedgerEntry)) {
+    if (!(object instanceof LedgerEntry)) {
       return false;
     }
 
     LedgerEntry other = (LedgerEntry) object;
     return Objects.equal(this.lastModifiedLedgerSeq, other.lastModifiedLedgerSeq) && Objects.equal(this.data, other.data) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private Uint32 lastModifiedLedgerSeq;
+    private LedgerEntryData data;
+    private LedgerEntryExt ext;
+
+    public Builder lastModifiedLedgerSeq(Uint32 lastModifiedLedgerSeq) {
+      this.lastModifiedLedgerSeq = lastModifiedLedgerSeq;
+      return this;
+    }
+
+    public Builder data(LedgerEntryData data) {
+      this.data = data;
+      return this;
+    }
+
+    public Builder ext(LedgerEntryExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public LedgerEntry build() {
+      LedgerEntry val = new LedgerEntry();
+      val.setLastModifiedLedgerSeq(lastModifiedLedgerSeq);
+      val.setData(data);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class LedgerEntryData {
@@ -137,6 +166,57 @@ public class LedgerEntry implements XdrElement {
     public void setClaimableBalance(ClaimableBalanceEntry value) {
       this.claimableBalance = value;
     }
+
+    public static final class Builder {
+      private LedgerEntryType discriminant;
+      private AccountEntry account;
+      private TrustLineEntry trustLine;
+      private OfferEntry offer;
+      private DataEntry data;
+      private ClaimableBalanceEntry claimableBalance;
+
+      public Builder discriminant(LedgerEntryType discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder account(AccountEntry account) {
+        this.account = account;
+        return this;
+      }
+
+      public Builder trustLine(TrustLineEntry trustLine) {
+        this.trustLine = trustLine;
+        return this;
+      }
+
+      public Builder offer(OfferEntry offer) {
+        this.offer = offer;
+        return this;
+      }
+
+      public Builder data(DataEntry data) {
+        this.data = data;
+        return this;
+      }
+
+      public Builder claimableBalance(ClaimableBalanceEntry claimableBalance) {
+        this.claimableBalance = claimableBalance;
+        return this;
+      }
+
+      public LedgerEntryData build() {
+        LedgerEntryData val = new LedgerEntryData();
+        val.setDiscriminant(discriminant);
+        val.setAccount(account);
+        val.setTrustLine(trustLine);
+        val.setOffer(offer);
+        val.setData(data);
+        val.setClaimableBalance(claimableBalance);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, LedgerEntryData encodedLedgerEntryData) throws IOException {
     //Xdrgen::AST::Identifier
     //LedgerEntryType
@@ -191,7 +271,7 @@ public class LedgerEntry implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof LedgerEntryData)) {
+      if (!(object instanceof LedgerEntryData)) {
         return false;
       }
 
@@ -216,6 +296,29 @@ public class LedgerEntry implements XdrElement {
     public void setV1(LedgerEntryExtensionV1 value) {
       this.v1 = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+      private LedgerEntryExtensionV1 v1;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder v1(LedgerEntryExtensionV1 v1) {
+        this.v1 = v1;
+        return this;
+      }
+
+      public LedgerEntryExt build() {
+        LedgerEntryExt val = new LedgerEntryExt();
+        val.setDiscriminant(discriminant);
+        val.setV1(v1);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, LedgerEntryExt encodedLedgerEntryExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -250,7 +353,7 @@ public class LedgerEntry implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof LedgerEntryExt)) {
+      if (!(object instanceof LedgerEntryExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/LedgerEntryChange.java
+++ b/src/main/java/org/stellar/sdk/xdr/LedgerEntryChange.java
@@ -60,6 +60,50 @@ public class LedgerEntryChange implements XdrElement {
   public void setState(LedgerEntry value) {
     this.state = value;
   }
+
+  public static final class Builder {
+    private LedgerEntryChangeType discriminant;
+    private LedgerEntry created;
+    private LedgerEntry updated;
+    private LedgerKey removed;
+    private LedgerEntry state;
+
+    public Builder discriminant(LedgerEntryChangeType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder created(LedgerEntry created) {
+      this.created = created;
+      return this;
+    }
+
+    public Builder updated(LedgerEntry updated) {
+      this.updated = updated;
+      return this;
+    }
+
+    public Builder removed(LedgerKey removed) {
+      this.removed = removed;
+      return this;
+    }
+
+    public Builder state(LedgerEntry state) {
+      this.state = state;
+      return this;
+    }
+
+    public LedgerEntryChange build() {
+      LedgerEntryChange val = new LedgerEntryChange();
+      val.setDiscriminant(discriminant);
+      val.setCreated(created);
+      val.setUpdated(updated);
+      val.setRemoved(removed);
+      val.setState(state);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, LedgerEntryChange encodedLedgerEntryChange) throws IOException {
   //Xdrgen::AST::Identifier
   //LedgerEntryChangeType
@@ -108,7 +152,7 @@ public class LedgerEntryChange implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof LedgerEntryChange)) {
+    if (!(object instanceof LedgerEntryChange)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/LedgerEntryChanges.java
+++ b/src/main/java/org/stellar/sdk/xdr/LedgerEntryChanges.java
@@ -15,38 +15,50 @@ import java.util.Arrays;
 //  ===========================================================================
 public class LedgerEntryChanges implements XdrElement {
   private LedgerEntryChange[] LedgerEntryChanges;
+
+  public LedgerEntryChanges() {}
+
+  public LedgerEntryChanges(LedgerEntryChange[] LedgerEntryChanges) {
+    this.LedgerEntryChanges = LedgerEntryChanges;
+  }
+
   public LedgerEntryChange[] getLedgerEntryChanges() {
     return this.LedgerEntryChanges;
   }
+
   public void setLedgerEntryChanges(LedgerEntryChange[] value) {
     this.LedgerEntryChanges = value;
   }
+
   public static void encode(XdrDataOutputStream stream, LedgerEntryChanges  encodedLedgerEntryChanges) throws IOException {
-  int LedgerEntryChangessize = encodedLedgerEntryChanges.getLedgerEntryChanges().length;
-  stream.writeInt(LedgerEntryChangessize);
-  for (int i = 0; i < LedgerEntryChangessize; i++) {
-    LedgerEntryChange.encode(stream, encodedLedgerEntryChanges.LedgerEntryChanges[i]);
+    int LedgerEntryChangessize = encodedLedgerEntryChanges.getLedgerEntryChanges().length;
+    stream.writeInt(LedgerEntryChangessize);
+    for (int i = 0; i < LedgerEntryChangessize; i++) {
+      LedgerEntryChange.encode(stream, encodedLedgerEntryChanges.LedgerEntryChanges[i]);
+    }
   }
-  }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static LedgerEntryChanges decode(XdrDataInputStream stream) throws IOException {
     LedgerEntryChanges decodedLedgerEntryChanges = new LedgerEntryChanges();
-  int LedgerEntryChangessize = stream.readInt();
-  decodedLedgerEntryChanges.LedgerEntryChanges = new LedgerEntryChange[LedgerEntryChangessize];
-  for (int i = 0; i < LedgerEntryChangessize; i++) {
-    decodedLedgerEntryChanges.LedgerEntryChanges[i] = LedgerEntryChange.decode(stream);
-  }
+    int LedgerEntryChangessize = stream.readInt();
+    decodedLedgerEntryChanges.LedgerEntryChanges = new LedgerEntryChange[LedgerEntryChangessize];
+    for (int i = 0; i < LedgerEntryChangessize; i++) {
+      decodedLedgerEntryChanges.LedgerEntryChanges[i] = LedgerEntryChange.decode(stream);
+    }
     return decodedLedgerEntryChanges;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.LedgerEntryChanges);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof LedgerEntryChanges)) {
+    if (!(object instanceof LedgerEntryChanges)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/LedgerEntryExtensionV1.java
+++ b/src/main/java/org/stellar/sdk/xdr/LedgerEntryExtensionV1.java
@@ -58,12 +58,34 @@ public class LedgerEntryExtensionV1 implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof LedgerEntryExtensionV1)) {
+    if (!(object instanceof LedgerEntryExtensionV1)) {
       return false;
     }
 
     LedgerEntryExtensionV1 other = (LedgerEntryExtensionV1) object;
     return Objects.equal(this.sponsoringID, other.sponsoringID) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private SponsorshipDescriptor sponsoringID;
+    private LedgerEntryExtensionV1Ext ext;
+
+    public Builder sponsoringID(SponsorshipDescriptor sponsoringID) {
+      this.sponsoringID = sponsoringID;
+      return this;
+    }
+
+    public Builder ext(LedgerEntryExtensionV1Ext ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public LedgerEntryExtensionV1 build() {
+      LedgerEntryExtensionV1 val = new LedgerEntryExtensionV1();
+      val.setSponsoringID(sponsoringID);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class LedgerEntryExtensionV1Ext {
@@ -75,6 +97,22 @@ public class LedgerEntryExtensionV1 implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public LedgerEntryExtensionV1Ext build() {
+        LedgerEntryExtensionV1Ext val = new LedgerEntryExtensionV1Ext();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, LedgerEntryExtensionV1Ext encodedLedgerEntryExtensionV1Ext) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -103,7 +141,7 @@ public class LedgerEntryExtensionV1 implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof LedgerEntryExtensionV1Ext)) {
+      if (!(object instanceof LedgerEntryExtensionV1Ext)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/LedgerHeader.java
+++ b/src/main/java/org/stellar/sdk/xdr/LedgerHeader.java
@@ -209,12 +209,125 @@ public class LedgerHeader implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof LedgerHeader)) {
+    if (!(object instanceof LedgerHeader)) {
       return false;
     }
 
     LedgerHeader other = (LedgerHeader) object;
     return Objects.equal(this.ledgerVersion, other.ledgerVersion) && Objects.equal(this.previousLedgerHash, other.previousLedgerHash) && Objects.equal(this.scpValue, other.scpValue) && Objects.equal(this.txSetResultHash, other.txSetResultHash) && Objects.equal(this.bucketListHash, other.bucketListHash) && Objects.equal(this.ledgerSeq, other.ledgerSeq) && Objects.equal(this.totalCoins, other.totalCoins) && Objects.equal(this.feePool, other.feePool) && Objects.equal(this.inflationSeq, other.inflationSeq) && Objects.equal(this.idPool, other.idPool) && Objects.equal(this.baseFee, other.baseFee) && Objects.equal(this.baseReserve, other.baseReserve) && Objects.equal(this.maxTxSetSize, other.maxTxSetSize) && Arrays.equals(this.skipList, other.skipList) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private Uint32 ledgerVersion;
+    private Hash previousLedgerHash;
+    private StellarValue scpValue;
+    private Hash txSetResultHash;
+    private Hash bucketListHash;
+    private Uint32 ledgerSeq;
+    private Int64 totalCoins;
+    private Int64 feePool;
+    private Uint32 inflationSeq;
+    private Uint64 idPool;
+    private Uint32 baseFee;
+    private Uint32 baseReserve;
+    private Uint32 maxTxSetSize;
+    private Hash[] skipList;
+    private LedgerHeaderExt ext;
+
+    public Builder ledgerVersion(Uint32 ledgerVersion) {
+      this.ledgerVersion = ledgerVersion;
+      return this;
+    }
+
+    public Builder previousLedgerHash(Hash previousLedgerHash) {
+      this.previousLedgerHash = previousLedgerHash;
+      return this;
+    }
+
+    public Builder scpValue(StellarValue scpValue) {
+      this.scpValue = scpValue;
+      return this;
+    }
+
+    public Builder txSetResultHash(Hash txSetResultHash) {
+      this.txSetResultHash = txSetResultHash;
+      return this;
+    }
+
+    public Builder bucketListHash(Hash bucketListHash) {
+      this.bucketListHash = bucketListHash;
+      return this;
+    }
+
+    public Builder ledgerSeq(Uint32 ledgerSeq) {
+      this.ledgerSeq = ledgerSeq;
+      return this;
+    }
+
+    public Builder totalCoins(Int64 totalCoins) {
+      this.totalCoins = totalCoins;
+      return this;
+    }
+
+    public Builder feePool(Int64 feePool) {
+      this.feePool = feePool;
+      return this;
+    }
+
+    public Builder inflationSeq(Uint32 inflationSeq) {
+      this.inflationSeq = inflationSeq;
+      return this;
+    }
+
+    public Builder idPool(Uint64 idPool) {
+      this.idPool = idPool;
+      return this;
+    }
+
+    public Builder baseFee(Uint32 baseFee) {
+      this.baseFee = baseFee;
+      return this;
+    }
+
+    public Builder baseReserve(Uint32 baseReserve) {
+      this.baseReserve = baseReserve;
+      return this;
+    }
+
+    public Builder maxTxSetSize(Uint32 maxTxSetSize) {
+      this.maxTxSetSize = maxTxSetSize;
+      return this;
+    }
+
+    public Builder skipList(Hash[] skipList) {
+      this.skipList = skipList;
+      return this;
+    }
+
+    public Builder ext(LedgerHeaderExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public LedgerHeader build() {
+      LedgerHeader val = new LedgerHeader();
+      val.setLedgerVersion(ledgerVersion);
+      val.setPreviousLedgerHash(previousLedgerHash);
+      val.setScpValue(scpValue);
+      val.setTxSetResultHash(txSetResultHash);
+      val.setBucketListHash(bucketListHash);
+      val.setLedgerSeq(ledgerSeq);
+      val.setTotalCoins(totalCoins);
+      val.setFeePool(feePool);
+      val.setInflationSeq(inflationSeq);
+      val.setIdPool(idPool);
+      val.setBaseFee(baseFee);
+      val.setBaseReserve(baseReserve);
+      val.setMaxTxSetSize(maxTxSetSize);
+      val.setSkipList(skipList);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class LedgerHeaderExt {
@@ -226,6 +339,22 @@ public class LedgerHeader implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public LedgerHeaderExt build() {
+        LedgerHeaderExt val = new LedgerHeaderExt();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, LedgerHeaderExt encodedLedgerHeaderExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -254,7 +383,7 @@ public class LedgerHeader implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof LedgerHeaderExt)) {
+      if (!(object instanceof LedgerHeaderExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/LedgerHeaderHistoryEntry.java
+++ b/src/main/java/org/stellar/sdk/xdr/LedgerHeaderHistoryEntry.java
@@ -69,12 +69,41 @@ public class LedgerHeaderHistoryEntry implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof LedgerHeaderHistoryEntry)) {
+    if (!(object instanceof LedgerHeaderHistoryEntry)) {
       return false;
     }
 
     LedgerHeaderHistoryEntry other = (LedgerHeaderHistoryEntry) object;
     return Objects.equal(this.hash, other.hash) && Objects.equal(this.header, other.header) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private Hash hash;
+    private LedgerHeader header;
+    private LedgerHeaderHistoryEntryExt ext;
+
+    public Builder hash(Hash hash) {
+      this.hash = hash;
+      return this;
+    }
+
+    public Builder header(LedgerHeader header) {
+      this.header = header;
+      return this;
+    }
+
+    public Builder ext(LedgerHeaderHistoryEntryExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public LedgerHeaderHistoryEntry build() {
+      LedgerHeaderHistoryEntry val = new LedgerHeaderHistoryEntry();
+      val.setHash(hash);
+      val.setHeader(header);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class LedgerHeaderHistoryEntryExt {
@@ -86,6 +115,22 @@ public class LedgerHeaderHistoryEntry implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public LedgerHeaderHistoryEntryExt build() {
+        LedgerHeaderHistoryEntryExt val = new LedgerHeaderHistoryEntryExt();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, LedgerHeaderHistoryEntryExt encodedLedgerHeaderHistoryEntryExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -114,7 +159,7 @@ public class LedgerHeaderHistoryEntry implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof LedgerHeaderHistoryEntryExt)) {
+      if (!(object instanceof LedgerHeaderHistoryEntryExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/LedgerKey.java
+++ b/src/main/java/org/stellar/sdk/xdr/LedgerKey.java
@@ -91,6 +91,57 @@ public class LedgerKey implements XdrElement {
   public void setClaimableBalance(LedgerKeyClaimableBalance value) {
     this.claimableBalance = value;
   }
+
+  public static final class Builder {
+    private LedgerEntryType discriminant;
+    private LedgerKeyAccount account;
+    private LedgerKeyTrustLine trustLine;
+    private LedgerKeyOffer offer;
+    private LedgerKeyData data;
+    private LedgerKeyClaimableBalance claimableBalance;
+
+    public Builder discriminant(LedgerEntryType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder account(LedgerKeyAccount account) {
+      this.account = account;
+      return this;
+    }
+
+    public Builder trustLine(LedgerKeyTrustLine trustLine) {
+      this.trustLine = trustLine;
+      return this;
+    }
+
+    public Builder offer(LedgerKeyOffer offer) {
+      this.offer = offer;
+      return this;
+    }
+
+    public Builder data(LedgerKeyData data) {
+      this.data = data;
+      return this;
+    }
+
+    public Builder claimableBalance(LedgerKeyClaimableBalance claimableBalance) {
+      this.claimableBalance = claimableBalance;
+      return this;
+    }
+
+    public LedgerKey build() {
+      LedgerKey val = new LedgerKey();
+      val.setDiscriminant(discriminant);
+      val.setAccount(account);
+      val.setTrustLine(trustLine);
+      val.setOffer(offer);
+      val.setData(data);
+      val.setClaimableBalance(claimableBalance);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, LedgerKey encodedLedgerKey) throws IOException {
   //Xdrgen::AST::Identifier
   //LedgerEntryType
@@ -145,7 +196,7 @@ public class LedgerKey implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof LedgerKey)) {
+    if (!(object instanceof LedgerKey)) {
       return false;
     }
 
@@ -179,12 +230,27 @@ public class LedgerKey implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof LedgerKeyAccount)) {
+      if (!(object instanceof LedgerKeyAccount)) {
         return false;
       }
 
       LedgerKeyAccount other = (LedgerKeyAccount) object;
       return Objects.equal(this.accountID, other.accountID);
+    }
+
+    public static final class Builder {
+      private AccountID accountID;
+
+      public Builder accountID(AccountID accountID) {
+        this.accountID = accountID;
+        return this;
+      }
+
+      public LedgerKeyAccount build() {
+        LedgerKeyAccount val = new LedgerKeyAccount();
+        val.setAccountID(accountID);
+        return val;
+      }
     }
 
   }
@@ -223,12 +289,34 @@ public class LedgerKey implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof LedgerKeyTrustLine)) {
+      if (!(object instanceof LedgerKeyTrustLine)) {
         return false;
       }
 
       LedgerKeyTrustLine other = (LedgerKeyTrustLine) object;
       return Objects.equal(this.accountID, other.accountID) && Objects.equal(this.asset, other.asset);
+    }
+
+    public static final class Builder {
+      private AccountID accountID;
+      private Asset asset;
+
+      public Builder accountID(AccountID accountID) {
+        this.accountID = accountID;
+        return this;
+      }
+
+      public Builder asset(Asset asset) {
+        this.asset = asset;
+        return this;
+      }
+
+      public LedgerKeyTrustLine build() {
+        LedgerKeyTrustLine val = new LedgerKeyTrustLine();
+        val.setAccountID(accountID);
+        val.setAsset(asset);
+        return val;
+      }
     }
 
   }
@@ -267,12 +355,34 @@ public class LedgerKey implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof LedgerKeyOffer)) {
+      if (!(object instanceof LedgerKeyOffer)) {
         return false;
       }
 
       LedgerKeyOffer other = (LedgerKeyOffer) object;
       return Objects.equal(this.sellerID, other.sellerID) && Objects.equal(this.offerID, other.offerID);
+    }
+
+    public static final class Builder {
+      private AccountID sellerID;
+      private Int64 offerID;
+
+      public Builder sellerID(AccountID sellerID) {
+        this.sellerID = sellerID;
+        return this;
+      }
+
+      public Builder offerID(Int64 offerID) {
+        this.offerID = offerID;
+        return this;
+      }
+
+      public LedgerKeyOffer build() {
+        LedgerKeyOffer val = new LedgerKeyOffer();
+        val.setSellerID(sellerID);
+        val.setOfferID(offerID);
+        return val;
+      }
     }
 
   }
@@ -311,12 +421,34 @@ public class LedgerKey implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof LedgerKeyData)) {
+      if (!(object instanceof LedgerKeyData)) {
         return false;
       }
 
       LedgerKeyData other = (LedgerKeyData) object;
       return Objects.equal(this.accountID, other.accountID) && Objects.equal(this.dataName, other.dataName);
+    }
+
+    public static final class Builder {
+      private AccountID accountID;
+      private String64 dataName;
+
+      public Builder accountID(AccountID accountID) {
+        this.accountID = accountID;
+        return this;
+      }
+
+      public Builder dataName(String64 dataName) {
+        this.dataName = dataName;
+        return this;
+      }
+
+      public LedgerKeyData build() {
+        LedgerKeyData val = new LedgerKeyData();
+        val.setAccountID(accountID);
+        val.setDataName(dataName);
+        return val;
+      }
     }
 
   }
@@ -346,12 +478,27 @@ public class LedgerKey implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof LedgerKeyClaimableBalance)) {
+      if (!(object instanceof LedgerKeyClaimableBalance)) {
         return false;
       }
 
       LedgerKeyClaimableBalance other = (LedgerKeyClaimableBalance) object;
       return Objects.equal(this.balanceID, other.balanceID);
+    }
+
+    public static final class Builder {
+      private ClaimableBalanceID balanceID;
+
+      public Builder balanceID(ClaimableBalanceID balanceID) {
+        this.balanceID = balanceID;
+        return this;
+      }
+
+      public LedgerKeyClaimableBalance build() {
+        LedgerKeyClaimableBalance val = new LedgerKeyClaimableBalance();
+        val.setBalanceID(balanceID);
+        return val;
+      }
     }
 
   }

--- a/src/main/java/org/stellar/sdk/xdr/LedgerSCPMessages.java
+++ b/src/main/java/org/stellar/sdk/xdr/LedgerSCPMessages.java
@@ -61,11 +61,33 @@ public class LedgerSCPMessages implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof LedgerSCPMessages)) {
+    if (!(object instanceof LedgerSCPMessages)) {
       return false;
     }
 
     LedgerSCPMessages other = (LedgerSCPMessages) object;
     return Objects.equal(this.ledgerSeq, other.ledgerSeq) && Arrays.equals(this.messages, other.messages);
+  }
+
+  public static final class Builder {
+    private Uint32 ledgerSeq;
+    private SCPEnvelope[] messages;
+
+    public Builder ledgerSeq(Uint32 ledgerSeq) {
+      this.ledgerSeq = ledgerSeq;
+      return this;
+    }
+
+    public Builder messages(SCPEnvelope[] messages) {
+      this.messages = messages;
+      return this;
+    }
+
+    public LedgerSCPMessages build() {
+      LedgerSCPMessages val = new LedgerSCPMessages();
+      val.setLedgerSeq(ledgerSeq);
+      val.setMessages(messages);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/LedgerUpgrade.java
+++ b/src/main/java/org/stellar/sdk/xdr/LedgerUpgrade.java
@@ -60,6 +60,50 @@ public class LedgerUpgrade implements XdrElement {
   public void setNewBaseReserve(Uint32 value) {
     this.newBaseReserve = value;
   }
+
+  public static final class Builder {
+    private LedgerUpgradeType discriminant;
+    private Uint32 newLedgerVersion;
+    private Uint32 newBaseFee;
+    private Uint32 newMaxTxSetSize;
+    private Uint32 newBaseReserve;
+
+    public Builder discriminant(LedgerUpgradeType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder newLedgerVersion(Uint32 newLedgerVersion) {
+      this.newLedgerVersion = newLedgerVersion;
+      return this;
+    }
+
+    public Builder newBaseFee(Uint32 newBaseFee) {
+      this.newBaseFee = newBaseFee;
+      return this;
+    }
+
+    public Builder newMaxTxSetSize(Uint32 newMaxTxSetSize) {
+      this.newMaxTxSetSize = newMaxTxSetSize;
+      return this;
+    }
+
+    public Builder newBaseReserve(Uint32 newBaseReserve) {
+      this.newBaseReserve = newBaseReserve;
+      return this;
+    }
+
+    public LedgerUpgrade build() {
+      LedgerUpgrade val = new LedgerUpgrade();
+      val.setDiscriminant(discriminant);
+      val.setNewLedgerVersion(newLedgerVersion);
+      val.setNewBaseFee(newBaseFee);
+      val.setNewMaxTxSetSize(newMaxTxSetSize);
+      val.setNewBaseReserve(newBaseReserve);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, LedgerUpgrade encodedLedgerUpgrade) throws IOException {
   //Xdrgen::AST::Identifier
   //LedgerUpgradeType
@@ -108,7 +152,7 @@ public class LedgerUpgrade implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof LedgerUpgrade)) {
+    if (!(object instanceof LedgerUpgrade)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/Liabilities.java
+++ b/src/main/java/org/stellar/sdk/xdr/Liabilities.java
@@ -52,11 +52,33 @@ public class Liabilities implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Liabilities)) {
+    if (!(object instanceof Liabilities)) {
       return false;
     }
 
     Liabilities other = (Liabilities) object;
     return Objects.equal(this.buying, other.buying) && Objects.equal(this.selling, other.selling);
+  }
+
+  public static final class Builder {
+    private Int64 buying;
+    private Int64 selling;
+
+    public Builder buying(Int64 buying) {
+      this.buying = buying;
+      return this;
+    }
+
+    public Builder selling(Int64 selling) {
+      this.selling = selling;
+      return this;
+    }
+
+    public Liabilities build() {
+      Liabilities val = new Liabilities();
+      val.setBuying(buying);
+      val.setSelling(selling);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/ManageBuyOfferOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/ManageBuyOfferOp.java
@@ -85,11 +85,54 @@ public class ManageBuyOfferOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ManageBuyOfferOp)) {
+    if (!(object instanceof ManageBuyOfferOp)) {
       return false;
     }
 
     ManageBuyOfferOp other = (ManageBuyOfferOp) object;
     return Objects.equal(this.selling, other.selling) && Objects.equal(this.buying, other.buying) && Objects.equal(this.buyAmount, other.buyAmount) && Objects.equal(this.price, other.price) && Objects.equal(this.offerID, other.offerID);
+  }
+
+  public static final class Builder {
+    private Asset selling;
+    private Asset buying;
+    private Int64 buyAmount;
+    private Price price;
+    private Int64 offerID;
+
+    public Builder selling(Asset selling) {
+      this.selling = selling;
+      return this;
+    }
+
+    public Builder buying(Asset buying) {
+      this.buying = buying;
+      return this;
+    }
+
+    public Builder buyAmount(Int64 buyAmount) {
+      this.buyAmount = buyAmount;
+      return this;
+    }
+
+    public Builder price(Price price) {
+      this.price = price;
+      return this;
+    }
+
+    public Builder offerID(Int64 offerID) {
+      this.offerID = offerID;
+      return this;
+    }
+
+    public ManageBuyOfferOp build() {
+      ManageBuyOfferOp val = new ManageBuyOfferOp();
+      val.setSelling(selling);
+      val.setBuying(buying);
+      val.setBuyAmount(buyAmount);
+      val.setPrice(price);
+      val.setOfferID(offerID);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/ManageBuyOfferResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/ManageBuyOfferResult.java
@@ -35,6 +35,29 @@ public class ManageBuyOfferResult implements XdrElement {
   public void setSuccess(ManageOfferSuccessResult value) {
     this.success = value;
   }
+
+  public static final class Builder {
+    private ManageBuyOfferResultCode discriminant;
+    private ManageOfferSuccessResult success;
+
+    public Builder discriminant(ManageBuyOfferResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder success(ManageOfferSuccessResult success) {
+      this.success = success;
+      return this;
+    }
+
+    public ManageBuyOfferResult build() {
+      ManageBuyOfferResult val = new ManageBuyOfferResult();
+      val.setDiscriminant(discriminant);
+      val.setSuccess(success);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, ManageBuyOfferResult encodedManageBuyOfferResult) throws IOException {
   //Xdrgen::AST::Identifier
   //ManageBuyOfferResultCode
@@ -69,7 +92,7 @@ public class ManageBuyOfferResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ManageBuyOfferResult)) {
+    if (!(object instanceof ManageBuyOfferResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/ManageDataOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/ManageDataOp.java
@@ -60,11 +60,33 @@ public class ManageDataOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ManageDataOp)) {
+    if (!(object instanceof ManageDataOp)) {
       return false;
     }
 
     ManageDataOp other = (ManageDataOp) object;
     return Objects.equal(this.dataName, other.dataName) && Objects.equal(this.dataValue, other.dataValue);
+  }
+
+  public static final class Builder {
+    private String64 dataName;
+    private DataValue dataValue;
+
+    public Builder dataName(String64 dataName) {
+      this.dataName = dataName;
+      return this;
+    }
+
+    public Builder dataValue(DataValue dataValue) {
+      this.dataValue = dataValue;
+      return this;
+    }
+
+    public ManageDataOp build() {
+      ManageDataOp val = new ManageDataOp();
+      val.setDataName(dataName);
+      val.setDataValue(dataValue);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/ManageDataResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/ManageDataResult.java
@@ -28,6 +28,22 @@ public class ManageDataResult implements XdrElement {
   public void setDiscriminant(ManageDataResultCode value) {
     this.code = value;
   }
+
+  public static final class Builder {
+    private ManageDataResultCode discriminant;
+
+    public Builder discriminant(ManageDataResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public ManageDataResult build() {
+      ManageDataResult val = new ManageDataResult();
+      val.setDiscriminant(discriminant);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, ManageDataResult encodedManageDataResult) throws IOException {
   //Xdrgen::AST::Identifier
   //ManageDataResultCode
@@ -60,7 +76,7 @@ public class ManageDataResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ManageDataResult)) {
+    if (!(object instanceof ManageDataResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/ManageOfferSuccessResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/ManageOfferSuccessResult.java
@@ -71,12 +71,34 @@ public class ManageOfferSuccessResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ManageOfferSuccessResult)) {
+    if (!(object instanceof ManageOfferSuccessResult)) {
       return false;
     }
 
     ManageOfferSuccessResult other = (ManageOfferSuccessResult) object;
     return Arrays.equals(this.offersClaimed, other.offersClaimed) && Objects.equal(this.offer, other.offer);
+  }
+
+  public static final class Builder {
+    private ClaimOfferAtom[] offersClaimed;
+    private ManageOfferSuccessResultOffer offer;
+
+    public Builder offersClaimed(ClaimOfferAtom[] offersClaimed) {
+      this.offersClaimed = offersClaimed;
+      return this;
+    }
+
+    public Builder offer(ManageOfferSuccessResultOffer offer) {
+      this.offer = offer;
+      return this;
+    }
+
+    public ManageOfferSuccessResult build() {
+      ManageOfferSuccessResult val = new ManageOfferSuccessResult();
+      val.setOffersClaimed(offersClaimed);
+      val.setOffer(offer);
+      return val;
+    }
   }
 
   public static class ManageOfferSuccessResultOffer {
@@ -95,6 +117,29 @@ public class ManageOfferSuccessResult implements XdrElement {
     public void setOffer(OfferEntry value) {
       this.offer = value;
     }
+
+    public static final class Builder {
+      private ManageOfferEffect discriminant;
+      private OfferEntry offer;
+
+      public Builder discriminant(ManageOfferEffect discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder offer(OfferEntry offer) {
+        this.offer = offer;
+        return this;
+      }
+
+      public ManageOfferSuccessResultOffer build() {
+        ManageOfferSuccessResultOffer val = new ManageOfferSuccessResultOffer();
+        val.setDiscriminant(discriminant);
+        val.setOffer(offer);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, ManageOfferSuccessResultOffer encodedManageOfferSuccessResultOffer) throws IOException {
     //Xdrgen::AST::Identifier
     //ManageOfferEffect
@@ -131,7 +176,7 @@ public class ManageOfferSuccessResult implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof ManageOfferSuccessResultOffer)) {
+      if (!(object instanceof ManageOfferSuccessResultOffer)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/ManageSellOfferOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/ManageSellOfferOp.java
@@ -84,11 +84,54 @@ public class ManageSellOfferOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ManageSellOfferOp)) {
+    if (!(object instanceof ManageSellOfferOp)) {
       return false;
     }
 
     ManageSellOfferOp other = (ManageSellOfferOp) object;
     return Objects.equal(this.selling, other.selling) && Objects.equal(this.buying, other.buying) && Objects.equal(this.amount, other.amount) && Objects.equal(this.price, other.price) && Objects.equal(this.offerID, other.offerID);
+  }
+
+  public static final class Builder {
+    private Asset selling;
+    private Asset buying;
+    private Int64 amount;
+    private Price price;
+    private Int64 offerID;
+
+    public Builder selling(Asset selling) {
+      this.selling = selling;
+      return this;
+    }
+
+    public Builder buying(Asset buying) {
+      this.buying = buying;
+      return this;
+    }
+
+    public Builder amount(Int64 amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    public Builder price(Price price) {
+      this.price = price;
+      return this;
+    }
+
+    public Builder offerID(Int64 offerID) {
+      this.offerID = offerID;
+      return this;
+    }
+
+    public ManageSellOfferOp build() {
+      ManageSellOfferOp val = new ManageSellOfferOp();
+      val.setSelling(selling);
+      val.setBuying(buying);
+      val.setAmount(amount);
+      val.setPrice(price);
+      val.setOfferID(offerID);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/ManageSellOfferResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/ManageSellOfferResult.java
@@ -35,6 +35,29 @@ public class ManageSellOfferResult implements XdrElement {
   public void setSuccess(ManageOfferSuccessResult value) {
     this.success = value;
   }
+
+  public static final class Builder {
+    private ManageSellOfferResultCode discriminant;
+    private ManageOfferSuccessResult success;
+
+    public Builder discriminant(ManageSellOfferResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder success(ManageOfferSuccessResult success) {
+      this.success = success;
+      return this;
+    }
+
+    public ManageSellOfferResult build() {
+      ManageSellOfferResult val = new ManageSellOfferResult();
+      val.setDiscriminant(discriminant);
+      val.setSuccess(success);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, ManageSellOfferResult encodedManageSellOfferResult) throws IOException {
   //Xdrgen::AST::Identifier
   //ManageSellOfferResultCode
@@ -69,7 +92,7 @@ public class ManageSellOfferResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ManageSellOfferResult)) {
+    if (!(object instanceof ManageSellOfferResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/Memo.java
+++ b/src/main/java/org/stellar/sdk/xdr/Memo.java
@@ -62,6 +62,50 @@ public class Memo implements XdrElement {
   public void setRetHash(Hash value) {
     this.retHash = value;
   }
+
+  public static final class Builder {
+    private MemoType discriminant;
+    private XdrString text;
+    private Uint64 id;
+    private Hash hash;
+    private Hash retHash;
+
+    public Builder discriminant(MemoType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder text(XdrString text) {
+      this.text = text;
+      return this;
+    }
+
+    public Builder id(Uint64 id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder hash(Hash hash) {
+      this.hash = hash;
+      return this;
+    }
+
+    public Builder retHash(Hash retHash) {
+      this.retHash = retHash;
+      return this;
+    }
+
+    public Memo build() {
+      Memo val = new Memo();
+      val.setDiscriminant(discriminant);
+      val.setText(text);
+      val.setId(id);
+      val.setHash(hash);
+      val.setRetHash(retHash);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, Memo encodedMemo) throws IOException {
   //Xdrgen::AST::Identifier
   //MemoType
@@ -114,7 +158,7 @@ public class Memo implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Memo)) {
+    if (!(object instanceof Memo)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/MuxedAccount.java
+++ b/src/main/java/org/stellar/sdk/xdr/MuxedAccount.java
@@ -46,6 +46,36 @@ public class MuxedAccount implements XdrElement {
   public void setMed25519(MuxedAccountMed25519 value) {
     this.med25519 = value;
   }
+
+  public static final class Builder {
+    private CryptoKeyType discriminant;
+    private Uint256 ed25519;
+    private MuxedAccountMed25519 med25519;
+
+    public Builder discriminant(CryptoKeyType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder ed25519(Uint256 ed25519) {
+      this.ed25519 = ed25519;
+      return this;
+    }
+
+    public Builder med25519(MuxedAccountMed25519 med25519) {
+      this.med25519 = med25519;
+      return this;
+    }
+
+    public MuxedAccount build() {
+      MuxedAccount val = new MuxedAccount();
+      val.setDiscriminant(discriminant);
+      val.setEd25519(ed25519);
+      val.setMed25519(med25519);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, MuxedAccount encodedMuxedAccount) throws IOException {
   //Xdrgen::AST::Identifier
   //CryptoKeyType
@@ -82,7 +112,7 @@ public class MuxedAccount implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof MuxedAccount)) {
+    if (!(object instanceof MuxedAccount)) {
       return false;
     }
 
@@ -125,12 +155,34 @@ public class MuxedAccount implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof MuxedAccountMed25519)) {
+      if (!(object instanceof MuxedAccountMed25519)) {
         return false;
       }
 
       MuxedAccountMed25519 other = (MuxedAccountMed25519) object;
       return Objects.equal(this.id, other.id) && Objects.equal(this.ed25519, other.ed25519);
+    }
+
+    public static final class Builder {
+      private Uint64 id;
+      private Uint256 ed25519;
+
+      public Builder id(Uint64 id) {
+        this.id = id;
+        return this;
+      }
+
+      public Builder ed25519(Uint256 ed25519) {
+        this.ed25519 = ed25519;
+        return this;
+      }
+
+      public MuxedAccountMed25519 build() {
+        MuxedAccountMed25519 val = new MuxedAccountMed25519();
+        val.setId(id);
+        val.setEd25519(ed25519);
+        return val;
+      }
     }
 
   }

--- a/src/main/java/org/stellar/sdk/xdr/NodeID.java
+++ b/src/main/java/org/stellar/sdk/xdr/NodeID.java
@@ -15,30 +15,42 @@ import com.google.common.base.Objects;
 //  ===========================================================================
 public class NodeID implements XdrElement {
   private PublicKey NodeID;
+
+  public NodeID() {}
+
+  public NodeID(PublicKey NodeID) {
+    this.NodeID = NodeID;
+  }
+
   public PublicKey getNodeID() {
     return this.NodeID;
   }
+
   public void setNodeID(PublicKey value) {
     this.NodeID = value;
   }
+
   public static void encode(XdrDataOutputStream stream, NodeID  encodedNodeID) throws IOException {
-  PublicKey.encode(stream, encodedNodeID.NodeID);
+    PublicKey.encode(stream, encodedNodeID.NodeID);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static NodeID decode(XdrDataInputStream stream) throws IOException {
     NodeID decodedNodeID = new NodeID();
-  decodedNodeID.NodeID = PublicKey.decode(stream);
+    decodedNodeID.NodeID = PublicKey.decode(stream);
     return decodedNodeID;
   }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(this.NodeID);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof NodeID)) {
+    if (!(object instanceof NodeID)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/OfferEntry.java
+++ b/src/main/java/org/stellar/sdk/xdr/OfferEntry.java
@@ -125,12 +125,76 @@ public class OfferEntry implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof OfferEntry)) {
+    if (!(object instanceof OfferEntry)) {
       return false;
     }
 
     OfferEntry other = (OfferEntry) object;
     return Objects.equal(this.sellerID, other.sellerID) && Objects.equal(this.offerID, other.offerID) && Objects.equal(this.selling, other.selling) && Objects.equal(this.buying, other.buying) && Objects.equal(this.amount, other.amount) && Objects.equal(this.price, other.price) && Objects.equal(this.flags, other.flags) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private AccountID sellerID;
+    private Int64 offerID;
+    private Asset selling;
+    private Asset buying;
+    private Int64 amount;
+    private Price price;
+    private Uint32 flags;
+    private OfferEntryExt ext;
+
+    public Builder sellerID(AccountID sellerID) {
+      this.sellerID = sellerID;
+      return this;
+    }
+
+    public Builder offerID(Int64 offerID) {
+      this.offerID = offerID;
+      return this;
+    }
+
+    public Builder selling(Asset selling) {
+      this.selling = selling;
+      return this;
+    }
+
+    public Builder buying(Asset buying) {
+      this.buying = buying;
+      return this;
+    }
+
+    public Builder amount(Int64 amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    public Builder price(Price price) {
+      this.price = price;
+      return this;
+    }
+
+    public Builder flags(Uint32 flags) {
+      this.flags = flags;
+      return this;
+    }
+
+    public Builder ext(OfferEntryExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public OfferEntry build() {
+      OfferEntry val = new OfferEntry();
+      val.setSellerID(sellerID);
+      val.setOfferID(offerID);
+      val.setSelling(selling);
+      val.setBuying(buying);
+      val.setAmount(amount);
+      val.setPrice(price);
+      val.setFlags(flags);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class OfferEntryExt {
@@ -142,6 +206,22 @@ public class OfferEntry implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public OfferEntryExt build() {
+        OfferEntryExt val = new OfferEntryExt();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, OfferEntryExt encodedOfferEntryExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -170,7 +250,7 @@ public class OfferEntry implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof OfferEntryExt)) {
+      if (!(object instanceof OfferEntryExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/Operation.java
+++ b/src/main/java/org/stellar/sdk/xdr/Operation.java
@@ -105,12 +105,34 @@ public class Operation implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Operation)) {
+    if (!(object instanceof Operation)) {
       return false;
     }
 
     Operation other = (Operation) object;
     return Objects.equal(this.sourceAccount, other.sourceAccount) && Objects.equal(this.body, other.body);
+  }
+
+  public static final class Builder {
+    private MuxedAccount sourceAccount;
+    private OperationBody body;
+
+    public Builder sourceAccount(MuxedAccount sourceAccount) {
+      this.sourceAccount = sourceAccount;
+      return this;
+    }
+
+    public Builder body(OperationBody body) {
+      this.body = body;
+      return this;
+    }
+
+    public Operation build() {
+      Operation val = new Operation();
+      val.setSourceAccount(sourceAccount);
+      val.setBody(body);
+      return val;
+    }
   }
 
   public static class OperationBody {
@@ -241,6 +263,141 @@ public class Operation implements XdrElement {
     public void setRevokeSponsorshipOp(RevokeSponsorshipOp value) {
       this.revokeSponsorshipOp = value;
     }
+
+    public static final class Builder {
+      private OperationType discriminant;
+      private CreateAccountOp createAccountOp;
+      private PaymentOp paymentOp;
+      private PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
+      private ManageSellOfferOp manageSellOfferOp;
+      private CreatePassiveSellOfferOp createPassiveSellOfferOp;
+      private SetOptionsOp setOptionsOp;
+      private ChangeTrustOp changeTrustOp;
+      private AllowTrustOp allowTrustOp;
+      private MuxedAccount destination;
+      private ManageDataOp manageDataOp;
+      private BumpSequenceOp bumpSequenceOp;
+      private ManageBuyOfferOp manageBuyOfferOp;
+      private PathPaymentStrictSendOp pathPaymentStrictSendOp;
+      private CreateClaimableBalanceOp createClaimableBalanceOp;
+      private ClaimClaimableBalanceOp claimClaimableBalanceOp;
+      private BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
+      private RevokeSponsorshipOp revokeSponsorshipOp;
+
+      public Builder discriminant(OperationType discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder createAccountOp(CreateAccountOp createAccountOp) {
+        this.createAccountOp = createAccountOp;
+        return this;
+      }
+
+      public Builder paymentOp(PaymentOp paymentOp) {
+        this.paymentOp = paymentOp;
+        return this;
+      }
+
+      public Builder pathPaymentStrictReceiveOp(PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp) {
+        this.pathPaymentStrictReceiveOp = pathPaymentStrictReceiveOp;
+        return this;
+      }
+
+      public Builder manageSellOfferOp(ManageSellOfferOp manageSellOfferOp) {
+        this.manageSellOfferOp = manageSellOfferOp;
+        return this;
+      }
+
+      public Builder createPassiveSellOfferOp(CreatePassiveSellOfferOp createPassiveSellOfferOp) {
+        this.createPassiveSellOfferOp = createPassiveSellOfferOp;
+        return this;
+      }
+
+      public Builder setOptionsOp(SetOptionsOp setOptionsOp) {
+        this.setOptionsOp = setOptionsOp;
+        return this;
+      }
+
+      public Builder changeTrustOp(ChangeTrustOp changeTrustOp) {
+        this.changeTrustOp = changeTrustOp;
+        return this;
+      }
+
+      public Builder allowTrustOp(AllowTrustOp allowTrustOp) {
+        this.allowTrustOp = allowTrustOp;
+        return this;
+      }
+
+      public Builder destination(MuxedAccount destination) {
+        this.destination = destination;
+        return this;
+      }
+
+      public Builder manageDataOp(ManageDataOp manageDataOp) {
+        this.manageDataOp = manageDataOp;
+        return this;
+      }
+
+      public Builder bumpSequenceOp(BumpSequenceOp bumpSequenceOp) {
+        this.bumpSequenceOp = bumpSequenceOp;
+        return this;
+      }
+
+      public Builder manageBuyOfferOp(ManageBuyOfferOp manageBuyOfferOp) {
+        this.manageBuyOfferOp = manageBuyOfferOp;
+        return this;
+      }
+
+      public Builder pathPaymentStrictSendOp(PathPaymentStrictSendOp pathPaymentStrictSendOp) {
+        this.pathPaymentStrictSendOp = pathPaymentStrictSendOp;
+        return this;
+      }
+
+      public Builder createClaimableBalanceOp(CreateClaimableBalanceOp createClaimableBalanceOp) {
+        this.createClaimableBalanceOp = createClaimableBalanceOp;
+        return this;
+      }
+
+      public Builder claimClaimableBalanceOp(ClaimClaimableBalanceOp claimClaimableBalanceOp) {
+        this.claimClaimableBalanceOp = claimClaimableBalanceOp;
+        return this;
+      }
+
+      public Builder beginSponsoringFutureReservesOp(BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp) {
+        this.beginSponsoringFutureReservesOp = beginSponsoringFutureReservesOp;
+        return this;
+      }
+
+      public Builder revokeSponsorshipOp(RevokeSponsorshipOp revokeSponsorshipOp) {
+        this.revokeSponsorshipOp = revokeSponsorshipOp;
+        return this;
+      }
+
+      public OperationBody build() {
+        OperationBody val = new OperationBody();
+        val.setDiscriminant(discriminant);
+        val.setCreateAccountOp(createAccountOp);
+        val.setPaymentOp(paymentOp);
+        val.setPathPaymentStrictReceiveOp(pathPaymentStrictReceiveOp);
+        val.setManageSellOfferOp(manageSellOfferOp);
+        val.setCreatePassiveSellOfferOp(createPassiveSellOfferOp);
+        val.setSetOptionsOp(setOptionsOp);
+        val.setChangeTrustOp(changeTrustOp);
+        val.setAllowTrustOp(allowTrustOp);
+        val.setDestination(destination);
+        val.setManageDataOp(manageDataOp);
+        val.setBumpSequenceOp(bumpSequenceOp);
+        val.setManageBuyOfferOp(manageBuyOfferOp);
+        val.setPathPaymentStrictSendOp(pathPaymentStrictSendOp);
+        val.setCreateClaimableBalanceOp(createClaimableBalanceOp);
+        val.setClaimClaimableBalanceOp(claimClaimableBalanceOp);
+        val.setBeginSponsoringFutureReservesOp(beginSponsoringFutureReservesOp);
+        val.setRevokeSponsorshipOp(revokeSponsorshipOp);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, OperationBody encodedOperationBody) throws IOException {
     //Xdrgen::AST::Identifier
     //OperationType
@@ -375,7 +532,7 @@ public class Operation implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof OperationBody)) {
+      if (!(object instanceof OperationBody)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/OperationID.java
+++ b/src/main/java/org/stellar/sdk/xdr/OperationID.java
@@ -38,6 +38,29 @@ public class OperationID implements XdrElement {
   public void setId(OperationIDId value) {
     this.id = value;
   }
+
+  public static final class Builder {
+    private EnvelopeType discriminant;
+    private OperationIDId id;
+
+    public Builder discriminant(EnvelopeType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder id(OperationIDId id) {
+      this.id = id;
+      return this;
+    }
+
+    public OperationID build() {
+      OperationID val = new OperationID();
+      val.setDiscriminant(discriminant);
+      val.setId(id);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, OperationID encodedOperationID) throws IOException {
   //Xdrgen::AST::Identifier
   //EnvelopeType
@@ -68,7 +91,7 @@ public class OperationID implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof OperationID)) {
+    if (!(object instanceof OperationID)) {
       return false;
     }
 
@@ -120,12 +143,41 @@ public class OperationID implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof OperationIDId)) {
+      if (!(object instanceof OperationIDId)) {
         return false;
       }
 
       OperationIDId other = (OperationIDId) object;
       return Objects.equal(this.sourceAccount, other.sourceAccount) && Objects.equal(this.seqNum, other.seqNum) && Objects.equal(this.opNum, other.opNum);
+    }
+
+    public static final class Builder {
+      private MuxedAccount sourceAccount;
+      private SequenceNumber seqNum;
+      private Uint32 opNum;
+
+      public Builder sourceAccount(MuxedAccount sourceAccount) {
+        this.sourceAccount = sourceAccount;
+        return this;
+      }
+
+      public Builder seqNum(SequenceNumber seqNum) {
+        this.seqNum = seqNum;
+        return this;
+      }
+
+      public Builder opNum(Uint32 opNum) {
+        this.opNum = opNum;
+        return this;
+      }
+
+      public OperationIDId build() {
+        OperationIDId val = new OperationIDId();
+        val.setSourceAccount(sourceAccount);
+        val.setSeqNum(seqNum);
+        val.setOpNum(opNum);
+        return val;
+      }
     }
 
   }

--- a/src/main/java/org/stellar/sdk/xdr/OperationMeta.java
+++ b/src/main/java/org/stellar/sdk/xdr/OperationMeta.java
@@ -42,11 +42,26 @@ public class OperationMeta implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof OperationMeta)) {
+    if (!(object instanceof OperationMeta)) {
       return false;
     }
 
     OperationMeta other = (OperationMeta) object;
     return Objects.equal(this.changes, other.changes);
+  }
+
+  public static final class Builder {
+    private LedgerEntryChanges changes;
+
+    public Builder changes(LedgerEntryChanges changes) {
+      this.changes = changes;
+      return this;
+    }
+
+    public OperationMeta build() {
+      OperationMeta val = new OperationMeta();
+      val.setChanges(changes);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/OperationResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/OperationResult.java
@@ -76,6 +76,29 @@ public class OperationResult implements XdrElement {
   public void setTr(OperationResultTr value) {
     this.tr = value;
   }
+
+  public static final class Builder {
+    private OperationResultCode discriminant;
+    private OperationResultTr tr;
+
+    public Builder discriminant(OperationResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder tr(OperationResultTr tr) {
+      this.tr = tr;
+      return this;
+    }
+
+    public OperationResult build() {
+      OperationResult val = new OperationResult();
+      val.setDiscriminant(discriminant);
+      val.setTr(tr);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, OperationResult encodedOperationResult) throws IOException {
   //Xdrgen::AST::Identifier
   //OperationResultCode
@@ -110,7 +133,7 @@ public class OperationResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof OperationResult)) {
+    if (!(object instanceof OperationResult)) {
       return false;
     }
 
@@ -260,6 +283,155 @@ public class OperationResult implements XdrElement {
     public void setRevokeSponsorshipResult(RevokeSponsorshipResult value) {
       this.revokeSponsorshipResult = value;
     }
+
+    public static final class Builder {
+      private OperationType discriminant;
+      private CreateAccountResult createAccountResult;
+      private PaymentResult paymentResult;
+      private PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
+      private ManageSellOfferResult manageSellOfferResult;
+      private ManageSellOfferResult createPassiveSellOfferResult;
+      private SetOptionsResult setOptionsResult;
+      private ChangeTrustResult changeTrustResult;
+      private AllowTrustResult allowTrustResult;
+      private AccountMergeResult accountMergeResult;
+      private InflationResult inflationResult;
+      private ManageDataResult manageDataResult;
+      private BumpSequenceResult bumpSeqResult;
+      private ManageBuyOfferResult manageBuyOfferResult;
+      private PathPaymentStrictSendResult pathPaymentStrictSendResult;
+      private CreateClaimableBalanceResult createClaimableBalanceResult;
+      private ClaimClaimableBalanceResult claimClaimableBalanceResult;
+      private BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
+      private EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
+      private RevokeSponsorshipResult revokeSponsorshipResult;
+
+      public Builder discriminant(OperationType discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder createAccountResult(CreateAccountResult createAccountResult) {
+        this.createAccountResult = createAccountResult;
+        return this;
+      }
+
+      public Builder paymentResult(PaymentResult paymentResult) {
+        this.paymentResult = paymentResult;
+        return this;
+      }
+
+      public Builder pathPaymentStrictReceiveResult(PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult) {
+        this.pathPaymentStrictReceiveResult = pathPaymentStrictReceiveResult;
+        return this;
+      }
+
+      public Builder manageSellOfferResult(ManageSellOfferResult manageSellOfferResult) {
+        this.manageSellOfferResult = manageSellOfferResult;
+        return this;
+      }
+
+      public Builder createPassiveSellOfferResult(ManageSellOfferResult createPassiveSellOfferResult) {
+        this.createPassiveSellOfferResult = createPassiveSellOfferResult;
+        return this;
+      }
+
+      public Builder setOptionsResult(SetOptionsResult setOptionsResult) {
+        this.setOptionsResult = setOptionsResult;
+        return this;
+      }
+
+      public Builder changeTrustResult(ChangeTrustResult changeTrustResult) {
+        this.changeTrustResult = changeTrustResult;
+        return this;
+      }
+
+      public Builder allowTrustResult(AllowTrustResult allowTrustResult) {
+        this.allowTrustResult = allowTrustResult;
+        return this;
+      }
+
+      public Builder accountMergeResult(AccountMergeResult accountMergeResult) {
+        this.accountMergeResult = accountMergeResult;
+        return this;
+      }
+
+      public Builder inflationResult(InflationResult inflationResult) {
+        this.inflationResult = inflationResult;
+        return this;
+      }
+
+      public Builder manageDataResult(ManageDataResult manageDataResult) {
+        this.manageDataResult = manageDataResult;
+        return this;
+      }
+
+      public Builder bumpSeqResult(BumpSequenceResult bumpSeqResult) {
+        this.bumpSeqResult = bumpSeqResult;
+        return this;
+      }
+
+      public Builder manageBuyOfferResult(ManageBuyOfferResult manageBuyOfferResult) {
+        this.manageBuyOfferResult = manageBuyOfferResult;
+        return this;
+      }
+
+      public Builder pathPaymentStrictSendResult(PathPaymentStrictSendResult pathPaymentStrictSendResult) {
+        this.pathPaymentStrictSendResult = pathPaymentStrictSendResult;
+        return this;
+      }
+
+      public Builder createClaimableBalanceResult(CreateClaimableBalanceResult createClaimableBalanceResult) {
+        this.createClaimableBalanceResult = createClaimableBalanceResult;
+        return this;
+      }
+
+      public Builder claimClaimableBalanceResult(ClaimClaimableBalanceResult claimClaimableBalanceResult) {
+        this.claimClaimableBalanceResult = claimClaimableBalanceResult;
+        return this;
+      }
+
+      public Builder beginSponsoringFutureReservesResult(BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult) {
+        this.beginSponsoringFutureReservesResult = beginSponsoringFutureReservesResult;
+        return this;
+      }
+
+      public Builder endSponsoringFutureReservesResult(EndSponsoringFutureReservesResult endSponsoringFutureReservesResult) {
+        this.endSponsoringFutureReservesResult = endSponsoringFutureReservesResult;
+        return this;
+      }
+
+      public Builder revokeSponsorshipResult(RevokeSponsorshipResult revokeSponsorshipResult) {
+        this.revokeSponsorshipResult = revokeSponsorshipResult;
+        return this;
+      }
+
+      public OperationResultTr build() {
+        OperationResultTr val = new OperationResultTr();
+        val.setDiscriminant(discriminant);
+        val.setCreateAccountResult(createAccountResult);
+        val.setPaymentResult(paymentResult);
+        val.setPathPaymentStrictReceiveResult(pathPaymentStrictReceiveResult);
+        val.setManageSellOfferResult(manageSellOfferResult);
+        val.setCreatePassiveSellOfferResult(createPassiveSellOfferResult);
+        val.setSetOptionsResult(setOptionsResult);
+        val.setChangeTrustResult(changeTrustResult);
+        val.setAllowTrustResult(allowTrustResult);
+        val.setAccountMergeResult(accountMergeResult);
+        val.setInflationResult(inflationResult);
+        val.setManageDataResult(manageDataResult);
+        val.setBumpSeqResult(bumpSeqResult);
+        val.setManageBuyOfferResult(manageBuyOfferResult);
+        val.setPathPaymentStrictSendResult(pathPaymentStrictSendResult);
+        val.setCreateClaimableBalanceResult(createClaimableBalanceResult);
+        val.setClaimClaimableBalanceResult(claimClaimableBalanceResult);
+        val.setBeginSponsoringFutureReservesResult(beginSponsoringFutureReservesResult);
+        val.setEndSponsoringFutureReservesResult(endSponsoringFutureReservesResult);
+        val.setRevokeSponsorshipResult(revokeSponsorshipResult);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, OperationResultTr encodedOperationResultTr) throws IOException {
     //Xdrgen::AST::Identifier
     //OperationType
@@ -398,7 +570,7 @@ public class OperationResult implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof OperationResultTr)) {
+      if (!(object instanceof OperationResultTr)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/PathPaymentStrictReceiveOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/PathPaymentStrictReceiveOp.java
@@ -105,11 +105,61 @@ public class PathPaymentStrictReceiveOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PathPaymentStrictReceiveOp)) {
+    if (!(object instanceof PathPaymentStrictReceiveOp)) {
       return false;
     }
 
     PathPaymentStrictReceiveOp other = (PathPaymentStrictReceiveOp) object;
     return Objects.equal(this.sendAsset, other.sendAsset) && Objects.equal(this.sendMax, other.sendMax) && Objects.equal(this.destination, other.destination) && Objects.equal(this.destAsset, other.destAsset) && Objects.equal(this.destAmount, other.destAmount) && Arrays.equals(this.path, other.path);
+  }
+
+  public static final class Builder {
+    private Asset sendAsset;
+    private Int64 sendMax;
+    private MuxedAccount destination;
+    private Asset destAsset;
+    private Int64 destAmount;
+    private Asset[] path;
+
+    public Builder sendAsset(Asset sendAsset) {
+      this.sendAsset = sendAsset;
+      return this;
+    }
+
+    public Builder sendMax(Int64 sendMax) {
+      this.sendMax = sendMax;
+      return this;
+    }
+
+    public Builder destination(MuxedAccount destination) {
+      this.destination = destination;
+      return this;
+    }
+
+    public Builder destAsset(Asset destAsset) {
+      this.destAsset = destAsset;
+      return this;
+    }
+
+    public Builder destAmount(Int64 destAmount) {
+      this.destAmount = destAmount;
+      return this;
+    }
+
+    public Builder path(Asset[] path) {
+      this.path = path;
+      return this;
+    }
+
+    public PathPaymentStrictReceiveOp build() {
+      PathPaymentStrictReceiveOp val = new PathPaymentStrictReceiveOp();
+      val.setSendAsset(sendAsset);
+      val.setSendMax(sendMax);
+      val.setDestination(destination);
+      val.setDestAsset(destAsset);
+      val.setDestAmount(destAmount);
+      val.setPath(path);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/PathPaymentStrictReceiveResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/PathPaymentStrictReceiveResult.java
@@ -49,6 +49,36 @@ public class PathPaymentStrictReceiveResult implements XdrElement {
   public void setNoIssuer(Asset value) {
     this.noIssuer = value;
   }
+
+  public static final class Builder {
+    private PathPaymentStrictReceiveResultCode discriminant;
+    private PathPaymentStrictReceiveResultSuccess success;
+    private Asset noIssuer;
+
+    public Builder discriminant(PathPaymentStrictReceiveResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder success(PathPaymentStrictReceiveResultSuccess success) {
+      this.success = success;
+      return this;
+    }
+
+    public Builder noIssuer(Asset noIssuer) {
+      this.noIssuer = noIssuer;
+      return this;
+    }
+
+    public PathPaymentStrictReceiveResult build() {
+      PathPaymentStrictReceiveResult val = new PathPaymentStrictReceiveResult();
+      val.setDiscriminant(discriminant);
+      val.setSuccess(success);
+      val.setNoIssuer(noIssuer);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, PathPaymentStrictReceiveResult encodedPathPaymentStrictReceiveResult) throws IOException {
   //Xdrgen::AST::Identifier
   //PathPaymentStrictReceiveResultCode
@@ -89,7 +119,7 @@ public class PathPaymentStrictReceiveResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PathPaymentStrictReceiveResult)) {
+    if (!(object instanceof PathPaymentStrictReceiveResult)) {
       return false;
     }
 
@@ -140,12 +170,34 @@ public class PathPaymentStrictReceiveResult implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof PathPaymentStrictReceiveResultSuccess)) {
+      if (!(object instanceof PathPaymentStrictReceiveResultSuccess)) {
         return false;
       }
 
       PathPaymentStrictReceiveResultSuccess other = (PathPaymentStrictReceiveResultSuccess) object;
       return Arrays.equals(this.offers, other.offers) && Objects.equal(this.last, other.last);
+    }
+
+    public static final class Builder {
+      private ClaimOfferAtom[] offers;
+      private SimplePaymentResult last;
+
+      public Builder offers(ClaimOfferAtom[] offers) {
+        this.offers = offers;
+        return this;
+      }
+
+      public Builder last(SimplePaymentResult last) {
+        this.last = last;
+        return this;
+      }
+
+      public PathPaymentStrictReceiveResultSuccess build() {
+        PathPaymentStrictReceiveResultSuccess val = new PathPaymentStrictReceiveResultSuccess();
+        val.setOffers(offers);
+        val.setLast(last);
+        return val;
+      }
     }
 
   }

--- a/src/main/java/org/stellar/sdk/xdr/PathPaymentStrictSendOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/PathPaymentStrictSendOp.java
@@ -105,11 +105,61 @@ public class PathPaymentStrictSendOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PathPaymentStrictSendOp)) {
+    if (!(object instanceof PathPaymentStrictSendOp)) {
       return false;
     }
 
     PathPaymentStrictSendOp other = (PathPaymentStrictSendOp) object;
     return Objects.equal(this.sendAsset, other.sendAsset) && Objects.equal(this.sendAmount, other.sendAmount) && Objects.equal(this.destination, other.destination) && Objects.equal(this.destAsset, other.destAsset) && Objects.equal(this.destMin, other.destMin) && Arrays.equals(this.path, other.path);
+  }
+
+  public static final class Builder {
+    private Asset sendAsset;
+    private Int64 sendAmount;
+    private MuxedAccount destination;
+    private Asset destAsset;
+    private Int64 destMin;
+    private Asset[] path;
+
+    public Builder sendAsset(Asset sendAsset) {
+      this.sendAsset = sendAsset;
+      return this;
+    }
+
+    public Builder sendAmount(Int64 sendAmount) {
+      this.sendAmount = sendAmount;
+      return this;
+    }
+
+    public Builder destination(MuxedAccount destination) {
+      this.destination = destination;
+      return this;
+    }
+
+    public Builder destAsset(Asset destAsset) {
+      this.destAsset = destAsset;
+      return this;
+    }
+
+    public Builder destMin(Int64 destMin) {
+      this.destMin = destMin;
+      return this;
+    }
+
+    public Builder path(Asset[] path) {
+      this.path = path;
+      return this;
+    }
+
+    public PathPaymentStrictSendOp build() {
+      PathPaymentStrictSendOp val = new PathPaymentStrictSendOp();
+      val.setSendAsset(sendAsset);
+      val.setSendAmount(sendAmount);
+      val.setDestination(destination);
+      val.setDestAsset(destAsset);
+      val.setDestMin(destMin);
+      val.setPath(path);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/PathPaymentStrictSendResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/PathPaymentStrictSendResult.java
@@ -49,6 +49,36 @@ public class PathPaymentStrictSendResult implements XdrElement {
   public void setNoIssuer(Asset value) {
     this.noIssuer = value;
   }
+
+  public static final class Builder {
+    private PathPaymentStrictSendResultCode discriminant;
+    private PathPaymentStrictSendResultSuccess success;
+    private Asset noIssuer;
+
+    public Builder discriminant(PathPaymentStrictSendResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder success(PathPaymentStrictSendResultSuccess success) {
+      this.success = success;
+      return this;
+    }
+
+    public Builder noIssuer(Asset noIssuer) {
+      this.noIssuer = noIssuer;
+      return this;
+    }
+
+    public PathPaymentStrictSendResult build() {
+      PathPaymentStrictSendResult val = new PathPaymentStrictSendResult();
+      val.setDiscriminant(discriminant);
+      val.setSuccess(success);
+      val.setNoIssuer(noIssuer);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, PathPaymentStrictSendResult encodedPathPaymentStrictSendResult) throws IOException {
   //Xdrgen::AST::Identifier
   //PathPaymentStrictSendResultCode
@@ -89,7 +119,7 @@ public class PathPaymentStrictSendResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PathPaymentStrictSendResult)) {
+    if (!(object instanceof PathPaymentStrictSendResult)) {
       return false;
     }
 
@@ -140,12 +170,34 @@ public class PathPaymentStrictSendResult implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof PathPaymentStrictSendResultSuccess)) {
+      if (!(object instanceof PathPaymentStrictSendResultSuccess)) {
         return false;
       }
 
       PathPaymentStrictSendResultSuccess other = (PathPaymentStrictSendResultSuccess) object;
       return Arrays.equals(this.offers, other.offers) && Objects.equal(this.last, other.last);
+    }
+
+    public static final class Builder {
+      private ClaimOfferAtom[] offers;
+      private SimplePaymentResult last;
+
+      public Builder offers(ClaimOfferAtom[] offers) {
+        this.offers = offers;
+        return this;
+      }
+
+      public Builder last(SimplePaymentResult last) {
+        this.last = last;
+        return this;
+      }
+
+      public PathPaymentStrictSendResultSuccess build() {
+        PathPaymentStrictSendResultSuccess val = new PathPaymentStrictSendResultSuccess();
+        val.setOffers(offers);
+        val.setLast(last);
+        return val;
+      }
     }
 
   }

--- a/src/main/java/org/stellar/sdk/xdr/PaymentOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/PaymentOp.java
@@ -62,11 +62,40 @@ public class PaymentOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PaymentOp)) {
+    if (!(object instanceof PaymentOp)) {
       return false;
     }
 
     PaymentOp other = (PaymentOp) object;
     return Objects.equal(this.destination, other.destination) && Objects.equal(this.asset, other.asset) && Objects.equal(this.amount, other.amount);
+  }
+
+  public static final class Builder {
+    private MuxedAccount destination;
+    private Asset asset;
+    private Int64 amount;
+
+    public Builder destination(MuxedAccount destination) {
+      this.destination = destination;
+      return this;
+    }
+
+    public Builder asset(Asset asset) {
+      this.asset = asset;
+      return this;
+    }
+
+    public Builder amount(Int64 amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    public PaymentOp build() {
+      PaymentOp val = new PaymentOp();
+      val.setDestination(destination);
+      val.setAsset(asset);
+      val.setAmount(amount);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/PaymentResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/PaymentResult.java
@@ -28,6 +28,22 @@ public class PaymentResult implements XdrElement {
   public void setDiscriminant(PaymentResultCode value) {
     this.code = value;
   }
+
+  public static final class Builder {
+    private PaymentResultCode discriminant;
+
+    public Builder discriminant(PaymentResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public PaymentResult build() {
+      PaymentResult val = new PaymentResult();
+      val.setDiscriminant(discriminant);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, PaymentResult encodedPaymentResult) throws IOException {
   //Xdrgen::AST::Identifier
   //PaymentResultCode
@@ -60,7 +76,7 @@ public class PaymentResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PaymentResult)) {
+    if (!(object instanceof PaymentResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/PeerAddress.java
+++ b/src/main/java/org/stellar/sdk/xdr/PeerAddress.java
@@ -70,12 +70,41 @@ public class PeerAddress implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PeerAddress)) {
+    if (!(object instanceof PeerAddress)) {
       return false;
     }
 
     PeerAddress other = (PeerAddress) object;
     return Objects.equal(this.ip, other.ip) && Objects.equal(this.port, other.port) && Objects.equal(this.numFailures, other.numFailures);
+  }
+
+  public static final class Builder {
+    private PeerAddressIp ip;
+    private Uint32 port;
+    private Uint32 numFailures;
+
+    public Builder ip(PeerAddressIp ip) {
+      this.ip = ip;
+      return this;
+    }
+
+    public Builder port(Uint32 port) {
+      this.port = port;
+      return this;
+    }
+
+    public Builder numFailures(Uint32 numFailures) {
+      this.numFailures = numFailures;
+      return this;
+    }
+
+    public PeerAddress build() {
+      PeerAddress val = new PeerAddress();
+      val.setIp(ip);
+      val.setPort(port);
+      val.setNumFailures(numFailures);
+      return val;
+    }
   }
 
   public static class PeerAddressIp {
@@ -101,6 +130,36 @@ public class PeerAddress implements XdrElement {
     public void setIpv6(byte[] value) {
       this.ipv6 = value;
     }
+
+    public static final class Builder {
+      private IPAddrType discriminant;
+      private byte[] ipv4;
+      private byte[] ipv6;
+
+      public Builder discriminant(IPAddrType discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder ipv4(byte[] ipv4) {
+        this.ipv4 = ipv4;
+        return this;
+      }
+
+      public Builder ipv6(byte[] ipv6) {
+        this.ipv6 = ipv6;
+        return this;
+      }
+
+      public PeerAddressIp build() {
+        PeerAddressIp val = new PeerAddressIp();
+        val.setDiscriminant(discriminant);
+        val.setIpv4(ipv4);
+        val.setIpv6(ipv6);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, PeerAddressIp encodedPeerAddressIp) throws IOException {
     //Xdrgen::AST::Identifier
     //IPAddrType
@@ -143,7 +202,7 @@ public class PeerAddress implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof PeerAddressIp)) {
+      if (!(object instanceof PeerAddressIp)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/PeerStatList.java
+++ b/src/main/java/org/stellar/sdk/xdr/PeerStatList.java
@@ -15,38 +15,50 @@ import java.util.Arrays;
 //  ===========================================================================
 public class PeerStatList implements XdrElement {
   private PeerStats[] PeerStatList;
+
+  public PeerStatList() {}
+
+  public PeerStatList(PeerStats[] PeerStatList) {
+    this.PeerStatList = PeerStatList;
+  }
+
   public PeerStats[] getPeerStatList() {
     return this.PeerStatList;
   }
+
   public void setPeerStatList(PeerStats[] value) {
     this.PeerStatList = value;
   }
+
   public static void encode(XdrDataOutputStream stream, PeerStatList  encodedPeerStatList) throws IOException {
-  int PeerStatListsize = encodedPeerStatList.getPeerStatList().length;
-  stream.writeInt(PeerStatListsize);
-  for (int i = 0; i < PeerStatListsize; i++) {
-    PeerStats.encode(stream, encodedPeerStatList.PeerStatList[i]);
+    int PeerStatListsize = encodedPeerStatList.getPeerStatList().length;
+    stream.writeInt(PeerStatListsize);
+    for (int i = 0; i < PeerStatListsize; i++) {
+      PeerStats.encode(stream, encodedPeerStatList.PeerStatList[i]);
+    }
   }
-  }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static PeerStatList decode(XdrDataInputStream stream) throws IOException {
     PeerStatList decodedPeerStatList = new PeerStatList();
-  int PeerStatListsize = stream.readInt();
-  decodedPeerStatList.PeerStatList = new PeerStats[PeerStatListsize];
-  for (int i = 0; i < PeerStatListsize; i++) {
-    decodedPeerStatList.PeerStatList[i] = PeerStats.decode(stream);
-  }
+    int PeerStatListsize = stream.readInt();
+    decodedPeerStatList.PeerStatList = new PeerStats[PeerStatListsize];
+    for (int i = 0; i < PeerStatListsize; i++) {
+      decodedPeerStatList.PeerStatList[i] = PeerStats.decode(stream);
+    }
     return decodedPeerStatList;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.PeerStatList);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PeerStatList)) {
+    if (!(object instanceof PeerStatList)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/PeerStats.java
+++ b/src/main/java/org/stellar/sdk/xdr/PeerStats.java
@@ -184,11 +184,124 @@ public class PeerStats implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PeerStats)) {
+    if (!(object instanceof PeerStats)) {
       return false;
     }
 
     PeerStats other = (PeerStats) object;
     return Objects.equal(this.id, other.id) && Objects.equal(this.versionStr, other.versionStr) && Objects.equal(this.messagesRead, other.messagesRead) && Objects.equal(this.messagesWritten, other.messagesWritten) && Objects.equal(this.bytesRead, other.bytesRead) && Objects.equal(this.bytesWritten, other.bytesWritten) && Objects.equal(this.secondsConnected, other.secondsConnected) && Objects.equal(this.uniqueFloodBytesRecv, other.uniqueFloodBytesRecv) && Objects.equal(this.duplicateFloodBytesRecv, other.duplicateFloodBytesRecv) && Objects.equal(this.uniqueFetchBytesRecv, other.uniqueFetchBytesRecv) && Objects.equal(this.duplicateFetchBytesRecv, other.duplicateFetchBytesRecv) && Objects.equal(this.uniqueFloodMessageRecv, other.uniqueFloodMessageRecv) && Objects.equal(this.duplicateFloodMessageRecv, other.duplicateFloodMessageRecv) && Objects.equal(this.uniqueFetchMessageRecv, other.uniqueFetchMessageRecv) && Objects.equal(this.duplicateFetchMessageRecv, other.duplicateFetchMessageRecv);
+  }
+
+  public static final class Builder {
+    private NodeID id;
+    private XdrString versionStr;
+    private Uint64 messagesRead;
+    private Uint64 messagesWritten;
+    private Uint64 bytesRead;
+    private Uint64 bytesWritten;
+    private Uint64 secondsConnected;
+    private Uint64 uniqueFloodBytesRecv;
+    private Uint64 duplicateFloodBytesRecv;
+    private Uint64 uniqueFetchBytesRecv;
+    private Uint64 duplicateFetchBytesRecv;
+    private Uint64 uniqueFloodMessageRecv;
+    private Uint64 duplicateFloodMessageRecv;
+    private Uint64 uniqueFetchMessageRecv;
+    private Uint64 duplicateFetchMessageRecv;
+
+    public Builder id(NodeID id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder versionStr(XdrString versionStr) {
+      this.versionStr = versionStr;
+      return this;
+    }
+
+    public Builder messagesRead(Uint64 messagesRead) {
+      this.messagesRead = messagesRead;
+      return this;
+    }
+
+    public Builder messagesWritten(Uint64 messagesWritten) {
+      this.messagesWritten = messagesWritten;
+      return this;
+    }
+
+    public Builder bytesRead(Uint64 bytesRead) {
+      this.bytesRead = bytesRead;
+      return this;
+    }
+
+    public Builder bytesWritten(Uint64 bytesWritten) {
+      this.bytesWritten = bytesWritten;
+      return this;
+    }
+
+    public Builder secondsConnected(Uint64 secondsConnected) {
+      this.secondsConnected = secondsConnected;
+      return this;
+    }
+
+    public Builder uniqueFloodBytesRecv(Uint64 uniqueFloodBytesRecv) {
+      this.uniqueFloodBytesRecv = uniqueFloodBytesRecv;
+      return this;
+    }
+
+    public Builder duplicateFloodBytesRecv(Uint64 duplicateFloodBytesRecv) {
+      this.duplicateFloodBytesRecv = duplicateFloodBytesRecv;
+      return this;
+    }
+
+    public Builder uniqueFetchBytesRecv(Uint64 uniqueFetchBytesRecv) {
+      this.uniqueFetchBytesRecv = uniqueFetchBytesRecv;
+      return this;
+    }
+
+    public Builder duplicateFetchBytesRecv(Uint64 duplicateFetchBytesRecv) {
+      this.duplicateFetchBytesRecv = duplicateFetchBytesRecv;
+      return this;
+    }
+
+    public Builder uniqueFloodMessageRecv(Uint64 uniqueFloodMessageRecv) {
+      this.uniqueFloodMessageRecv = uniqueFloodMessageRecv;
+      return this;
+    }
+
+    public Builder duplicateFloodMessageRecv(Uint64 duplicateFloodMessageRecv) {
+      this.duplicateFloodMessageRecv = duplicateFloodMessageRecv;
+      return this;
+    }
+
+    public Builder uniqueFetchMessageRecv(Uint64 uniqueFetchMessageRecv) {
+      this.uniqueFetchMessageRecv = uniqueFetchMessageRecv;
+      return this;
+    }
+
+    public Builder duplicateFetchMessageRecv(Uint64 duplicateFetchMessageRecv) {
+      this.duplicateFetchMessageRecv = duplicateFetchMessageRecv;
+      return this;
+    }
+
+    public PeerStats build() {
+      PeerStats val = new PeerStats();
+      val.setId(id);
+      val.setVersionStr(versionStr);
+      val.setMessagesRead(messagesRead);
+      val.setMessagesWritten(messagesWritten);
+      val.setBytesRead(bytesRead);
+      val.setBytesWritten(bytesWritten);
+      val.setSecondsConnected(secondsConnected);
+      val.setUniqueFloodBytesRecv(uniqueFloodBytesRecv);
+      val.setDuplicateFloodBytesRecv(duplicateFloodBytesRecv);
+      val.setUniqueFetchBytesRecv(uniqueFetchBytesRecv);
+      val.setDuplicateFetchBytesRecv(duplicateFetchBytesRecv);
+      val.setUniqueFloodMessageRecv(uniqueFloodMessageRecv);
+      val.setDuplicateFloodMessageRecv(duplicateFloodMessageRecv);
+      val.setUniqueFetchMessageRecv(uniqueFetchMessageRecv);
+      val.setDuplicateFetchMessageRecv(duplicateFetchMessageRecv);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Price.java
+++ b/src/main/java/org/stellar/sdk/xdr/Price.java
@@ -52,11 +52,33 @@ public class Price implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Price)) {
+    if (!(object instanceof Price)) {
       return false;
     }
 
     Price other = (Price) object;
     return Objects.equal(this.n, other.n) && Objects.equal(this.d, other.d);
+  }
+
+  public static final class Builder {
+    private Int32 n;
+    private Int32 d;
+
+    public Builder n(Int32 n) {
+      this.n = n;
+      return this;
+    }
+
+    public Builder d(Int32 d) {
+      this.d = d;
+      return this;
+    }
+
+    public Price build() {
+      Price val = new Price();
+      val.setN(n);
+      val.setD(d);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/PublicKey.java
+++ b/src/main/java/org/stellar/sdk/xdr/PublicKey.java
@@ -33,6 +33,29 @@ public class PublicKey implements XdrElement {
   public void setEd25519(Uint256 value) {
     this.ed25519 = value;
   }
+
+  public static final class Builder {
+    private PublicKeyType discriminant;
+    private Uint256 ed25519;
+
+    public Builder discriminant(PublicKeyType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder ed25519(Uint256 ed25519) {
+      this.ed25519 = ed25519;
+      return this;
+    }
+
+    public PublicKey build() {
+      PublicKey val = new PublicKey();
+      val.setDiscriminant(discriminant);
+      val.setEd25519(ed25519);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, PublicKey encodedPublicKey) throws IOException {
   //Xdrgen::AST::Identifier
   //PublicKeyType
@@ -63,7 +86,7 @@ public class PublicKey implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PublicKey)) {
+    if (!(object instanceof PublicKey)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/RevokeSponsorshipOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/RevokeSponsorshipOp.java
@@ -47,6 +47,36 @@ public class RevokeSponsorshipOp implements XdrElement {
   public void setSigner(RevokeSponsorshipOpSigner value) {
     this.signer = value;
   }
+
+  public static final class Builder {
+    private RevokeSponsorshipType discriminant;
+    private LedgerKey ledgerKey;
+    private RevokeSponsorshipOpSigner signer;
+
+    public Builder discriminant(RevokeSponsorshipType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder ledgerKey(LedgerKey ledgerKey) {
+      this.ledgerKey = ledgerKey;
+      return this;
+    }
+
+    public Builder signer(RevokeSponsorshipOpSigner signer) {
+      this.signer = signer;
+      return this;
+    }
+
+    public RevokeSponsorshipOp build() {
+      RevokeSponsorshipOp val = new RevokeSponsorshipOp();
+      val.setDiscriminant(discriminant);
+      val.setLedgerKey(ledgerKey);
+      val.setSigner(signer);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, RevokeSponsorshipOp encodedRevokeSponsorshipOp) throws IOException {
   //Xdrgen::AST::Identifier
   //RevokeSponsorshipType
@@ -83,7 +113,7 @@ public class RevokeSponsorshipOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof RevokeSponsorshipOp)) {
+    if (!(object instanceof RevokeSponsorshipOp)) {
       return false;
     }
 
@@ -126,12 +156,34 @@ public class RevokeSponsorshipOp implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof RevokeSponsorshipOpSigner)) {
+      if (!(object instanceof RevokeSponsorshipOpSigner)) {
         return false;
       }
 
       RevokeSponsorshipOpSigner other = (RevokeSponsorshipOpSigner) object;
       return Objects.equal(this.accountID, other.accountID) && Objects.equal(this.signerKey, other.signerKey);
+    }
+
+    public static final class Builder {
+      private AccountID accountID;
+      private SignerKey signerKey;
+
+      public Builder accountID(AccountID accountID) {
+        this.accountID = accountID;
+        return this;
+      }
+
+      public Builder signerKey(SignerKey signerKey) {
+        this.signerKey = signerKey;
+        return this;
+      }
+
+      public RevokeSponsorshipOpSigner build() {
+        RevokeSponsorshipOpSigner val = new RevokeSponsorshipOpSigner();
+        val.setAccountID(accountID);
+        val.setSignerKey(signerKey);
+        return val;
+      }
     }
 
   }

--- a/src/main/java/org/stellar/sdk/xdr/RevokeSponsorshipResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/RevokeSponsorshipResult.java
@@ -28,6 +28,22 @@ public class RevokeSponsorshipResult implements XdrElement {
   public void setDiscriminant(RevokeSponsorshipResultCode value) {
     this.code = value;
   }
+
+  public static final class Builder {
+    private RevokeSponsorshipResultCode discriminant;
+
+    public Builder discriminant(RevokeSponsorshipResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public RevokeSponsorshipResult build() {
+      RevokeSponsorshipResult val = new RevokeSponsorshipResult();
+      val.setDiscriminant(discriminant);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, RevokeSponsorshipResult encodedRevokeSponsorshipResult) throws IOException {
   //Xdrgen::AST::Identifier
   //RevokeSponsorshipResultCode
@@ -60,7 +76,7 @@ public class RevokeSponsorshipResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof RevokeSponsorshipResult)) {
+    if (!(object instanceof RevokeSponsorshipResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/SCPBallot.java
+++ b/src/main/java/org/stellar/sdk/xdr/SCPBallot.java
@@ -52,11 +52,33 @@ public class SCPBallot implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SCPBallot)) {
+    if (!(object instanceof SCPBallot)) {
       return false;
     }
 
     SCPBallot other = (SCPBallot) object;
     return Objects.equal(this.counter, other.counter) && Objects.equal(this.value, other.value);
+  }
+
+  public static final class Builder {
+    private Uint32 counter;
+    private Value value;
+
+    public Builder counter(Uint32 counter) {
+      this.counter = counter;
+      return this;
+    }
+
+    public Builder value(Value value) {
+      this.value = value;
+      return this;
+    }
+
+    public SCPBallot build() {
+      SCPBallot val = new SCPBallot();
+      val.setCounter(counter);
+      val.setValue(value);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/SCPEnvelope.java
+++ b/src/main/java/org/stellar/sdk/xdr/SCPEnvelope.java
@@ -52,11 +52,33 @@ public class SCPEnvelope implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SCPEnvelope)) {
+    if (!(object instanceof SCPEnvelope)) {
       return false;
     }
 
     SCPEnvelope other = (SCPEnvelope) object;
     return Objects.equal(this.statement, other.statement) && Objects.equal(this.signature, other.signature);
+  }
+
+  public static final class Builder {
+    private SCPStatement statement;
+    private Signature signature;
+
+    public Builder statement(SCPStatement statement) {
+      this.statement = statement;
+      return this;
+    }
+
+    public Builder signature(Signature signature) {
+      this.signature = signature;
+      return this;
+    }
+
+    public SCPEnvelope build() {
+      SCPEnvelope val = new SCPEnvelope();
+      val.setStatement(statement);
+      val.setSignature(signature);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/SCPHistoryEntry.java
+++ b/src/main/java/org/stellar/sdk/xdr/SCPHistoryEntry.java
@@ -33,6 +33,29 @@ public class SCPHistoryEntry implements XdrElement {
   public void setV0(SCPHistoryEntryV0 value) {
     this.v0 = value;
   }
+
+  public static final class Builder {
+    private Integer discriminant;
+    private SCPHistoryEntryV0 v0;
+
+    public Builder discriminant(Integer discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder v0(SCPHistoryEntryV0 v0) {
+      this.v0 = v0;
+      return this;
+    }
+
+    public SCPHistoryEntry build() {
+      SCPHistoryEntry val = new SCPHistoryEntry();
+      val.setDiscriminant(discriminant);
+      val.setV0(v0);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, SCPHistoryEntry encodedSCPHistoryEntry) throws IOException {
   //Xdrgen::AST::Typespecs::Int
   //Integer
@@ -63,7 +86,7 @@ public class SCPHistoryEntry implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SCPHistoryEntry)) {
+    if (!(object instanceof SCPHistoryEntry)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/SCPHistoryEntryV0.java
+++ b/src/main/java/org/stellar/sdk/xdr/SCPHistoryEntryV0.java
@@ -61,11 +61,33 @@ public class SCPHistoryEntryV0 implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SCPHistoryEntryV0)) {
+    if (!(object instanceof SCPHistoryEntryV0)) {
       return false;
     }
 
     SCPHistoryEntryV0 other = (SCPHistoryEntryV0) object;
     return Arrays.equals(this.quorumSets, other.quorumSets) && Objects.equal(this.ledgerMessages, other.ledgerMessages);
+  }
+
+  public static final class Builder {
+    private SCPQuorumSet[] quorumSets;
+    private LedgerSCPMessages ledgerMessages;
+
+    public Builder quorumSets(SCPQuorumSet[] quorumSets) {
+      this.quorumSets = quorumSets;
+      return this;
+    }
+
+    public Builder ledgerMessages(LedgerSCPMessages ledgerMessages) {
+      this.ledgerMessages = ledgerMessages;
+      return this;
+    }
+
+    public SCPHistoryEntryV0 build() {
+      SCPHistoryEntryV0 val = new SCPHistoryEntryV0();
+      val.setQuorumSets(quorumSets);
+      val.setLedgerMessages(ledgerMessages);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/SCPNomination.java
+++ b/src/main/java/org/stellar/sdk/xdr/SCPNomination.java
@@ -79,11 +79,40 @@ public class SCPNomination implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SCPNomination)) {
+    if (!(object instanceof SCPNomination)) {
       return false;
     }
 
     SCPNomination other = (SCPNomination) object;
     return Objects.equal(this.quorumSetHash, other.quorumSetHash) && Arrays.equals(this.votes, other.votes) && Arrays.equals(this.accepted, other.accepted);
+  }
+
+  public static final class Builder {
+    private Hash quorumSetHash;
+    private Value[] votes;
+    private Value[] accepted;
+
+    public Builder quorumSetHash(Hash quorumSetHash) {
+      this.quorumSetHash = quorumSetHash;
+      return this;
+    }
+
+    public Builder votes(Value[] votes) {
+      this.votes = votes;
+      return this;
+    }
+
+    public Builder accepted(Value[] accepted) {
+      this.accepted = accepted;
+      return this;
+    }
+
+    public SCPNomination build() {
+      SCPNomination val = new SCPNomination();
+      val.setQuorumSetHash(quorumSetHash);
+      val.setVotes(votes);
+      val.setAccepted(accepted);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/SCPQuorumSet.java
+++ b/src/main/java/org/stellar/sdk/xdr/SCPQuorumSet.java
@@ -79,11 +79,40 @@ public class SCPQuorumSet implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SCPQuorumSet)) {
+    if (!(object instanceof SCPQuorumSet)) {
       return false;
     }
 
     SCPQuorumSet other = (SCPQuorumSet) object;
     return Objects.equal(this.threshold, other.threshold) && Arrays.equals(this.validators, other.validators) && Arrays.equals(this.innerSets, other.innerSets);
+  }
+
+  public static final class Builder {
+    private Uint32 threshold;
+    private PublicKey[] validators;
+    private SCPQuorumSet[] innerSets;
+
+    public Builder threshold(Uint32 threshold) {
+      this.threshold = threshold;
+      return this;
+    }
+
+    public Builder validators(PublicKey[] validators) {
+      this.validators = validators;
+      return this;
+    }
+
+    public Builder innerSets(SCPQuorumSet[] innerSets) {
+      this.innerSets = innerSets;
+      return this;
+    }
+
+    public SCPQuorumSet build() {
+      SCPQuorumSet val = new SCPQuorumSet();
+      val.setThreshold(threshold);
+      val.setValidators(validators);
+      val.setInnerSets(innerSets);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/SCPStatement.java
+++ b/src/main/java/org/stellar/sdk/xdr/SCPStatement.java
@@ -94,12 +94,41 @@ public class SCPStatement implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SCPStatement)) {
+    if (!(object instanceof SCPStatement)) {
       return false;
     }
 
     SCPStatement other = (SCPStatement) object;
     return Objects.equal(this.nodeID, other.nodeID) && Objects.equal(this.slotIndex, other.slotIndex) && Objects.equal(this.pledges, other.pledges);
+  }
+
+  public static final class Builder {
+    private NodeID nodeID;
+    private Uint64 slotIndex;
+    private SCPStatementPledges pledges;
+
+    public Builder nodeID(NodeID nodeID) {
+      this.nodeID = nodeID;
+      return this;
+    }
+
+    public Builder slotIndex(Uint64 slotIndex) {
+      this.slotIndex = slotIndex;
+      return this;
+    }
+
+    public Builder pledges(SCPStatementPledges pledges) {
+      this.pledges = pledges;
+      return this;
+    }
+
+    public SCPStatement build() {
+      SCPStatement val = new SCPStatement();
+      val.setNodeID(nodeID);
+      val.setSlotIndex(slotIndex);
+      val.setPledges(pledges);
+      return val;
+    }
   }
 
   public static class SCPStatementPledges {
@@ -139,6 +168,50 @@ public class SCPStatement implements XdrElement {
     public void setNominate(SCPNomination value) {
       this.nominate = value;
     }
+
+    public static final class Builder {
+      private SCPStatementType discriminant;
+      private SCPStatementPrepare prepare;
+      private SCPStatementConfirm confirm;
+      private SCPStatementExternalize externalize;
+      private SCPNomination nominate;
+
+      public Builder discriminant(SCPStatementType discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder prepare(SCPStatementPrepare prepare) {
+        this.prepare = prepare;
+        return this;
+      }
+
+      public Builder confirm(SCPStatementConfirm confirm) {
+        this.confirm = confirm;
+        return this;
+      }
+
+      public Builder externalize(SCPStatementExternalize externalize) {
+        this.externalize = externalize;
+        return this;
+      }
+
+      public Builder nominate(SCPNomination nominate) {
+        this.nominate = nominate;
+        return this;
+      }
+
+      public SCPStatementPledges build() {
+        SCPStatementPledges val = new SCPStatementPledges();
+        val.setDiscriminant(discriminant);
+        val.setPrepare(prepare);
+        val.setConfirm(confirm);
+        val.setExternalize(externalize);
+        val.setNominate(nominate);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, SCPStatementPledges encodedSCPStatementPledges) throws IOException {
     //Xdrgen::AST::Identifier
     //SCPStatementType
@@ -187,7 +260,7 @@ public class SCPStatement implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof SCPStatementPledges)) {
+      if (!(object instanceof SCPStatementPledges)) {
         return false;
       }
 
@@ -282,12 +355,62 @@ public class SCPStatement implements XdrElement {
       }
       @Override
       public boolean equals(Object object) {
-        if (object == null || !(object instanceof SCPStatementPrepare)) {
+        if (!(object instanceof SCPStatementPrepare)) {
           return false;
         }
 
         SCPStatementPrepare other = (SCPStatementPrepare) object;
         return Objects.equal(this.quorumSetHash, other.quorumSetHash) && Objects.equal(this.ballot, other.ballot) && Objects.equal(this.prepared, other.prepared) && Objects.equal(this.preparedPrime, other.preparedPrime) && Objects.equal(this.nC, other.nC) && Objects.equal(this.nH, other.nH);
+      }
+
+      public static final class Builder {
+        private Hash quorumSetHash;
+        private SCPBallot ballot;
+        private SCPBallot prepared;
+        private SCPBallot preparedPrime;
+        private Uint32 nC;
+        private Uint32 nH;
+
+        public Builder quorumSetHash(Hash quorumSetHash) {
+          this.quorumSetHash = quorumSetHash;
+          return this;
+        }
+
+        public Builder ballot(SCPBallot ballot) {
+          this.ballot = ballot;
+          return this;
+        }
+
+        public Builder prepared(SCPBallot prepared) {
+          this.prepared = prepared;
+          return this;
+        }
+
+        public Builder preparedPrime(SCPBallot preparedPrime) {
+          this.preparedPrime = preparedPrime;
+          return this;
+        }
+
+        public Builder nC(Uint32 nC) {
+          this.nC = nC;
+          return this;
+        }
+
+        public Builder nH(Uint32 nH) {
+          this.nH = nH;
+          return this;
+        }
+
+        public SCPStatementPrepare build() {
+          SCPStatementPrepare val = new SCPStatementPrepare();
+          val.setQuorumSetHash(quorumSetHash);
+          val.setBallot(ballot);
+          val.setPrepared(prepared);
+          val.setPreparedPrime(preparedPrime);
+          val.setNC(nC);
+          val.setNH(nH);
+          return val;
+        }
       }
 
     }
@@ -353,12 +476,55 @@ public class SCPStatement implements XdrElement {
       }
       @Override
       public boolean equals(Object object) {
-        if (object == null || !(object instanceof SCPStatementConfirm)) {
+        if (!(object instanceof SCPStatementConfirm)) {
           return false;
         }
 
         SCPStatementConfirm other = (SCPStatementConfirm) object;
         return Objects.equal(this.ballot, other.ballot) && Objects.equal(this.nPrepared, other.nPrepared) && Objects.equal(this.nCommit, other.nCommit) && Objects.equal(this.nH, other.nH) && Objects.equal(this.quorumSetHash, other.quorumSetHash);
+      }
+
+      public static final class Builder {
+        private SCPBallot ballot;
+        private Uint32 nPrepared;
+        private Uint32 nCommit;
+        private Uint32 nH;
+        private Hash quorumSetHash;
+
+        public Builder ballot(SCPBallot ballot) {
+          this.ballot = ballot;
+          return this;
+        }
+
+        public Builder nPrepared(Uint32 nPrepared) {
+          this.nPrepared = nPrepared;
+          return this;
+        }
+
+        public Builder nCommit(Uint32 nCommit) {
+          this.nCommit = nCommit;
+          return this;
+        }
+
+        public Builder nH(Uint32 nH) {
+          this.nH = nH;
+          return this;
+        }
+
+        public Builder quorumSetHash(Hash quorumSetHash) {
+          this.quorumSetHash = quorumSetHash;
+          return this;
+        }
+
+        public SCPStatementConfirm build() {
+          SCPStatementConfirm val = new SCPStatementConfirm();
+          val.setBallot(ballot);
+          val.setNPrepared(nPrepared);
+          val.setNCommit(nCommit);
+          val.setNH(nH);
+          val.setQuorumSetHash(quorumSetHash);
+          return val;
+        }
       }
 
     }
@@ -406,12 +572,41 @@ public class SCPStatement implements XdrElement {
       }
       @Override
       public boolean equals(Object object) {
-        if (object == null || !(object instanceof SCPStatementExternalize)) {
+        if (!(object instanceof SCPStatementExternalize)) {
           return false;
         }
 
         SCPStatementExternalize other = (SCPStatementExternalize) object;
         return Objects.equal(this.commit, other.commit) && Objects.equal(this.nH, other.nH) && Objects.equal(this.commitQuorumSetHash, other.commitQuorumSetHash);
+      }
+
+      public static final class Builder {
+        private SCPBallot commit;
+        private Uint32 nH;
+        private Hash commitQuorumSetHash;
+
+        public Builder commit(SCPBallot commit) {
+          this.commit = commit;
+          return this;
+        }
+
+        public Builder nH(Uint32 nH) {
+          this.nH = nH;
+          return this;
+        }
+
+        public Builder commitQuorumSetHash(Hash commitQuorumSetHash) {
+          this.commitQuorumSetHash = commitQuorumSetHash;
+          return this;
+        }
+
+        public SCPStatementExternalize build() {
+          SCPStatementExternalize val = new SCPStatementExternalize();
+          val.setCommit(commit);
+          val.setNH(nH);
+          val.setCommitQuorumSetHash(commitQuorumSetHash);
+          return val;
+        }
       }
 
     }

--- a/src/main/java/org/stellar/sdk/xdr/SequenceNumber.java
+++ b/src/main/java/org/stellar/sdk/xdr/SequenceNumber.java
@@ -15,30 +15,42 @@ import com.google.common.base.Objects;
 //  ===========================================================================
 public class SequenceNumber implements XdrElement {
   private Int64 SequenceNumber;
+
+  public SequenceNumber() {}
+
+  public SequenceNumber(Int64 SequenceNumber) {
+    this.SequenceNumber = SequenceNumber;
+  }
+
   public Int64 getSequenceNumber() {
     return this.SequenceNumber;
   }
+
   public void setSequenceNumber(Int64 value) {
     this.SequenceNumber = value;
   }
+
   public static void encode(XdrDataOutputStream stream, SequenceNumber  encodedSequenceNumber) throws IOException {
-  Int64.encode(stream, encodedSequenceNumber.SequenceNumber);
+    Int64.encode(stream, encodedSequenceNumber.SequenceNumber);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static SequenceNumber decode(XdrDataInputStream stream) throws IOException {
     SequenceNumber decodedSequenceNumber = new SequenceNumber();
-  decodedSequenceNumber.SequenceNumber = Int64.decode(stream);
+    decodedSequenceNumber.SequenceNumber = Int64.decode(stream);
     return decodedSequenceNumber;
   }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(this.SequenceNumber);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SequenceNumber)) {
+    if (!(object instanceof SequenceNumber)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/SetOptionsOp.java
+++ b/src/main/java/org/stellar/sdk/xdr/SetOptionsOp.java
@@ -201,11 +201,82 @@ public class SetOptionsOp implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SetOptionsOp)) {
+    if (!(object instanceof SetOptionsOp)) {
       return false;
     }
 
     SetOptionsOp other = (SetOptionsOp) object;
     return Objects.equal(this.inflationDest, other.inflationDest) && Objects.equal(this.clearFlags, other.clearFlags) && Objects.equal(this.setFlags, other.setFlags) && Objects.equal(this.masterWeight, other.masterWeight) && Objects.equal(this.lowThreshold, other.lowThreshold) && Objects.equal(this.medThreshold, other.medThreshold) && Objects.equal(this.highThreshold, other.highThreshold) && Objects.equal(this.homeDomain, other.homeDomain) && Objects.equal(this.signer, other.signer);
+  }
+
+  public static final class Builder {
+    private AccountID inflationDest;
+    private Uint32 clearFlags;
+    private Uint32 setFlags;
+    private Uint32 masterWeight;
+    private Uint32 lowThreshold;
+    private Uint32 medThreshold;
+    private Uint32 highThreshold;
+    private String32 homeDomain;
+    private Signer signer;
+
+    public Builder inflationDest(AccountID inflationDest) {
+      this.inflationDest = inflationDest;
+      return this;
+    }
+
+    public Builder clearFlags(Uint32 clearFlags) {
+      this.clearFlags = clearFlags;
+      return this;
+    }
+
+    public Builder setFlags(Uint32 setFlags) {
+      this.setFlags = setFlags;
+      return this;
+    }
+
+    public Builder masterWeight(Uint32 masterWeight) {
+      this.masterWeight = masterWeight;
+      return this;
+    }
+
+    public Builder lowThreshold(Uint32 lowThreshold) {
+      this.lowThreshold = lowThreshold;
+      return this;
+    }
+
+    public Builder medThreshold(Uint32 medThreshold) {
+      this.medThreshold = medThreshold;
+      return this;
+    }
+
+    public Builder highThreshold(Uint32 highThreshold) {
+      this.highThreshold = highThreshold;
+      return this;
+    }
+
+    public Builder homeDomain(String32 homeDomain) {
+      this.homeDomain = homeDomain;
+      return this;
+    }
+
+    public Builder signer(Signer signer) {
+      this.signer = signer;
+      return this;
+    }
+
+    public SetOptionsOp build() {
+      SetOptionsOp val = new SetOptionsOp();
+      val.setInflationDest(inflationDest);
+      val.setClearFlags(clearFlags);
+      val.setSetFlags(setFlags);
+      val.setMasterWeight(masterWeight);
+      val.setLowThreshold(lowThreshold);
+      val.setMedThreshold(medThreshold);
+      val.setHighThreshold(highThreshold);
+      val.setHomeDomain(homeDomain);
+      val.setSigner(signer);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/SetOptionsResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/SetOptionsResult.java
@@ -28,6 +28,22 @@ public class SetOptionsResult implements XdrElement {
   public void setDiscriminant(SetOptionsResultCode value) {
     this.code = value;
   }
+
+  public static final class Builder {
+    private SetOptionsResultCode discriminant;
+
+    public Builder discriminant(SetOptionsResultCode discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public SetOptionsResult build() {
+      SetOptionsResult val = new SetOptionsResult();
+      val.setDiscriminant(discriminant);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, SetOptionsResult encodedSetOptionsResult) throws IOException {
   //Xdrgen::AST::Identifier
   //SetOptionsResultCode
@@ -60,7 +76,7 @@ public class SetOptionsResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SetOptionsResult)) {
+    if (!(object instanceof SetOptionsResult)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/Signature.java
+++ b/src/main/java/org/stellar/sdk/xdr/Signature.java
@@ -15,34 +15,46 @@ import java.util.Arrays;
 //  ===========================================================================
 public class Signature implements XdrElement {
   private byte[] Signature;
+
+  public Signature() {}
+
+  public Signature(byte[] Signature) {
+    this.Signature = Signature;
+  }
+
   public byte[] getSignature() {
     return this.Signature;
   }
+
   public void setSignature(byte[] value) {
     this.Signature = value;
   }
+
   public static void encode(XdrDataOutputStream stream, Signature  encodedSignature) throws IOException {
-  int Signaturesize = encodedSignature.Signature.length;
-  stream.writeInt(Signaturesize);
-  stream.write(encodedSignature.getSignature(), 0, Signaturesize);
+    int Signaturesize = encodedSignature.Signature.length;
+    stream.writeInt(Signaturesize);
+    stream.write(encodedSignature.getSignature(), 0, Signaturesize);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static Signature decode(XdrDataInputStream stream) throws IOException {
     Signature decodedSignature = new Signature();
-  int Signaturesize = stream.readInt();
-  decodedSignature.Signature = new byte[Signaturesize];
-  stream.read(decodedSignature.Signature, 0, Signaturesize);
+    int Signaturesize = stream.readInt();
+    decodedSignature.Signature = new byte[Signaturesize];
+    stream.read(decodedSignature.Signature, 0, Signaturesize);
     return decodedSignature;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.Signature);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Signature)) {
+    if (!(object instanceof Signature)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/SignatureHint.java
+++ b/src/main/java/org/stellar/sdk/xdr/SignatureHint.java
@@ -15,33 +15,45 @@ import java.util.Arrays;
 //  ===========================================================================
 public class SignatureHint implements XdrElement {
   private byte[] SignatureHint;
+
+  public SignatureHint() {}
+
+  public SignatureHint(byte[] SignatureHint) {
+    this.SignatureHint = SignatureHint;
+  }
+
   public byte[] getSignatureHint() {
     return this.SignatureHint;
   }
+
   public void setSignatureHint(byte[] value) {
     this.SignatureHint = value;
   }
+
   public static void encode(XdrDataOutputStream stream, SignatureHint  encodedSignatureHint) throws IOException {
-  int SignatureHintsize = encodedSignatureHint.SignatureHint.length;
-  stream.write(encodedSignatureHint.getSignatureHint(), 0, SignatureHintsize);
+    int SignatureHintsize = encodedSignatureHint.SignatureHint.length;
+    stream.write(encodedSignatureHint.getSignatureHint(), 0, SignatureHintsize);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static SignatureHint decode(XdrDataInputStream stream) throws IOException {
     SignatureHint decodedSignatureHint = new SignatureHint();
-  int SignatureHintsize = 4;
-  decodedSignatureHint.SignatureHint = new byte[SignatureHintsize];
-  stream.read(decodedSignatureHint.SignatureHint, 0, SignatureHintsize);
+    int SignatureHintsize = 4;
+    decodedSignatureHint.SignatureHint = new byte[SignatureHintsize];
+    stream.read(decodedSignatureHint.SignatureHint, 0, SignatureHintsize);
     return decodedSignatureHint;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.SignatureHint);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SignatureHint)) {
+    if (!(object instanceof SignatureHint)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/SignedSurveyRequestMessage.java
+++ b/src/main/java/org/stellar/sdk/xdr/SignedSurveyRequestMessage.java
@@ -52,11 +52,33 @@ public class SignedSurveyRequestMessage implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SignedSurveyRequestMessage)) {
+    if (!(object instanceof SignedSurveyRequestMessage)) {
       return false;
     }
 
     SignedSurveyRequestMessage other = (SignedSurveyRequestMessage) object;
     return Objects.equal(this.requestSignature, other.requestSignature) && Objects.equal(this.request, other.request);
+  }
+
+  public static final class Builder {
+    private Signature requestSignature;
+    private SurveyRequestMessage request;
+
+    public Builder requestSignature(Signature requestSignature) {
+      this.requestSignature = requestSignature;
+      return this;
+    }
+
+    public Builder request(SurveyRequestMessage request) {
+      this.request = request;
+      return this;
+    }
+
+    public SignedSurveyRequestMessage build() {
+      SignedSurveyRequestMessage val = new SignedSurveyRequestMessage();
+      val.setRequestSignature(requestSignature);
+      val.setRequest(request);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/SignedSurveyResponseMessage.java
+++ b/src/main/java/org/stellar/sdk/xdr/SignedSurveyResponseMessage.java
@@ -52,11 +52,33 @@ public class SignedSurveyResponseMessage implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SignedSurveyResponseMessage)) {
+    if (!(object instanceof SignedSurveyResponseMessage)) {
       return false;
     }
 
     SignedSurveyResponseMessage other = (SignedSurveyResponseMessage) object;
     return Objects.equal(this.responseSignature, other.responseSignature) && Objects.equal(this.response, other.response);
+  }
+
+  public static final class Builder {
+    private Signature responseSignature;
+    private SurveyResponseMessage response;
+
+    public Builder responseSignature(Signature responseSignature) {
+      this.responseSignature = responseSignature;
+      return this;
+    }
+
+    public Builder response(SurveyResponseMessage response) {
+      this.response = response;
+      return this;
+    }
+
+    public SignedSurveyResponseMessage build() {
+      SignedSurveyResponseMessage val = new SignedSurveyResponseMessage();
+      val.setResponseSignature(responseSignature);
+      val.setResponse(response);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Signer.java
+++ b/src/main/java/org/stellar/sdk/xdr/Signer.java
@@ -52,11 +52,33 @@ public class Signer implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Signer)) {
+    if (!(object instanceof Signer)) {
       return false;
     }
 
     Signer other = (Signer) object;
     return Objects.equal(this.key, other.key) && Objects.equal(this.weight, other.weight);
+  }
+
+  public static final class Builder {
+    private SignerKey key;
+    private Uint32 weight;
+
+    public Builder key(SignerKey key) {
+      this.key = key;
+      return this;
+    }
+
+    public Builder weight(Uint32 weight) {
+      this.weight = weight;
+      return this;
+    }
+
+    public Signer build() {
+      Signer val = new Signer();
+      val.setKey(key);
+      val.setWeight(weight);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/SignerKey.java
+++ b/src/main/java/org/stellar/sdk/xdr/SignerKey.java
@@ -53,6 +53,43 @@ public class SignerKey implements XdrElement {
   public void setHashX(Uint256 value) {
     this.hashX = value;
   }
+
+  public static final class Builder {
+    private SignerKeyType discriminant;
+    private Uint256 ed25519;
+    private Uint256 preAuthTx;
+    private Uint256 hashX;
+
+    public Builder discriminant(SignerKeyType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder ed25519(Uint256 ed25519) {
+      this.ed25519 = ed25519;
+      return this;
+    }
+
+    public Builder preAuthTx(Uint256 preAuthTx) {
+      this.preAuthTx = preAuthTx;
+      return this;
+    }
+
+    public Builder hashX(Uint256 hashX) {
+      this.hashX = hashX;
+      return this;
+    }
+
+    public SignerKey build() {
+      SignerKey val = new SignerKey();
+      val.setDiscriminant(discriminant);
+      val.setEd25519(ed25519);
+      val.setPreAuthTx(preAuthTx);
+      val.setHashX(hashX);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, SignerKey encodedSignerKey) throws IOException {
   //Xdrgen::AST::Identifier
   //SignerKeyType
@@ -95,7 +132,7 @@ public class SignerKey implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SignerKey)) {
+    if (!(object instanceof SignerKey)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/SimplePaymentResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/SimplePaymentResult.java
@@ -62,11 +62,40 @@ public class SimplePaymentResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SimplePaymentResult)) {
+    if (!(object instanceof SimplePaymentResult)) {
       return false;
     }
 
     SimplePaymentResult other = (SimplePaymentResult) object;
     return Objects.equal(this.destination, other.destination) && Objects.equal(this.asset, other.asset) && Objects.equal(this.amount, other.amount);
+  }
+
+  public static final class Builder {
+    private AccountID destination;
+    private Asset asset;
+    private Int64 amount;
+
+    public Builder destination(AccountID destination) {
+      this.destination = destination;
+      return this;
+    }
+
+    public Builder asset(Asset asset) {
+      this.asset = asset;
+      return this;
+    }
+
+    public Builder amount(Int64 amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    public SimplePaymentResult build() {
+      SimplePaymentResult val = new SimplePaymentResult();
+      val.setDestination(destination);
+      val.setAsset(asset);
+      val.setAmount(amount);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/SponsorshipDescriptor.java
+++ b/src/main/java/org/stellar/sdk/xdr/SponsorshipDescriptor.java
@@ -15,38 +15,50 @@ import com.google.common.base.Objects;
 //  ===========================================================================
 public class SponsorshipDescriptor implements XdrElement {
   private AccountID SponsorshipDescriptor;
+
+  public SponsorshipDescriptor() {}
+
+  public SponsorshipDescriptor(AccountID SponsorshipDescriptor) {
+    this.SponsorshipDescriptor = SponsorshipDescriptor;
+  }
+
   public AccountID getSponsorshipDescriptor() {
     return this.SponsorshipDescriptor;
   }
+
   public void setSponsorshipDescriptor(AccountID value) {
     this.SponsorshipDescriptor = value;
   }
+
   public static void encode(XdrDataOutputStream stream, SponsorshipDescriptor  encodedSponsorshipDescriptor) throws IOException {
-  if (encodedSponsorshipDescriptor.SponsorshipDescriptor != null) {
-  stream.writeInt(1);
-  AccountID.encode(stream, encodedSponsorshipDescriptor.SponsorshipDescriptor);
-  } else {
-  stream.writeInt(0);
+    if (encodedSponsorshipDescriptor.SponsorshipDescriptor != null) {
+    stream.writeInt(1);
+    AccountID.encode(stream, encodedSponsorshipDescriptor.SponsorshipDescriptor);
+    } else {
+    stream.writeInt(0);
+    }
   }
-  }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static SponsorshipDescriptor decode(XdrDataInputStream stream) throws IOException {
     SponsorshipDescriptor decodedSponsorshipDescriptor = new SponsorshipDescriptor();
-  int SponsorshipDescriptorPresent = stream.readInt();
-  if (SponsorshipDescriptorPresent != 0) {
-  decodedSponsorshipDescriptor.SponsorshipDescriptor = AccountID.decode(stream);
-  }
+    int SponsorshipDescriptorPresent = stream.readInt();
+    if (SponsorshipDescriptorPresent != 0) {
+    decodedSponsorshipDescriptor.SponsorshipDescriptor = AccountID.decode(stream);
+    }
     return decodedSponsorshipDescriptor;
   }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(this.SponsorshipDescriptor);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SponsorshipDescriptor)) {
+    if (!(object instanceof SponsorshipDescriptor)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/StellarMessage.java
+++ b/src/main/java/org/stellar/sdk/xdr/StellarMessage.java
@@ -159,6 +159,120 @@ public class StellarMessage implements XdrElement {
   public void setGetSCPLedgerSeq(Uint32 value) {
     this.getSCPLedgerSeq = value;
   }
+
+  public static final class Builder {
+    private MessageType discriminant;
+    private Error error;
+    private Hello hello;
+    private Auth auth;
+    private DontHave dontHave;
+    private PeerAddress[] peers;
+    private Uint256 txSetHash;
+    private TransactionSet txSet;
+    private TransactionEnvelope transaction;
+    private SignedSurveyRequestMessage signedSurveyRequestMessage;
+    private SignedSurveyResponseMessage signedSurveyResponseMessage;
+    private Uint256 qSetHash;
+    private SCPQuorumSet qSet;
+    private SCPEnvelope envelope;
+    private Uint32 getSCPLedgerSeq;
+
+    public Builder discriminant(MessageType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder error(Error error) {
+      this.error = error;
+      return this;
+    }
+
+    public Builder hello(Hello hello) {
+      this.hello = hello;
+      return this;
+    }
+
+    public Builder auth(Auth auth) {
+      this.auth = auth;
+      return this;
+    }
+
+    public Builder dontHave(DontHave dontHave) {
+      this.dontHave = dontHave;
+      return this;
+    }
+
+    public Builder peers(PeerAddress[] peers) {
+      this.peers = peers;
+      return this;
+    }
+
+    public Builder txSetHash(Uint256 txSetHash) {
+      this.txSetHash = txSetHash;
+      return this;
+    }
+
+    public Builder txSet(TransactionSet txSet) {
+      this.txSet = txSet;
+      return this;
+    }
+
+    public Builder transaction(TransactionEnvelope transaction) {
+      this.transaction = transaction;
+      return this;
+    }
+
+    public Builder signedSurveyRequestMessage(SignedSurveyRequestMessage signedSurveyRequestMessage) {
+      this.signedSurveyRequestMessage = signedSurveyRequestMessage;
+      return this;
+    }
+
+    public Builder signedSurveyResponseMessage(SignedSurveyResponseMessage signedSurveyResponseMessage) {
+      this.signedSurveyResponseMessage = signedSurveyResponseMessage;
+      return this;
+    }
+
+    public Builder qSetHash(Uint256 qSetHash) {
+      this.qSetHash = qSetHash;
+      return this;
+    }
+
+    public Builder qSet(SCPQuorumSet qSet) {
+      this.qSet = qSet;
+      return this;
+    }
+
+    public Builder envelope(SCPEnvelope envelope) {
+      this.envelope = envelope;
+      return this;
+    }
+
+    public Builder getSCPLedgerSeq(Uint32 getSCPLedgerSeq) {
+      this.getSCPLedgerSeq = getSCPLedgerSeq;
+      return this;
+    }
+
+    public StellarMessage build() {
+      StellarMessage val = new StellarMessage();
+      val.setDiscriminant(discriminant);
+      val.setError(error);
+      val.setHello(hello);
+      val.setAuth(auth);
+      val.setDontHave(dontHave);
+      val.setPeers(peers);
+      val.setTxSetHash(txSetHash);
+      val.setTxSet(txSet);
+      val.setTransaction(transaction);
+      val.setSignedSurveyRequestMessage(signedSurveyRequestMessage);
+      val.setSignedSurveyResponseMessage(signedSurveyResponseMessage);
+      val.setQSetHash(qSetHash);
+      val.setQSet(qSet);
+      val.setEnvelope(envelope);
+      val.setGetSCPLedgerSeq(getSCPLedgerSeq);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, StellarMessage encodedStellarMessage) throws IOException {
   //Xdrgen::AST::Identifier
   //MessageType
@@ -279,7 +393,7 @@ public class StellarMessage implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof StellarMessage)) {
+    if (!(object instanceof StellarMessage)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/StellarValue.java
+++ b/src/main/java/org/stellar/sdk/xdr/StellarValue.java
@@ -96,12 +96,48 @@ public class StellarValue implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof StellarValue)) {
+    if (!(object instanceof StellarValue)) {
       return false;
     }
 
     StellarValue other = (StellarValue) object;
     return Objects.equal(this.txSetHash, other.txSetHash) && Objects.equal(this.closeTime, other.closeTime) && Arrays.equals(this.upgrades, other.upgrades) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private Hash txSetHash;
+    private TimePoint closeTime;
+    private UpgradeType[] upgrades;
+    private StellarValueExt ext;
+
+    public Builder txSetHash(Hash txSetHash) {
+      this.txSetHash = txSetHash;
+      return this;
+    }
+
+    public Builder closeTime(TimePoint closeTime) {
+      this.closeTime = closeTime;
+      return this;
+    }
+
+    public Builder upgrades(UpgradeType[] upgrades) {
+      this.upgrades = upgrades;
+      return this;
+    }
+
+    public Builder ext(StellarValueExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public StellarValue build() {
+      StellarValue val = new StellarValue();
+      val.setTxSetHash(txSetHash);
+      val.setCloseTime(closeTime);
+      val.setUpgrades(upgrades);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class StellarValueExt {
@@ -120,6 +156,29 @@ public class StellarValue implements XdrElement {
     public void setLcValueSignature(LedgerCloseValueSignature value) {
       this.lcValueSignature = value;
     }
+
+    public static final class Builder {
+      private StellarValueType discriminant;
+      private LedgerCloseValueSignature lcValueSignature;
+
+      public Builder discriminant(StellarValueType discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder lcValueSignature(LedgerCloseValueSignature lcValueSignature) {
+        this.lcValueSignature = lcValueSignature;
+        return this;
+      }
+
+      public StellarValueExt build() {
+        StellarValueExt val = new StellarValueExt();
+        val.setDiscriminant(discriminant);
+        val.setLcValueSignature(lcValueSignature);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, StellarValueExt encodedStellarValueExt) throws IOException {
     //Xdrgen::AST::Identifier
     //StellarValueType
@@ -154,7 +213,7 @@ public class StellarValue implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof StellarValueExt)) {
+      if (!(object instanceof StellarValueExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/String32.java
+++ b/src/main/java/org/stellar/sdk/xdr/String32.java
@@ -15,30 +15,42 @@ import com.google.common.base.Objects;
 //  ===========================================================================
 public class String32 implements XdrElement {
   private XdrString string32;
+
+  public String32() {}
+
+  public String32(XdrString string32) {
+    this.string32 = string32;
+  }
+
   public XdrString getString32() {
     return this.string32;
   }
+
   public void setString32(XdrString value) {
     this.string32 = value;
   }
+
   public static void encode(XdrDataOutputStream stream, String32  encodedString32) throws IOException {
-  encodedString32.string32.encode(stream);
+    encodedString32.string32.encode(stream);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static String32 decode(XdrDataInputStream stream) throws IOException {
     String32 decodedString32 = new String32();
-  decodedString32.string32 = XdrString.decode(stream, 32);
+    decodedString32.string32 = XdrString.decode(stream, 32);
     return decodedString32;
   }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(this.string32);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof String32)) {
+    if (!(object instanceof String32)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/String64.java
+++ b/src/main/java/org/stellar/sdk/xdr/String64.java
@@ -15,30 +15,42 @@ import com.google.common.base.Objects;
 //  ===========================================================================
 public class String64 implements XdrElement {
   private XdrString string64;
+
+  public String64() {}
+
+  public String64(XdrString string64) {
+    this.string64 = string64;
+  }
+
   public XdrString getString64() {
     return this.string64;
   }
+
   public void setString64(XdrString value) {
     this.string64 = value;
   }
+
   public static void encode(XdrDataOutputStream stream, String64  encodedString64) throws IOException {
-  encodedString64.string64.encode(stream);
+    encodedString64.string64.encode(stream);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static String64 decode(XdrDataInputStream stream) throws IOException {
     String64 decodedString64 = new String64();
-  decodedString64.string64 = XdrString.decode(stream, 64);
+    decodedString64.string64 = XdrString.decode(stream, 64);
     return decodedString64;
   }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(this.string64);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof String64)) {
+    if (!(object instanceof String64)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/SurveyRequestMessage.java
+++ b/src/main/java/org/stellar/sdk/xdr/SurveyRequestMessage.java
@@ -82,11 +82,54 @@ public class SurveyRequestMessage implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SurveyRequestMessage)) {
+    if (!(object instanceof SurveyRequestMessage)) {
       return false;
     }
 
     SurveyRequestMessage other = (SurveyRequestMessage) object;
     return Objects.equal(this.surveyorPeerID, other.surveyorPeerID) && Objects.equal(this.surveyedPeerID, other.surveyedPeerID) && Objects.equal(this.ledgerNum, other.ledgerNum) && Objects.equal(this.encryptionKey, other.encryptionKey) && Objects.equal(this.commandType, other.commandType);
+  }
+
+  public static final class Builder {
+    private NodeID surveyorPeerID;
+    private NodeID surveyedPeerID;
+    private Uint32 ledgerNum;
+    private Curve25519Public encryptionKey;
+    private SurveyMessageCommandType commandType;
+
+    public Builder surveyorPeerID(NodeID surveyorPeerID) {
+      this.surveyorPeerID = surveyorPeerID;
+      return this;
+    }
+
+    public Builder surveyedPeerID(NodeID surveyedPeerID) {
+      this.surveyedPeerID = surveyedPeerID;
+      return this;
+    }
+
+    public Builder ledgerNum(Uint32 ledgerNum) {
+      this.ledgerNum = ledgerNum;
+      return this;
+    }
+
+    public Builder encryptionKey(Curve25519Public encryptionKey) {
+      this.encryptionKey = encryptionKey;
+      return this;
+    }
+
+    public Builder commandType(SurveyMessageCommandType commandType) {
+      this.commandType = commandType;
+      return this;
+    }
+
+    public SurveyRequestMessage build() {
+      SurveyRequestMessage val = new SurveyRequestMessage();
+      val.setSurveyorPeerID(surveyorPeerID);
+      val.setSurveyedPeerID(surveyedPeerID);
+      val.setLedgerNum(ledgerNum);
+      val.setEncryptionKey(encryptionKey);
+      val.setCommandType(commandType);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/SurveyResponseBody.java
+++ b/src/main/java/org/stellar/sdk/xdr/SurveyResponseBody.java
@@ -33,6 +33,29 @@ public class SurveyResponseBody implements XdrElement {
   public void setTopologyResponseBody(TopologyResponseBody value) {
     this.topologyResponseBody = value;
   }
+
+  public static final class Builder {
+    private SurveyMessageCommandType discriminant;
+    private TopologyResponseBody topologyResponseBody;
+
+    public Builder discriminant(SurveyMessageCommandType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder topologyResponseBody(TopologyResponseBody topologyResponseBody) {
+      this.topologyResponseBody = topologyResponseBody;
+      return this;
+    }
+
+    public SurveyResponseBody build() {
+      SurveyResponseBody val = new SurveyResponseBody();
+      val.setDiscriminant(discriminant);
+      val.setTopologyResponseBody(topologyResponseBody);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, SurveyResponseBody encodedSurveyResponseBody) throws IOException {
   //Xdrgen::AST::Identifier
   //SurveyMessageCommandType
@@ -63,7 +86,7 @@ public class SurveyResponseBody implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SurveyResponseBody)) {
+    if (!(object instanceof SurveyResponseBody)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/SurveyResponseMessage.java
+++ b/src/main/java/org/stellar/sdk/xdr/SurveyResponseMessage.java
@@ -82,11 +82,54 @@ public class SurveyResponseMessage implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SurveyResponseMessage)) {
+    if (!(object instanceof SurveyResponseMessage)) {
       return false;
     }
 
     SurveyResponseMessage other = (SurveyResponseMessage) object;
     return Objects.equal(this.surveyorPeerID, other.surveyorPeerID) && Objects.equal(this.surveyedPeerID, other.surveyedPeerID) && Objects.equal(this.ledgerNum, other.ledgerNum) && Objects.equal(this.commandType, other.commandType) && Objects.equal(this.encryptedBody, other.encryptedBody);
+  }
+
+  public static final class Builder {
+    private NodeID surveyorPeerID;
+    private NodeID surveyedPeerID;
+    private Uint32 ledgerNum;
+    private SurveyMessageCommandType commandType;
+    private EncryptedBody encryptedBody;
+
+    public Builder surveyorPeerID(NodeID surveyorPeerID) {
+      this.surveyorPeerID = surveyorPeerID;
+      return this;
+    }
+
+    public Builder surveyedPeerID(NodeID surveyedPeerID) {
+      this.surveyedPeerID = surveyedPeerID;
+      return this;
+    }
+
+    public Builder ledgerNum(Uint32 ledgerNum) {
+      this.ledgerNum = ledgerNum;
+      return this;
+    }
+
+    public Builder commandType(SurveyMessageCommandType commandType) {
+      this.commandType = commandType;
+      return this;
+    }
+
+    public Builder encryptedBody(EncryptedBody encryptedBody) {
+      this.encryptedBody = encryptedBody;
+      return this;
+    }
+
+    public SurveyResponseMessage build() {
+      SurveyResponseMessage val = new SurveyResponseMessage();
+      val.setSurveyorPeerID(surveyorPeerID);
+      val.setSurveyedPeerID(surveyedPeerID);
+      val.setLedgerNum(ledgerNum);
+      val.setCommandType(commandType);
+      val.setEncryptedBody(encryptedBody);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Thresholds.java
+++ b/src/main/java/org/stellar/sdk/xdr/Thresholds.java
@@ -15,33 +15,45 @@ import java.util.Arrays;
 //  ===========================================================================
 public class Thresholds implements XdrElement {
   private byte[] Thresholds;
+
+  public Thresholds() {}
+
+  public Thresholds(byte[] Thresholds) {
+    this.Thresholds = Thresholds;
+  }
+
   public byte[] getThresholds() {
     return this.Thresholds;
   }
+
   public void setThresholds(byte[] value) {
     this.Thresholds = value;
   }
+
   public static void encode(XdrDataOutputStream stream, Thresholds  encodedThresholds) throws IOException {
-  int Thresholdssize = encodedThresholds.Thresholds.length;
-  stream.write(encodedThresholds.getThresholds(), 0, Thresholdssize);
+    int Thresholdssize = encodedThresholds.Thresholds.length;
+    stream.write(encodedThresholds.getThresholds(), 0, Thresholdssize);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static Thresholds decode(XdrDataInputStream stream) throws IOException {
     Thresholds decodedThresholds = new Thresholds();
-  int Thresholdssize = 4;
-  decodedThresholds.Thresholds = new byte[Thresholdssize];
-  stream.read(decodedThresholds.Thresholds, 0, Thresholdssize);
+    int Thresholdssize = 4;
+    decodedThresholds.Thresholds = new byte[Thresholdssize];
+    stream.read(decodedThresholds.Thresholds, 0, Thresholdssize);
     return decodedThresholds;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.Thresholds);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Thresholds)) {
+    if (!(object instanceof Thresholds)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/TimeBounds.java
+++ b/src/main/java/org/stellar/sdk/xdr/TimeBounds.java
@@ -52,11 +52,33 @@ public class TimeBounds implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TimeBounds)) {
+    if (!(object instanceof TimeBounds)) {
       return false;
     }
 
     TimeBounds other = (TimeBounds) object;
     return Objects.equal(this.minTime, other.minTime) && Objects.equal(this.maxTime, other.maxTime);
+  }
+
+  public static final class Builder {
+    private TimePoint minTime;
+    private TimePoint maxTime;
+
+    public Builder minTime(TimePoint minTime) {
+      this.minTime = minTime;
+      return this;
+    }
+
+    public Builder maxTime(TimePoint maxTime) {
+      this.maxTime = maxTime;
+      return this;
+    }
+
+    public TimeBounds build() {
+      TimeBounds val = new TimeBounds();
+      val.setMinTime(minTime);
+      val.setMaxTime(maxTime);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/TimePoint.java
+++ b/src/main/java/org/stellar/sdk/xdr/TimePoint.java
@@ -15,30 +15,42 @@ import com.google.common.base.Objects;
 //  ===========================================================================
 public class TimePoint implements XdrElement {
   private Uint64 TimePoint;
+
+  public TimePoint() {}
+
+  public TimePoint(Uint64 TimePoint) {
+    this.TimePoint = TimePoint;
+  }
+
   public Uint64 getTimePoint() {
     return this.TimePoint;
   }
+
   public void setTimePoint(Uint64 value) {
     this.TimePoint = value;
   }
+
   public static void encode(XdrDataOutputStream stream, TimePoint  encodedTimePoint) throws IOException {
-  Uint64.encode(stream, encodedTimePoint.TimePoint);
+    Uint64.encode(stream, encodedTimePoint.TimePoint);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static TimePoint decode(XdrDataInputStream stream) throws IOException {
     TimePoint decodedTimePoint = new TimePoint();
-  decodedTimePoint.TimePoint = Uint64.decode(stream);
+    decodedTimePoint.TimePoint = Uint64.decode(stream);
     return decodedTimePoint;
   }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(this.TimePoint);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TimePoint)) {
+    if (!(object instanceof TimePoint)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/TopologyResponseBody.java
+++ b/src/main/java/org/stellar/sdk/xdr/TopologyResponseBody.java
@@ -73,11 +73,47 @@ public class TopologyResponseBody implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TopologyResponseBody)) {
+    if (!(object instanceof TopologyResponseBody)) {
       return false;
     }
 
     TopologyResponseBody other = (TopologyResponseBody) object;
     return Objects.equal(this.inboundPeers, other.inboundPeers) && Objects.equal(this.outboundPeers, other.outboundPeers) && Objects.equal(this.totalInboundPeerCount, other.totalInboundPeerCount) && Objects.equal(this.totalOutboundPeerCount, other.totalOutboundPeerCount);
+  }
+
+  public static final class Builder {
+    private PeerStatList inboundPeers;
+    private PeerStatList outboundPeers;
+    private Uint32 totalInboundPeerCount;
+    private Uint32 totalOutboundPeerCount;
+
+    public Builder inboundPeers(PeerStatList inboundPeers) {
+      this.inboundPeers = inboundPeers;
+      return this;
+    }
+
+    public Builder outboundPeers(PeerStatList outboundPeers) {
+      this.outboundPeers = outboundPeers;
+      return this;
+    }
+
+    public Builder totalInboundPeerCount(Uint32 totalInboundPeerCount) {
+      this.totalInboundPeerCount = totalInboundPeerCount;
+      return this;
+    }
+
+    public Builder totalOutboundPeerCount(Uint32 totalOutboundPeerCount) {
+      this.totalOutboundPeerCount = totalOutboundPeerCount;
+      return this;
+    }
+
+    public TopologyResponseBody build() {
+      TopologyResponseBody val = new TopologyResponseBody();
+      val.setInboundPeers(inboundPeers);
+      val.setOutboundPeers(outboundPeers);
+      val.setTotalInboundPeerCount(totalInboundPeerCount);
+      val.setTotalOutboundPeerCount(totalOutboundPeerCount);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/Transaction.java
+++ b/src/main/java/org/stellar/sdk/xdr/Transaction.java
@@ -135,12 +135,69 @@ public class Transaction implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Transaction)) {
+    if (!(object instanceof Transaction)) {
       return false;
     }
 
     Transaction other = (Transaction) object;
     return Objects.equal(this.sourceAccount, other.sourceAccount) && Objects.equal(this.fee, other.fee) && Objects.equal(this.seqNum, other.seqNum) && Objects.equal(this.timeBounds, other.timeBounds) && Objects.equal(this.memo, other.memo) && Arrays.equals(this.operations, other.operations) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private MuxedAccount sourceAccount;
+    private Uint32 fee;
+    private SequenceNumber seqNum;
+    private TimeBounds timeBounds;
+    private Memo memo;
+    private Operation[] operations;
+    private TransactionExt ext;
+
+    public Builder sourceAccount(MuxedAccount sourceAccount) {
+      this.sourceAccount = sourceAccount;
+      return this;
+    }
+
+    public Builder fee(Uint32 fee) {
+      this.fee = fee;
+      return this;
+    }
+
+    public Builder seqNum(SequenceNumber seqNum) {
+      this.seqNum = seqNum;
+      return this;
+    }
+
+    public Builder timeBounds(TimeBounds timeBounds) {
+      this.timeBounds = timeBounds;
+      return this;
+    }
+
+    public Builder memo(Memo memo) {
+      this.memo = memo;
+      return this;
+    }
+
+    public Builder operations(Operation[] operations) {
+      this.operations = operations;
+      return this;
+    }
+
+    public Builder ext(TransactionExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public Transaction build() {
+      Transaction val = new Transaction();
+      val.setSourceAccount(sourceAccount);
+      val.setFee(fee);
+      val.setSeqNum(seqNum);
+      val.setTimeBounds(timeBounds);
+      val.setMemo(memo);
+      val.setOperations(operations);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class TransactionExt {
@@ -152,6 +209,22 @@ public class Transaction implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public TransactionExt build() {
+        TransactionExt val = new TransactionExt();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, TransactionExt encodedTransactionExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -180,7 +253,7 @@ public class Transaction implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof TransactionExt)) {
+      if (!(object instanceof TransactionExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/TransactionEnvelope.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionEnvelope.java
@@ -51,6 +51,43 @@ public class TransactionEnvelope implements XdrElement {
   public void setFeeBump(FeeBumpTransactionEnvelope value) {
     this.feeBump = value;
   }
+
+  public static final class Builder {
+    private EnvelopeType discriminant;
+    private TransactionV0Envelope v0;
+    private TransactionV1Envelope v1;
+    private FeeBumpTransactionEnvelope feeBump;
+
+    public Builder discriminant(EnvelopeType discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder v0(TransactionV0Envelope v0) {
+      this.v0 = v0;
+      return this;
+    }
+
+    public Builder v1(TransactionV1Envelope v1) {
+      this.v1 = v1;
+      return this;
+    }
+
+    public Builder feeBump(FeeBumpTransactionEnvelope feeBump) {
+      this.feeBump = feeBump;
+      return this;
+    }
+
+    public TransactionEnvelope build() {
+      TransactionEnvelope val = new TransactionEnvelope();
+      val.setDiscriminant(discriminant);
+      val.setV0(v0);
+      val.setV1(v1);
+      val.setFeeBump(feeBump);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, TransactionEnvelope encodedTransactionEnvelope) throws IOException {
   //Xdrgen::AST::Identifier
   //EnvelopeType
@@ -93,7 +130,7 @@ public class TransactionEnvelope implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionEnvelope)) {
+    if (!(object instanceof TransactionEnvelope)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/TransactionHistoryEntry.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionHistoryEntry.java
@@ -69,12 +69,41 @@ public class TransactionHistoryEntry implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionHistoryEntry)) {
+    if (!(object instanceof TransactionHistoryEntry)) {
       return false;
     }
 
     TransactionHistoryEntry other = (TransactionHistoryEntry) object;
     return Objects.equal(this.ledgerSeq, other.ledgerSeq) && Objects.equal(this.txSet, other.txSet) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private Uint32 ledgerSeq;
+    private TransactionSet txSet;
+    private TransactionHistoryEntryExt ext;
+
+    public Builder ledgerSeq(Uint32 ledgerSeq) {
+      this.ledgerSeq = ledgerSeq;
+      return this;
+    }
+
+    public Builder txSet(TransactionSet txSet) {
+      this.txSet = txSet;
+      return this;
+    }
+
+    public Builder ext(TransactionHistoryEntryExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public TransactionHistoryEntry build() {
+      TransactionHistoryEntry val = new TransactionHistoryEntry();
+      val.setLedgerSeq(ledgerSeq);
+      val.setTxSet(txSet);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class TransactionHistoryEntryExt {
@@ -86,6 +115,22 @@ public class TransactionHistoryEntry implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public TransactionHistoryEntryExt build() {
+        TransactionHistoryEntryExt val = new TransactionHistoryEntryExt();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, TransactionHistoryEntryExt encodedTransactionHistoryEntryExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -114,7 +159,7 @@ public class TransactionHistoryEntry implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof TransactionHistoryEntryExt)) {
+      if (!(object instanceof TransactionHistoryEntryExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/TransactionHistoryResultEntry.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionHistoryResultEntry.java
@@ -69,12 +69,41 @@ public class TransactionHistoryResultEntry implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionHistoryResultEntry)) {
+    if (!(object instanceof TransactionHistoryResultEntry)) {
       return false;
     }
 
     TransactionHistoryResultEntry other = (TransactionHistoryResultEntry) object;
     return Objects.equal(this.ledgerSeq, other.ledgerSeq) && Objects.equal(this.txResultSet, other.txResultSet) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private Uint32 ledgerSeq;
+    private TransactionResultSet txResultSet;
+    private TransactionHistoryResultEntryExt ext;
+
+    public Builder ledgerSeq(Uint32 ledgerSeq) {
+      this.ledgerSeq = ledgerSeq;
+      return this;
+    }
+
+    public Builder txResultSet(TransactionResultSet txResultSet) {
+      this.txResultSet = txResultSet;
+      return this;
+    }
+
+    public Builder ext(TransactionHistoryResultEntryExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public TransactionHistoryResultEntry build() {
+      TransactionHistoryResultEntry val = new TransactionHistoryResultEntry();
+      val.setLedgerSeq(ledgerSeq);
+      val.setTxResultSet(txResultSet);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class TransactionHistoryResultEntryExt {
@@ -86,6 +115,22 @@ public class TransactionHistoryResultEntry implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public TransactionHistoryResultEntryExt build() {
+        TransactionHistoryResultEntryExt val = new TransactionHistoryResultEntryExt();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, TransactionHistoryResultEntryExt encodedTransactionHistoryResultEntryExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -114,7 +159,7 @@ public class TransactionHistoryResultEntry implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof TransactionHistoryResultEntryExt)) {
+      if (!(object instanceof TransactionHistoryResultEntryExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/TransactionMeta.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionMeta.java
@@ -52,6 +52,43 @@ public class TransactionMeta implements XdrElement {
   public void setV2(TransactionMetaV2 value) {
     this.v2 = value;
   }
+
+  public static final class Builder {
+    private Integer discriminant;
+    private OperationMeta[] operations;
+    private TransactionMetaV1 v1;
+    private TransactionMetaV2 v2;
+
+    public Builder discriminant(Integer discriminant) {
+      this.discriminant = discriminant;
+      return this;
+    }
+
+    public Builder operations(OperationMeta[] operations) {
+      this.operations = operations;
+      return this;
+    }
+
+    public Builder v1(TransactionMetaV1 v1) {
+      this.v1 = v1;
+      return this;
+    }
+
+    public Builder v2(TransactionMetaV2 v2) {
+      this.v2 = v2;
+      return this;
+    }
+
+    public TransactionMeta build() {
+      TransactionMeta val = new TransactionMeta();
+      val.setDiscriminant(discriminant);
+      val.setOperations(operations);
+      val.setV1(v1);
+      val.setV2(v2);
+      return val;
+    }
+  }
+
   public static void encode(XdrDataOutputStream stream, TransactionMeta encodedTransactionMeta) throws IOException {
   //Xdrgen::AST::Typespecs::Int
   //Integer
@@ -102,7 +139,7 @@ public class TransactionMeta implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionMeta)) {
+    if (!(object instanceof TransactionMeta)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/TransactionMetaV1.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionMetaV1.java
@@ -61,11 +61,33 @@ public class TransactionMetaV1 implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionMetaV1)) {
+    if (!(object instanceof TransactionMetaV1)) {
       return false;
     }
 
     TransactionMetaV1 other = (TransactionMetaV1) object;
     return Objects.equal(this.txChanges, other.txChanges) && Arrays.equals(this.operations, other.operations);
+  }
+
+  public static final class Builder {
+    private LedgerEntryChanges txChanges;
+    private OperationMeta[] operations;
+
+    public Builder txChanges(LedgerEntryChanges txChanges) {
+      this.txChanges = txChanges;
+      return this;
+    }
+
+    public Builder operations(OperationMeta[] operations) {
+      this.operations = operations;
+      return this;
+    }
+
+    public TransactionMetaV1 build() {
+      TransactionMetaV1 val = new TransactionMetaV1();
+      val.setTxChanges(txChanges);
+      val.setOperations(operations);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/TransactionMetaV2.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionMetaV2.java
@@ -73,11 +73,40 @@ public class TransactionMetaV2 implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionMetaV2)) {
+    if (!(object instanceof TransactionMetaV2)) {
       return false;
     }
 
     TransactionMetaV2 other = (TransactionMetaV2) object;
     return Objects.equal(this.txChangesBefore, other.txChangesBefore) && Arrays.equals(this.operations, other.operations) && Objects.equal(this.txChangesAfter, other.txChangesAfter);
+  }
+
+  public static final class Builder {
+    private LedgerEntryChanges txChangesBefore;
+    private OperationMeta[] operations;
+    private LedgerEntryChanges txChangesAfter;
+
+    public Builder txChangesBefore(LedgerEntryChanges txChangesBefore) {
+      this.txChangesBefore = txChangesBefore;
+      return this;
+    }
+
+    public Builder operations(OperationMeta[] operations) {
+      this.operations = operations;
+      return this;
+    }
+
+    public Builder txChangesAfter(LedgerEntryChanges txChangesAfter) {
+      this.txChangesAfter = txChangesAfter;
+      return this;
+    }
+
+    public TransactionMetaV2 build() {
+      TransactionMetaV2 val = new TransactionMetaV2();
+      val.setTxChangesBefore(txChangesBefore);
+      val.setOperations(operations);
+      val.setTxChangesAfter(txChangesAfter);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/TransactionResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionResult.java
@@ -82,12 +82,41 @@ public class TransactionResult implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionResult)) {
+    if (!(object instanceof TransactionResult)) {
       return false;
     }
 
     TransactionResult other = (TransactionResult) object;
     return Objects.equal(this.feeCharged, other.feeCharged) && Objects.equal(this.result, other.result) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private Int64 feeCharged;
+    private TransactionResultResult result;
+    private TransactionResultExt ext;
+
+    public Builder feeCharged(Int64 feeCharged) {
+      this.feeCharged = feeCharged;
+      return this;
+    }
+
+    public Builder result(TransactionResultResult result) {
+      this.result = result;
+      return this;
+    }
+
+    public Builder ext(TransactionResultExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public TransactionResult build() {
+      TransactionResult val = new TransactionResult();
+      val.setFeeCharged(feeCharged);
+      val.setResult(result);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class TransactionResultResult {
@@ -113,6 +142,36 @@ public class TransactionResult implements XdrElement {
     public void setResults(OperationResult[] value) {
       this.results = value;
     }
+
+    public static final class Builder {
+      private TransactionResultCode discriminant;
+      private InnerTransactionResultPair innerResultPair;
+      private OperationResult[] results;
+
+      public Builder discriminant(TransactionResultCode discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder innerResultPair(InnerTransactionResultPair innerResultPair) {
+        this.innerResultPair = innerResultPair;
+        return this;
+      }
+
+      public Builder results(OperationResult[] results) {
+        this.results = results;
+        return this;
+      }
+
+      public TransactionResultResult build() {
+        TransactionResultResult val = new TransactionResultResult();
+        val.setDiscriminant(discriminant);
+        val.setInnerResultPair(innerResultPair);
+        val.setResults(results);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, TransactionResultResult encodedTransactionResultResult) throws IOException {
     //Xdrgen::AST::Identifier
     //TransactionResultCode
@@ -165,7 +224,7 @@ public class TransactionResult implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof TransactionResultResult)) {
+      if (!(object instanceof TransactionResultResult)) {
         return false;
       }
 
@@ -183,6 +242,22 @@ public class TransactionResult implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public TransactionResultExt build() {
+        TransactionResultExt val = new TransactionResultExt();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, TransactionResultExt encodedTransactionResultExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -211,7 +286,7 @@ public class TransactionResult implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof TransactionResultExt)) {
+      if (!(object instanceof TransactionResultExt)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/TransactionResultMeta.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionResultMeta.java
@@ -62,11 +62,40 @@ public class TransactionResultMeta implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionResultMeta)) {
+    if (!(object instanceof TransactionResultMeta)) {
       return false;
     }
 
     TransactionResultMeta other = (TransactionResultMeta) object;
     return Objects.equal(this.result, other.result) && Objects.equal(this.feeProcessing, other.feeProcessing) && Objects.equal(this.txApplyProcessing, other.txApplyProcessing);
+  }
+
+  public static final class Builder {
+    private TransactionResultPair result;
+    private LedgerEntryChanges feeProcessing;
+    private TransactionMeta txApplyProcessing;
+
+    public Builder result(TransactionResultPair result) {
+      this.result = result;
+      return this;
+    }
+
+    public Builder feeProcessing(LedgerEntryChanges feeProcessing) {
+      this.feeProcessing = feeProcessing;
+      return this;
+    }
+
+    public Builder txApplyProcessing(TransactionMeta txApplyProcessing) {
+      this.txApplyProcessing = txApplyProcessing;
+      return this;
+    }
+
+    public TransactionResultMeta build() {
+      TransactionResultMeta val = new TransactionResultMeta();
+      val.setResult(result);
+      val.setFeeProcessing(feeProcessing);
+      val.setTxApplyProcessing(txApplyProcessing);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/TransactionResultPair.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionResultPair.java
@@ -52,11 +52,33 @@ public class TransactionResultPair implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionResultPair)) {
+    if (!(object instanceof TransactionResultPair)) {
       return false;
     }
 
     TransactionResultPair other = (TransactionResultPair) object;
     return Objects.equal(this.transactionHash, other.transactionHash) && Objects.equal(this.result, other.result);
+  }
+
+  public static final class Builder {
+    private Hash transactionHash;
+    private TransactionResult result;
+
+    public Builder transactionHash(Hash transactionHash) {
+      this.transactionHash = transactionHash;
+      return this;
+    }
+
+    public Builder result(TransactionResult result) {
+      this.result = result;
+      return this;
+    }
+
+    public TransactionResultPair build() {
+      TransactionResultPair val = new TransactionResultPair();
+      val.setTransactionHash(transactionHash);
+      val.setResult(result);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/TransactionResultSet.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionResultSet.java
@@ -50,11 +50,26 @@ public class TransactionResultSet implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionResultSet)) {
+    if (!(object instanceof TransactionResultSet)) {
       return false;
     }
 
     TransactionResultSet other = (TransactionResultSet) object;
     return Arrays.equals(this.results, other.results);
+  }
+
+  public static final class Builder {
+    private TransactionResultPair[] results;
+
+    public Builder results(TransactionResultPair[] results) {
+      this.results = results;
+      return this;
+    }
+
+    public TransactionResultSet build() {
+      TransactionResultSet val = new TransactionResultSet();
+      val.setResults(results);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/TransactionSet.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionSet.java
@@ -61,11 +61,33 @@ public class TransactionSet implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionSet)) {
+    if (!(object instanceof TransactionSet)) {
       return false;
     }
 
     TransactionSet other = (TransactionSet) object;
     return Objects.equal(this.previousLedgerHash, other.previousLedgerHash) && Arrays.equals(this.txs, other.txs);
+  }
+
+  public static final class Builder {
+    private Hash previousLedgerHash;
+    private TransactionEnvelope[] txs;
+
+    public Builder previousLedgerHash(Hash previousLedgerHash) {
+      this.previousLedgerHash = previousLedgerHash;
+      return this;
+    }
+
+    public Builder txs(TransactionEnvelope[] txs) {
+      this.txs = txs;
+      return this;
+    }
+
+    public TransactionSet build() {
+      TransactionSet val = new TransactionSet();
+      val.setPreviousLedgerHash(previousLedgerHash);
+      val.setTxs(txs);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/TransactionSignaturePayload.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionSignaturePayload.java
@@ -60,12 +60,34 @@ public class TransactionSignaturePayload implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionSignaturePayload)) {
+    if (!(object instanceof TransactionSignaturePayload)) {
       return false;
     }
 
     TransactionSignaturePayload other = (TransactionSignaturePayload) object;
     return Objects.equal(this.networkId, other.networkId) && Objects.equal(this.taggedTransaction, other.taggedTransaction);
+  }
+
+  public static final class Builder {
+    private Hash networkId;
+    private TransactionSignaturePayloadTaggedTransaction taggedTransaction;
+
+    public Builder networkId(Hash networkId) {
+      this.networkId = networkId;
+      return this;
+    }
+
+    public Builder taggedTransaction(TransactionSignaturePayloadTaggedTransaction taggedTransaction) {
+      this.taggedTransaction = taggedTransaction;
+      return this;
+    }
+
+    public TransactionSignaturePayload build() {
+      TransactionSignaturePayload val = new TransactionSignaturePayload();
+      val.setNetworkId(networkId);
+      val.setTaggedTransaction(taggedTransaction);
+      return val;
+    }
   }
 
   public static class TransactionSignaturePayloadTaggedTransaction {
@@ -91,6 +113,36 @@ public class TransactionSignaturePayload implements XdrElement {
     public void setFeeBump(FeeBumpTransaction value) {
       this.feeBump = value;
     }
+
+    public static final class Builder {
+      private EnvelopeType discriminant;
+      private Transaction tx;
+      private FeeBumpTransaction feeBump;
+
+      public Builder discriminant(EnvelopeType discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder tx(Transaction tx) {
+        this.tx = tx;
+        return this;
+      }
+
+      public Builder feeBump(FeeBumpTransaction feeBump) {
+        this.feeBump = feeBump;
+        return this;
+      }
+
+      public TransactionSignaturePayloadTaggedTransaction build() {
+        TransactionSignaturePayloadTaggedTransaction val = new TransactionSignaturePayloadTaggedTransaction();
+        val.setDiscriminant(discriminant);
+        val.setTx(tx);
+        val.setFeeBump(feeBump);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, TransactionSignaturePayloadTaggedTransaction encodedTransactionSignaturePayloadTaggedTransaction) throws IOException {
     //Xdrgen::AST::Identifier
     //EnvelopeType
@@ -127,7 +179,7 @@ public class TransactionSignaturePayload implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof TransactionSignaturePayloadTaggedTransaction)) {
+      if (!(object instanceof TransactionSignaturePayloadTaggedTransaction)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/TransactionV0.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionV0.java
@@ -124,12 +124,69 @@ public class TransactionV0 implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionV0)) {
+    if (!(object instanceof TransactionV0)) {
       return false;
     }
 
     TransactionV0 other = (TransactionV0) object;
     return Objects.equal(this.sourceAccountEd25519, other.sourceAccountEd25519) && Objects.equal(this.fee, other.fee) && Objects.equal(this.seqNum, other.seqNum) && Objects.equal(this.timeBounds, other.timeBounds) && Objects.equal(this.memo, other.memo) && Arrays.equals(this.operations, other.operations) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private Uint256 sourceAccountEd25519;
+    private Uint32 fee;
+    private SequenceNumber seqNum;
+    private TimeBounds timeBounds;
+    private Memo memo;
+    private Operation[] operations;
+    private TransactionV0Ext ext;
+
+    public Builder sourceAccountEd25519(Uint256 sourceAccountEd25519) {
+      this.sourceAccountEd25519 = sourceAccountEd25519;
+      return this;
+    }
+
+    public Builder fee(Uint32 fee) {
+      this.fee = fee;
+      return this;
+    }
+
+    public Builder seqNum(SequenceNumber seqNum) {
+      this.seqNum = seqNum;
+      return this;
+    }
+
+    public Builder timeBounds(TimeBounds timeBounds) {
+      this.timeBounds = timeBounds;
+      return this;
+    }
+
+    public Builder memo(Memo memo) {
+      this.memo = memo;
+      return this;
+    }
+
+    public Builder operations(Operation[] operations) {
+      this.operations = operations;
+      return this;
+    }
+
+    public Builder ext(TransactionV0Ext ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public TransactionV0 build() {
+      TransactionV0 val = new TransactionV0();
+      val.setSourceAccountEd25519(sourceAccountEd25519);
+      val.setFee(fee);
+      val.setSeqNum(seqNum);
+      val.setTimeBounds(timeBounds);
+      val.setMemo(memo);
+      val.setOperations(operations);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class TransactionV0Ext {
@@ -141,6 +198,22 @@ public class TransactionV0 implements XdrElement {
     public void setDiscriminant(Integer value) {
       this.v = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public TransactionV0Ext build() {
+        TransactionV0Ext val = new TransactionV0Ext();
+        val.setDiscriminant(discriminant);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, TransactionV0Ext encodedTransactionV0Ext) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -169,7 +242,7 @@ public class TransactionV0 implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof TransactionV0Ext)) {
+      if (!(object instanceof TransactionV0Ext)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/TransactionV0Envelope.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionV0Envelope.java
@@ -63,11 +63,33 @@ public class TransactionV0Envelope implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionV0Envelope)) {
+    if (!(object instanceof TransactionV0Envelope)) {
       return false;
     }
 
     TransactionV0Envelope other = (TransactionV0Envelope) object;
     return Objects.equal(this.tx, other.tx) && Arrays.equals(this.signatures, other.signatures);
+  }
+
+  public static final class Builder {
+    private TransactionV0 tx;
+    private DecoratedSignature[] signatures;
+
+    public Builder tx(TransactionV0 tx) {
+      this.tx = tx;
+      return this;
+    }
+
+    public Builder signatures(DecoratedSignature[] signatures) {
+      this.signatures = signatures;
+      return this;
+    }
+
+    public TransactionV0Envelope build() {
+      TransactionV0Envelope val = new TransactionV0Envelope();
+      val.setTx(tx);
+      val.setSignatures(signatures);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/TransactionV1Envelope.java
+++ b/src/main/java/org/stellar/sdk/xdr/TransactionV1Envelope.java
@@ -63,11 +63,33 @@ public class TransactionV1Envelope implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TransactionV1Envelope)) {
+    if (!(object instanceof TransactionV1Envelope)) {
       return false;
     }
 
     TransactionV1Envelope other = (TransactionV1Envelope) object;
     return Objects.equal(this.tx, other.tx) && Arrays.equals(this.signatures, other.signatures);
+  }
+
+  public static final class Builder {
+    private Transaction tx;
+    private DecoratedSignature[] signatures;
+
+    public Builder tx(Transaction tx) {
+      this.tx = tx;
+      return this;
+    }
+
+    public Builder signatures(DecoratedSignature[] signatures) {
+      this.signatures = signatures;
+      return this;
+    }
+
+    public TransactionV1Envelope build() {
+      TransactionV1Envelope val = new TransactionV1Envelope();
+      val.setTx(tx);
+      val.setSignatures(signatures);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/TrustLineEntry.java
+++ b/src/main/java/org/stellar/sdk/xdr/TrustLineEntry.java
@@ -113,12 +113,62 @@ public class TrustLineEntry implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof TrustLineEntry)) {
+    if (!(object instanceof TrustLineEntry)) {
       return false;
     }
 
     TrustLineEntry other = (TrustLineEntry) object;
     return Objects.equal(this.accountID, other.accountID) && Objects.equal(this.asset, other.asset) && Objects.equal(this.balance, other.balance) && Objects.equal(this.limit, other.limit) && Objects.equal(this.flags, other.flags) && Objects.equal(this.ext, other.ext);
+  }
+
+  public static final class Builder {
+    private AccountID accountID;
+    private Asset asset;
+    private Int64 balance;
+    private Int64 limit;
+    private Uint32 flags;
+    private TrustLineEntryExt ext;
+
+    public Builder accountID(AccountID accountID) {
+      this.accountID = accountID;
+      return this;
+    }
+
+    public Builder asset(Asset asset) {
+      this.asset = asset;
+      return this;
+    }
+
+    public Builder balance(Int64 balance) {
+      this.balance = balance;
+      return this;
+    }
+
+    public Builder limit(Int64 limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public Builder flags(Uint32 flags) {
+      this.flags = flags;
+      return this;
+    }
+
+    public Builder ext(TrustLineEntryExt ext) {
+      this.ext = ext;
+      return this;
+    }
+
+    public TrustLineEntry build() {
+      TrustLineEntry val = new TrustLineEntry();
+      val.setAccountID(accountID);
+      val.setAsset(asset);
+      val.setBalance(balance);
+      val.setLimit(limit);
+      val.setFlags(flags);
+      val.setExt(ext);
+      return val;
+    }
   }
 
   public static class TrustLineEntryExt {
@@ -137,6 +187,29 @@ public class TrustLineEntry implements XdrElement {
     public void setV1(TrustLineEntryV1 value) {
       this.v1 = value;
     }
+
+    public static final class Builder {
+      private Integer discriminant;
+      private TrustLineEntryV1 v1;
+
+      public Builder discriminant(Integer discriminant) {
+        this.discriminant = discriminant;
+        return this;
+      }
+
+      public Builder v1(TrustLineEntryV1 v1) {
+        this.v1 = v1;
+        return this;
+      }
+
+      public TrustLineEntryExt build() {
+        TrustLineEntryExt val = new TrustLineEntryExt();
+        val.setDiscriminant(discriminant);
+        val.setV1(v1);
+        return val;
+      }
+    }
+
     public static void encode(XdrDataOutputStream stream, TrustLineEntryExt encodedTrustLineEntryExt) throws IOException {
     //Xdrgen::AST::Typespecs::Int
     //Integer
@@ -171,7 +244,7 @@ public class TrustLineEntry implements XdrElement {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof TrustLineEntryExt)) {
+      if (!(object instanceof TrustLineEntryExt)) {
         return false;
       }
 
@@ -214,12 +287,34 @@ public class TrustLineEntry implements XdrElement {
       }
       @Override
       public boolean equals(Object object) {
-        if (object == null || !(object instanceof TrustLineEntryV1)) {
+        if (!(object instanceof TrustLineEntryV1)) {
           return false;
         }
 
         TrustLineEntryV1 other = (TrustLineEntryV1) object;
         return Objects.equal(this.liabilities, other.liabilities) && Objects.equal(this.ext, other.ext);
+      }
+
+      public static final class Builder {
+        private Liabilities liabilities;
+        private TrustLineEntryV1Ext ext;
+
+        public Builder liabilities(Liabilities liabilities) {
+          this.liabilities = liabilities;
+          return this;
+        }
+
+        public Builder ext(TrustLineEntryV1Ext ext) {
+          this.ext = ext;
+          return this;
+        }
+
+        public TrustLineEntryV1 build() {
+          TrustLineEntryV1 val = new TrustLineEntryV1();
+          val.setLiabilities(liabilities);
+          val.setExt(ext);
+          return val;
+        }
       }
 
       public static class TrustLineEntryV1Ext {
@@ -231,6 +326,22 @@ public class TrustLineEntry implements XdrElement {
         public void setDiscriminant(Integer value) {
           this.v = value;
         }
+
+        public static final class Builder {
+          private Integer discriminant;
+
+          public Builder discriminant(Integer discriminant) {
+            this.discriminant = discriminant;
+            return this;
+          }
+
+          public TrustLineEntryV1Ext build() {
+            TrustLineEntryV1Ext val = new TrustLineEntryV1Ext();
+            val.setDiscriminant(discriminant);
+            return val;
+          }
+        }
+
         public static void encode(XdrDataOutputStream stream, TrustLineEntryV1Ext encodedTrustLineEntryV1Ext) throws IOException {
         //Xdrgen::AST::Typespecs::Int
         //Integer
@@ -259,7 +370,7 @@ public class TrustLineEntry implements XdrElement {
         }
         @Override
         public boolean equals(Object object) {
-          if (object == null || !(object instanceof TrustLineEntryV1Ext)) {
+          if (!(object instanceof TrustLineEntryV1Ext)) {
             return false;
           }
 

--- a/src/main/java/org/stellar/sdk/xdr/Uint256.java
+++ b/src/main/java/org/stellar/sdk/xdr/Uint256.java
@@ -15,33 +15,45 @@ import java.util.Arrays;
 //  ===========================================================================
 public class Uint256 implements XdrElement {
   private byte[] uint256;
+
+  public Uint256() {}
+
+  public Uint256(byte[] uint256) {
+    this.uint256 = uint256;
+  }
+
   public byte[] getUint256() {
     return this.uint256;
   }
+
   public void setUint256(byte[] value) {
     this.uint256 = value;
   }
+
   public static void encode(XdrDataOutputStream stream, Uint256  encodedUint256) throws IOException {
-  int uint256size = encodedUint256.uint256.length;
-  stream.write(encodedUint256.getUint256(), 0, uint256size);
+    int uint256size = encodedUint256.uint256.length;
+    stream.write(encodedUint256.getUint256(), 0, uint256size);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static Uint256 decode(XdrDataInputStream stream) throws IOException {
     Uint256 decodedUint256 = new Uint256();
-  int uint256size = 32;
-  decodedUint256.uint256 = new byte[uint256size];
-  stream.read(decodedUint256.uint256, 0, uint256size);
+    int uint256size = 32;
+    decodedUint256.uint256 = new byte[uint256size];
+    stream.read(decodedUint256.uint256, 0, uint256size);
     return decodedUint256;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.uint256);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Uint256)) {
+    if (!(object instanceof Uint256)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/Uint32.java
+++ b/src/main/java/org/stellar/sdk/xdr/Uint32.java
@@ -15,30 +15,42 @@ import com.google.common.base.Objects;
 //  ===========================================================================
 public class Uint32 implements XdrElement {
   private Integer uint32;
+
+  public Uint32() {}
+
+  public Uint32(Integer uint32) {
+    this.uint32 = uint32;
+  }
+
   public Integer getUint32() {
     return this.uint32;
   }
+
   public void setUint32(Integer value) {
     this.uint32 = value;
   }
+
   public static void encode(XdrDataOutputStream stream, Uint32  encodedUint32) throws IOException {
-  stream.writeInt(encodedUint32.uint32);
+    stream.writeInt(encodedUint32.uint32);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static Uint32 decode(XdrDataInputStream stream) throws IOException {
     Uint32 decodedUint32 = new Uint32();
-  decodedUint32.uint32 = stream.readInt();
+    decodedUint32.uint32 = stream.readInt();
     return decodedUint32;
   }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(this.uint32);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Uint32)) {
+    if (!(object instanceof Uint32)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/Uint64.java
+++ b/src/main/java/org/stellar/sdk/xdr/Uint64.java
@@ -15,30 +15,42 @@ import com.google.common.base.Objects;
 //  ===========================================================================
 public class Uint64 implements XdrElement {
   private Long uint64;
+
+  public Uint64() {}
+
+  public Uint64(Long uint64) {
+    this.uint64 = uint64;
+  }
+
   public Long getUint64() {
     return this.uint64;
   }
+
   public void setUint64(Long value) {
     this.uint64 = value;
   }
+
   public static void encode(XdrDataOutputStream stream, Uint64  encodedUint64) throws IOException {
-  stream.writeLong(encodedUint64.uint64);
+    stream.writeLong(encodedUint64.uint64);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static Uint64 decode(XdrDataInputStream stream) throws IOException {
     Uint64 decodedUint64 = new Uint64();
-  decodedUint64.uint64 = stream.readLong();
+    decodedUint64.uint64 = stream.readLong();
     return decodedUint64;
   }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(this.uint64);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Uint64)) {
+    if (!(object instanceof Uint64)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/UpgradeEntryMeta.java
+++ b/src/main/java/org/stellar/sdk/xdr/UpgradeEntryMeta.java
@@ -52,11 +52,33 @@ public class UpgradeEntryMeta implements XdrElement {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof UpgradeEntryMeta)) {
+    if (!(object instanceof UpgradeEntryMeta)) {
       return false;
     }
 
     UpgradeEntryMeta other = (UpgradeEntryMeta) object;
     return Objects.equal(this.upgrade, other.upgrade) && Objects.equal(this.changes, other.changes);
+  }
+
+  public static final class Builder {
+    private LedgerUpgrade upgrade;
+    private LedgerEntryChanges changes;
+
+    public Builder upgrade(LedgerUpgrade upgrade) {
+      this.upgrade = upgrade;
+      return this;
+    }
+
+    public Builder changes(LedgerEntryChanges changes) {
+      this.changes = changes;
+      return this;
+    }
+
+    public UpgradeEntryMeta build() {
+      UpgradeEntryMeta val = new UpgradeEntryMeta();
+      val.setUpgrade(upgrade);
+      val.setChanges(changes);
+      return val;
+    }
   }
 }

--- a/src/main/java/org/stellar/sdk/xdr/UpgradeType.java
+++ b/src/main/java/org/stellar/sdk/xdr/UpgradeType.java
@@ -15,34 +15,46 @@ import java.util.Arrays;
 //  ===========================================================================
 public class UpgradeType implements XdrElement {
   private byte[] UpgradeType;
+
+  public UpgradeType() {}
+
+  public UpgradeType(byte[] UpgradeType) {
+    this.UpgradeType = UpgradeType;
+  }
+
   public byte[] getUpgradeType() {
     return this.UpgradeType;
   }
+
   public void setUpgradeType(byte[] value) {
     this.UpgradeType = value;
   }
+
   public static void encode(XdrDataOutputStream stream, UpgradeType  encodedUpgradeType) throws IOException {
-  int UpgradeTypesize = encodedUpgradeType.UpgradeType.length;
-  stream.writeInt(UpgradeTypesize);
-  stream.write(encodedUpgradeType.getUpgradeType(), 0, UpgradeTypesize);
+    int UpgradeTypesize = encodedUpgradeType.UpgradeType.length;
+    stream.writeInt(UpgradeTypesize);
+    stream.write(encodedUpgradeType.getUpgradeType(), 0, UpgradeTypesize);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static UpgradeType decode(XdrDataInputStream stream) throws IOException {
     UpgradeType decodedUpgradeType = new UpgradeType();
-  int UpgradeTypesize = stream.readInt();
-  decodedUpgradeType.UpgradeType = new byte[UpgradeTypesize];
-  stream.read(decodedUpgradeType.UpgradeType, 0, UpgradeTypesize);
+    int UpgradeTypesize = stream.readInt();
+    decodedUpgradeType.UpgradeType = new byte[UpgradeTypesize];
+    stream.read(decodedUpgradeType.UpgradeType, 0, UpgradeTypesize);
     return decodedUpgradeType;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.UpgradeType);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof UpgradeType)) {
+    if (!(object instanceof UpgradeType)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/Value.java
+++ b/src/main/java/org/stellar/sdk/xdr/Value.java
@@ -15,34 +15,46 @@ import java.util.Arrays;
 //  ===========================================================================
 public class Value implements XdrElement {
   private byte[] Value;
+
+  public Value() {}
+
+  public Value(byte[] Value) {
+    this.Value = Value;
+  }
+
   public byte[] getValue() {
     return this.Value;
   }
+
   public void setValue(byte[] value) {
     this.Value = value;
   }
+
   public static void encode(XdrDataOutputStream stream, Value  encodedValue) throws IOException {
-  int Valuesize = encodedValue.Value.length;
-  stream.writeInt(Valuesize);
-  stream.write(encodedValue.getValue(), 0, Valuesize);
+    int Valuesize = encodedValue.Value.length;
+    stream.writeInt(Valuesize);
+    stream.write(encodedValue.getValue(), 0, Valuesize);
   }
+
   public void encode(XdrDataOutputStream stream) throws IOException {
     encode(stream, this);
   }
   public static Value decode(XdrDataInputStream stream) throws IOException {
     Value decodedValue = new Value();
-  int Valuesize = stream.readInt();
-  decodedValue.Value = new byte[Valuesize];
-  stream.read(decodedValue.Value, 0, Valuesize);
+    int Valuesize = stream.readInt();
+    decodedValue.Value = new byte[Valuesize];
+    stream.read(decodedValue.Value, 0, Valuesize);
     return decodedValue;
   }
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(this.Value);
   }
+
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Value)) {
+    if (!(object instanceof Value)) {
       return false;
     }
 


### PR DESCRIPTION
Two xdrgen PRs were merged recently which affect the generation of Java XDR classes:

https://github.com/stellar/xdrgen/pull/56
https://github.com/stellar/xdrgen/pull/57

This commit regenerates the XDR classes in the Java SDK with the latest version of xdrgen/