### PR TITLE
Add support for CAP 35 operations when building transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
+## 0.24.0
+
+### Deprecations
+
+* Operation `allow_trust` is deprecated in favor of `set_trust_line_flags` (although it will still be supported by the network)
+
+* Effects `trustline_authorized`, `trustline_authorized_to_maintain_liabilities` and `trustline_deauthorized` are deprecated
+  in favor of `trustline_flags_updated`. Note how we intentionally didn't add a new `trustline_authorized_clawback_enabled` effect.
+
+  For uniformity, the `allow_trust` operation will start producing `trustline_flags_updated` from this release.
+
+  For now `trustline_authorized`, `trustline_authorized_to_maintain_liabilities` and `trustline_deauthorized` will continue to be emitted as a result of the `allow_trust` operation but in the future we may stop doing so.
+
+
+Deprecated | New class
+-|-
+`org.stellar.sdk.AllowTrustOperation`                                                      | `org.stellar.sdk.SetTrustlineFlagsOperation`
+`org.stellar.sdk.responses.operations.AllowTrustOperationResponse`                         | `org.stellar.sdk.responses.operations.SetTrustLineFlagsOperationResponse`
+`org.stellar.sdk.responses.effects.TrustlineAuthorizedEffectResponse`                      | `org.stellar.sdk.responses.effects.TrustlineFlagsUpdatedEffectResponse`
+`org.stellar.sdk.responses.effects.TrustlineAuthorizedToMaintainLiabilitiesEffectResponse` | `org.stellar.sdk.responses.effects.TrustlineFlagsUpdatedEffectResponse`
+`org.stellar.sdk.responses.effects.TrustlineDeauthorizedEffectResponse`                    | `org.stellar.sdk.responses.effects.TrustlineFlagsUpdatedEffectResponse`
+
+
+### Changes
+
+## New Operations
+
+* `clawback` implemented in `org.stellar.sdk.ClawbackOperation` claws back a trustline from a given asset holder.
+
+* `clawback_claimable_balance` implemented in `org.stellar.sdk.ClawbackClaimableBalanceOperation` claws back a claimable balance.
+
+* `set_trust_line_flags` implemented in `org.stellar.sdk.SetTrustlineFlagsOperation` modifies a trustline's flags. This operation should be used instead of `org.stellar.sdk.AllowTrustOperation`.
+
+## New effects
+
+* `trustline_flags_updated` implemented in `org.stellar.sdk.responses.effects.TrustlineFlagsUpdatedEffectResponse`, with the following fields:
+  * Asset fields (like explained in the operations above):
+    * `asset_type`
+    * `asset_code`
+    * `asset_issuer`
+  * `trustor` - account whose trustline the effect refers to
+  * `authorized_flag` - true to indicate the flag is set, field ommited if not set
+  * `authorized_to_maintain_liabilites` - true to indicate the flag is set, field ommited if not set
+  * `clawback_enabled_flag` - true to indicate that the flag is set, field ommitted if not set
+
+
+* `claimable_balance_clawed_back` implemented in `org.stellar.sdk.responses.effects.ClaimableBalanceClawedBackEffectResponse`, with the following fields:
+  * `balance_id` - claimable balance identifer of the claimable balance clawed back
+
 ## 0.23.0
 ### Breaking change
 - Updates the SEP-10 utility function parameters to support [SEP-10 v3.1](https://github.com/stellar/stellar-protocol/commit/6c8c9cf6685c85509835188a136ffb8cd6b9c11c) [(#319)](https://github.com/stellar/java-stellar-sdk/pull/319)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 * Operation `allow_trust` is deprecated in favor of `set_trust_line_flags` (although it will still be supported by the network)
 
-* Effects `trustline_authorized`, `trustline_authorized_to_maintain_liabilities` and `trustline_deauthorized` are deprecated
-  in favor of `trustline_flags_updated`. Note how we intentionally didn't add a new `trustline_authorized_clawback_enabled` effect.
+* Effects `trustline_authorized`, `trustline_authorized_to_maintain_liabilities` and `trustline_deauthorized` are deprecated in favor of `trustline_flags_updated`. Note how we intentionally didn't add a new `trustline_authorized_clawback_enabled` effect.
 
-  For uniformity, the `allow_trust` operation will start producing `trustline_flags_updated` from this release.
+For uniformity, the `allow_trust` operation will start producing `trustline_flags_updated` from this release.
 
-  For now `trustline_authorized`, `trustline_authorized_to_maintain_liabilities` and `trustline_deauthorized` will continue to be emitted as a result of the `allow_trust` operation but in the future we may stop doing so.
+For now `trustline_authorized`, `trustline_authorized_to_maintain_liabilities` and `trustline_deauthorized` will continue to be emitted as a result of the `allow_trust` operation but in the future we may stop doing so.
 
 
 Deprecated | New class

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'com.github.ben-manes.versions' // gradle dependencyUpdates -Drevi
 apply plugin: 'project-report' // gradle htmlDependencyReport
 
 sourceCompatibility = 1.6
-version = '0.23.0'
+version = '0.24.0'
 group = 'stellar'
 
 jar {

--- a/src/main/java/org/stellar/sdk/AllowTrustOperation.java
+++ b/src/main/java/org/stellar/sdk/AllowTrustOperation.java
@@ -6,6 +6,8 @@ import org.stellar.sdk.xdr.*;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
+ * @deprecated As of release 0.24.0, replaced by {@link SetTrustlineFlagsOperation}
+ *
  * Represents <a href="https://www.stellar.org/developers/learn/concepts/list-of-operations.html#allow-trust" target="_blank">AllowTrust</a> operation.
  * @see <a href="https://www.stellar.org/developers/learn/concepts/list-of-operations.html" target="_blank">List of Operations</a>
  */

--- a/src/main/java/org/stellar/sdk/ClaimClaimableBalanceOperation.java
+++ b/src/main/java/org/stellar/sdk/ClaimClaimableBalanceOperation.java
@@ -1,12 +1,7 @@
 package org.stellar.sdk;
 
 import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
 import org.stellar.sdk.xdr.*;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -25,17 +20,7 @@ public class ClaimClaimableBalanceOperation extends Operation {
   @Override
   org.stellar.sdk.xdr.Operation.OperationBody toOperationBody() {
     ClaimClaimableBalanceOp op = new ClaimClaimableBalanceOp();
-
-    byte[] balanceIdBytes = BaseEncoding.base16().lowerCase().decode(balanceId.toLowerCase());
-    XdrDataInputStream balanceIdXdrDataInputStream = new XdrDataInputStream(new ByteArrayInputStream(balanceIdBytes));
-    ClaimableBalanceID id;
-    try {
-      id = ClaimableBalanceID.decode(balanceIdXdrDataInputStream);
-    } catch (IOException e) {
-      throw new IllegalArgumentException("invalid balanceId: " + balanceId, e);
-    }
-
-    op.setBalanceID(id);
+    op.setBalanceID(Util.claimableBalanceIdToXDR(balanceId));
     org.stellar.sdk.xdr.Operation.OperationBody body = new org.stellar.sdk.xdr.Operation.OperationBody();
     body.setDiscriminant(OperationType.CLAIM_CLAIMABLE_BALANCE);
     body.setClaimClaimableBalanceOp(op);
@@ -52,14 +37,7 @@ public class ClaimClaimableBalanceOperation extends Operation {
      * @param op {@link ClaimClaimableBalanceOp}
      */
     Builder(ClaimClaimableBalanceOp op) {
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-      XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-      try {
-        op.getBalanceID().encode(xdrDataOutputStream);
-      } catch (IOException e) {
-        throw new IllegalArgumentException("invalid claimClaimableBalanceOp.", e);
-      }
-      balanceId = BaseEncoding.base16().lowerCase().encode(byteArrayOutputStream.toByteArray());
+      balanceId = Util.xdrToClaimableBalanceId(op.getBalanceID());
     }
 
     /**

--- a/src/main/java/org/stellar/sdk/ClawbackClaimableBalanceOperation.java
+++ b/src/main/java/org/stellar/sdk/ClawbackClaimableBalanceOperation.java
@@ -30,7 +30,6 @@ public class ClawbackClaimableBalanceOperation extends Operation {
   org.stellar.sdk.xdr.Operation.OperationBody toOperationBody() {
     ClawbackClaimableBalanceOp op = new ClawbackClaimableBalanceOp();
 
-    // trustor
     op.setBalanceID(Util.claimableBalanceIdToXDR(balanceId));
 
 

--- a/src/main/java/org/stellar/sdk/ClawbackClaimableBalanceOperation.java
+++ b/src/main/java/org/stellar/sdk/ClawbackClaimableBalanceOperation.java
@@ -15,7 +15,7 @@ public class ClawbackClaimableBalanceOperation extends Operation {
   private final String balanceId;
 
   private ClawbackClaimableBalanceOperation(String balanceId) {
-    this.balanceId = checkNotNull(balanceId, "from cannot be null");
+    this.balanceId = checkNotNull(balanceId, "balanceId cannot be null");
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/ClawbackClaimableBalanceOperation.java
+++ b/src/main/java/org/stellar/sdk/ClawbackClaimableBalanceOperation.java
@@ -1,0 +1,105 @@
+package org.stellar.sdk;
+
+import com.google.common.base.Objects;
+import org.stellar.sdk.xdr.ClawbackClaimableBalanceOp;
+import org.stellar.sdk.xdr.OperationType;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ *
+ * Represents a Clawback Claimable Balance operation.
+ * @see <a href="https://www.stellar.org/developers/learn/concepts/list-of-operations.html" target="_blank">List of Operations</a>
+ */
+public class ClawbackClaimableBalanceOperation extends Operation {
+  private final String balanceId;
+
+  private ClawbackClaimableBalanceOperation(String balanceId) {
+    this.balanceId = checkNotNull(balanceId, "from cannot be null");
+  }
+
+  /**
+   * The id of the claimable balance which will be clawed back.
+   */
+  public String getBalanceId() {
+    return balanceId;
+  }
+
+
+  @Override
+  org.stellar.sdk.xdr.Operation.OperationBody toOperationBody() {
+    ClawbackClaimableBalanceOp op = new ClawbackClaimableBalanceOp();
+
+    // trustor
+    op.setBalanceID(Util.claimableBalanceIdToXDR(balanceId));
+
+
+    org.stellar.sdk.xdr.Operation.OperationBody body = new org.stellar.sdk.xdr.Operation.OperationBody();
+    body.setDiscriminant(OperationType.CLAWBACK_CLAIMABLE_BALANCE);
+    body.setClawbackClaimableBalanceOp(op);
+    return body;
+  }
+
+  /**
+   * Builds ClawbackClaimableBalanceOperation.
+   * @see ClawbackClaimableBalanceOperation
+   */
+  public static class Builder {
+    private final String balanceId;
+
+    private String mSourceAccount;
+
+    Builder(ClawbackClaimableBalanceOp op) {
+      balanceId = Util.xdrToClaimableBalanceId(op.getBalanceID());
+    }
+
+    /**
+     * Creates a new ClawbackClaimableBalanceOperation builder.
+     * @param balanceId The id of the claimable balance which will be clawed back.
+     */
+    public Builder(String balanceId) {
+      this.balanceId = balanceId;
+    }
+
+    /**
+     * Set source account of this operation
+     * @param sourceAccount Source account
+     * @return Builder object so you can chain methods.
+     */
+    public Builder setSourceAccount(String sourceAccount) {
+      mSourceAccount = sourceAccount;
+      return this;
+    }
+
+    /**
+     * Builds an operation
+     */
+    public ClawbackClaimableBalanceOperation build() {
+      ClawbackClaimableBalanceOperation operation = new ClawbackClaimableBalanceOperation(
+          balanceId
+      );
+      if (mSourceAccount != null) {
+        operation.setSourceAccount(mSourceAccount);
+      }
+      return operation;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        this.getSourceAccount(),
+        this.balanceId
+    );
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (object == null || !(object instanceof ClawbackClaimableBalanceOperation)) {
+      return false;
+    }
+
+    ClawbackClaimableBalanceOperation other = (ClawbackClaimableBalanceOperation) object;
+    return Objects.equal(this.balanceId, other.balanceId);
+  }
+}

--- a/src/main/java/org/stellar/sdk/ClawbackOperation.java
+++ b/src/main/java/org/stellar/sdk/ClawbackOperation.java
@@ -1,0 +1,139 @@
+package org.stellar.sdk;
+
+import com.google.common.base.Objects;
+import org.stellar.sdk.xdr.*;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ *
+ * Represents a Clawback operation.
+ * @see <a href="https://www.stellar.org/developers/learn/concepts/list-of-operations.html" target="_blank">List of Operations</a>
+ */
+public class ClawbackOperation extends Operation {
+  private final String from;
+  private final AssetTypeCreditAlphaNum asset;
+  private final String amount;
+
+  private ClawbackOperation(String from, AssetTypeCreditAlphaNum asset, String amount) {
+    this.from = checkNotNull(from, "from cannot be null");
+    this.asset = checkNotNull(asset, "asset cannot be null");
+    this.amount = checkNotNull(amount, "asset cannot be null");
+  }
+
+  /**
+   * The account owning of the trustline.
+   */
+  public String getFrom() {
+    return from;
+  }
+
+  /**
+   * The amount to be clawed back.
+   */
+  public String getAmount() {
+    return amount;
+  }
+
+  /**
+   * The asset to be clawed back.
+   */
+  public Asset getAsset() {
+    return asset;
+  }
+
+  @Override
+  org.stellar.sdk.xdr.Operation.OperationBody toOperationBody() {
+    ClawbackOp op = new ClawbackOp();
+
+    // trustor
+    op.setFrom(StrKey.encodeToXDRMuxedAccount(this.from));
+
+    Int64 amount = new Int64();
+    amount.setInt64(Operation.toXdrAmount(this.amount));
+    op.setAmount(amount);
+    op.setAsset(asset.toXdr());
+
+
+    org.stellar.sdk.xdr.Operation.OperationBody body = new org.stellar.sdk.xdr.Operation.OperationBody();
+    body.setDiscriminant(OperationType.CLAWBACK);
+    body.setClawbackOp(op);
+    return body;
+  }
+
+  /**
+   * Builds ClawbackOperation operation.
+   * @see ClawbackOperation
+   */
+  public static class Builder {
+    private final String from;
+    private final AssetTypeCreditAlphaNum asset;
+    private final String amount;
+
+    private String mSourceAccount;
+
+    Builder(ClawbackOp op) {
+      from = StrKey.encodeStellarAccountId(StrKey.muxedAccountToAccountId(op.getFrom()));
+      amount = Operation.fromXdrAmount(op.getAmount().getInt64().longValue());
+      asset = Util.assertNonNativeAsset(Asset.fromXdr(op.getAsset()));
+    }
+
+    /**
+     * Creates a new ClawbackOperation builder.
+     * @param from The account holding the trustline.
+     * @param asset The asset held in the trustline.
+     * @param amount The amount to be clawed back.
+     */
+    public Builder(String from, Asset asset, String amount) {
+      this.from = from;
+      this.asset = Util.assertNonNativeAsset(asset);
+      this.amount = amount;
+    }
+
+    /**
+     * Set source account of this operation
+     * @param sourceAccount Source account
+     * @return Builder object so you can chain methods.
+     */
+    public Builder setSourceAccount(String sourceAccount) {
+      mSourceAccount = sourceAccount;
+      return this;
+    }
+
+    /**
+     * Builds an operation
+     */
+    public ClawbackOperation build() {
+      ClawbackOperation operation = new ClawbackOperation(
+          from, asset, amount
+      );
+      if (mSourceAccount != null) {
+        operation.setSourceAccount(mSourceAccount);
+      }
+      return operation;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        this.getSourceAccount(),
+        this.from,
+        this.asset,
+        this.amount
+    );
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (object == null || !(object instanceof ClawbackOperation)) {
+      return false;
+    }
+
+    ClawbackOperation other = (ClawbackOperation) object;
+    return Objects.equal(this.from, other.from) &&
+        Objects.equal(this.asset, other.asset) &&
+        Objects.equal(this.amount, other.amount) &&
+        Objects.equal(this.getSourceAccount(), other.getSourceAccount());
+  }
+}

--- a/src/main/java/org/stellar/sdk/ClawbackOperation.java
+++ b/src/main/java/org/stellar/sdk/ClawbackOperation.java
@@ -18,7 +18,7 @@ public class ClawbackOperation extends Operation {
   private ClawbackOperation(String from, AssetTypeCreditAlphaNum asset, String amount) {
     this.from = checkNotNull(from, "from cannot be null");
     this.asset = checkNotNull(asset, "asset cannot be null");
-    this.amount = checkNotNull(amount, "asset cannot be null");
+    this.amount = checkNotNull(amount, "amount cannot be null");
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/Operation.java
+++ b/src/main/java/org/stellar/sdk/Operation.java
@@ -152,6 +152,15 @@ public abstract class Operation {
             throw new RuntimeException("Unknown revoke sponsorship body " + body.getRevokeSponsorshipOp().getDiscriminant());
         }
         break;
+      case CLAWBACK:
+        operation = new ClawbackOperation.Builder(body.getClawbackOp()).build();
+        break;
+      case CLAWBACK_CLAIMABLE_BALANCE:
+        operation = new ClawbackClaimableBalanceOperation.Builder(body.getClawbackClaimableBalanceOp()).build();
+        break;
+      case SET_TRUST_LINE_FLAGS:
+        operation = new SetTrustlineFlagsOperation.Builder(body.getSetTrustLineFlagsOp()).build();
+        break;
       default:
         throw new RuntimeException("Unknown operation body " + body.getDiscriminant());
     }

--- a/src/main/java/org/stellar/sdk/RevokeClaimableBalanceSponsorshipOperation.java
+++ b/src/main/java/org/stellar/sdk/RevokeClaimableBalanceSponsorshipOperation.java
@@ -1,12 +1,7 @@
 package org.stellar.sdk;
 
 import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
 import org.stellar.sdk.xdr.*;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -28,16 +23,7 @@ public class RevokeClaimableBalanceSponsorshipOperation extends Operation {
     key.setDiscriminant(LedgerEntryType.CLAIMABLE_BALANCE);
     LedgerKey.LedgerKeyClaimableBalance claimableBalance = new LedgerKey.LedgerKeyClaimableBalance();
 
-    byte[] balanceIdBytes = BaseEncoding.base16().lowerCase().decode(balanceId.toLowerCase());
-    XdrDataInputStream balanceIdXdrDataInputStream = new XdrDataInputStream(new ByteArrayInputStream(balanceIdBytes));
-    ClaimableBalanceID id;
-    try {
-      id = ClaimableBalanceID.decode(balanceIdXdrDataInputStream);
-    } catch (IOException e) {
-      throw new IllegalArgumentException("invalid balanceId: " + balanceId, e);
-    }
-
-    claimableBalance.setBalanceID(id);
+    claimableBalance.setBalanceID(Util.claimableBalanceIdToXDR(balanceId));
     key.setClaimableBalance(claimableBalance);
     op.setLedgerKey(key);
     op.setDiscriminant(RevokeSponsorshipType.REVOKE_SPONSORSHIP_LEDGER_ENTRY);
@@ -59,14 +45,7 @@ public class RevokeClaimableBalanceSponsorshipOperation extends Operation {
      * @param op {@link RevokeSponsorshipOp}
      */
     Builder(RevokeSponsorshipOp op) {
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-      XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-      try {
-        op.getLedgerKey().getClaimableBalance().getBalanceID().encode(xdrDataOutputStream);
-      } catch (IOException e) {
-        throw new IllegalArgumentException("invalid revokeSponsorshipOp.", e);
-      }
-      balanceId = BaseEncoding.base16().lowerCase().encode(byteArrayOutputStream.toByteArray());
+      balanceId = Util.xdrToClaimableBalanceId(op.getLedgerKey().getClaimableBalance().getBalanceID());
     }
 
     /**

--- a/src/main/java/org/stellar/sdk/SetTrustlineFlagsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetTrustlineFlagsOperation.java
@@ -1,0 +1,171 @@
+package org.stellar.sdk;
+
+import com.google.common.base.Objects;
+import org.stellar.sdk.xdr.*;
+
+import java.util.EnumSet;
+
+/**
+ *
+ * Represents a Set Trustline Flags operation.
+ * @see <a href="https://www.stellar.org/developers/learn/concepts/list-of-operations.html" target="_blank">List of Operations</a>
+ */
+public class SetTrustlineFlagsOperation extends Operation {
+  private final String trustor;
+  private final AssetTypeCreditAlphaNum asset;
+  private final EnumSet<TrustLineFlags> clearFlags;
+  private final EnumSet<TrustLineFlags> setFlags;
+
+  private SetTrustlineFlagsOperation(String trustor, AssetTypeCreditAlphaNum asset, EnumSet<TrustLineFlags> clearFlags, EnumSet<TrustLineFlags> setFlags) {
+    this.trustor = trustor;
+    this.asset = asset;
+    this.clearFlags = clearFlags;
+    this.setFlags = setFlags;
+  }
+
+  /**
+   * The account owning of the trustline.
+   */
+  public String getTrustor() {
+    return trustor;
+  }
+
+  /**
+   * The asset of the trustline.
+   */
+  public Asset getAsset() {
+    return asset;
+  }
+
+  /**
+   * The flags to be set.
+   */
+  public EnumSet<TrustLineFlags> getSetFlags() {
+    return setFlags;
+  }
+
+  /**
+   * The flags to be cleared.
+   */
+  public EnumSet<TrustLineFlags> getClearFlags() {
+    return clearFlags;
+  }
+
+  private static Uint32 bitwiseOr(EnumSet<TrustLineFlags> set) {
+    int v = 0;
+    for (TrustLineFlags f : set) {
+      v |= f.getValue();
+    }
+    Uint32 combined = new Uint32();
+    combined.setUint32(v);
+    return combined;
+  }
+
+  @Override
+  org.stellar.sdk.xdr.Operation.OperationBody toOperationBody() {
+    SetTrustLineFlagsOp op = new SetTrustLineFlagsOp();
+
+    op.setTrustor(StrKey.encodeToXDRAccountId(this.trustor));
+    op.setAsset(asset.toXdr());
+    op.setClearFlags(bitwiseOr(clearFlags));
+    op.setSetFlags(bitwiseOr(setFlags));
+
+    org.stellar.sdk.xdr.Operation.OperationBody body = new org.stellar.sdk.xdr.Operation.OperationBody();
+    body.setDiscriminant(OperationType.SET_TRUST_LINE_FLAGS);
+    body.setSetTrustLineFlagsOp(op);
+    return body;
+  }
+
+  /**
+   * Builds SetTrustlineFlagsOperation operation.
+   * @see SetTrustlineFlagsOperation
+   */
+  public static class Builder {
+    private final String trustor;
+    private final AssetTypeCreditAlphaNum asset;
+    private final EnumSet<TrustLineFlags> clearFlags;
+    private final EnumSet<TrustLineFlags> setFlags;
+
+    private String mSourceAccount;
+
+
+    Builder(SetTrustLineFlagsOp op) {
+      trustor = StrKey.encodeStellarAccountId(op.getTrustor());
+      asset = Util.assertNonNativeAsset(Asset.fromXdr(op.getAsset()));
+      clearFlags = flagSetFromInt(op.getClearFlags().getUint32());
+      setFlags = flagSetFromInt(op.getSetFlags().getUint32());
+    }
+
+    private static EnumSet<TrustLineFlags> flagSetFromInt(int x) {
+      EnumSet<TrustLineFlags> set = EnumSet.noneOf(TrustLineFlags.class);
+      for (TrustLineFlags flag : TrustLineFlags.values()) {
+        if ((flag.getValue() & x) != 0) {
+          set.add(flag);
+        }
+      }
+      return set;
+    }
+
+    /**
+     * Creates a new SetTrustlineFlagsOperation builder.
+     * @param trustor The account holding the trustline.
+     * @param asset The asset held in the trustline.
+     * @param clearFlags The flags to be cleared on the trustline.
+     * @param setFlags The flags to be set on the trustline.
+     */
+    public Builder(String trustor, Asset asset, EnumSet<TrustLineFlags> clearFlags, EnumSet<TrustLineFlags> setFlags) {
+      this.trustor = trustor;
+      this.asset = Util.assertNonNativeAsset(asset);
+      this.clearFlags = clearFlags;
+      this.setFlags = setFlags;
+    }
+
+    /**
+     * Set source account of this operation
+     * @param sourceAccount Source account
+     * @return Builder object so you can chain methods.
+     */
+    public Builder setSourceAccount(String sourceAccount) {
+      mSourceAccount = sourceAccount;
+      return this;
+    }
+
+    /**
+     * Builds an operation
+     */
+    public SetTrustlineFlagsOperation build() {
+      SetTrustlineFlagsOperation operation = new SetTrustlineFlagsOperation(
+          trustor, asset, clearFlags, setFlags
+      );
+      if (mSourceAccount != null) {
+        operation.setSourceAccount(mSourceAccount);
+      }
+      return operation;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        this.getSourceAccount(),
+        this.trustor,
+        this.asset,
+        this.clearFlags,
+        this.setFlags
+    );
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (object == null || !(object instanceof SetTrustlineFlagsOperation)) {
+      return false;
+    }
+
+    SetTrustlineFlagsOperation other = (SetTrustlineFlagsOperation) object;
+    return Objects.equal(this.trustor, other.trustor) &&
+        Objects.equal(this.asset, other.asset) &&
+        Objects.equal(this.clearFlags, other.clearFlags) &&
+        Objects.equal(this.setFlags, other.setFlags) &&
+        Objects.equal(this.getSourceAccount(), other.getSourceAccount());
+  }
+}

--- a/src/main/java/org/stellar/sdk/Util.java
+++ b/src/main/java/org/stellar/sdk/Util.java
@@ -1,5 +1,13 @@
 package org.stellar.sdk;
 
+import com.google.common.io.BaseEncoding;
+import org.stellar.sdk.xdr.ClaimableBalanceID;
+import org.stellar.sdk.xdr.XdrDataInputStream;
+import org.stellar.sdk.xdr.XdrDataOutputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -83,4 +91,34 @@ public class Util {
     }
     return clientVersion;
   }
+
+  public static ClaimableBalanceID claimableBalanceIdToXDR(String balanceId) {
+    byte[] balanceIdBytes = BaseEncoding.base16().lowerCase().decode(balanceId.toLowerCase());
+    XdrDataInputStream balanceIdXdrDataInputStream = new XdrDataInputStream(new ByteArrayInputStream(balanceIdBytes));
+
+    try {
+      return ClaimableBalanceID.decode(balanceIdXdrDataInputStream);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("invalid balanceId: " + balanceId, e);
+    }
+  }
+
+  public static String xdrToClaimableBalanceId(ClaimableBalanceID balanceId) {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    try {
+      balanceId.encode(xdrDataOutputStream);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("invalid claimClaimableBalanceOp.", e);
+    }
+    return BaseEncoding.base16().lowerCase().encode(byteArrayOutputStream.toByteArray());
+  }
+
+  public static AssetTypeCreditAlphaNum assertNonNativeAsset(Asset asset) {
+    if (asset instanceof AssetTypeCreditAlphaNum) {
+      return (AssetTypeCreditAlphaNum) asset;
+    }
+    throw new IllegalArgumentException("native assets are not supported");
+  }
+
 }

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineAuthorizedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineAuthorizedEffectResponse.java
@@ -1,7 +1,5 @@
 package org.stellar.sdk.responses.effects;
 
-import org.stellar.sdk.responses.operations.SetTrustLineFlagsOperationResponse;
-
 /**
  * @deprecated As of release 0.24.0, replaced by {@link TrustlineFlagsUpdatedEffectResponse}
  *

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineAuthorizedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineAuthorizedEffectResponse.java
@@ -1,6 +1,10 @@
 package org.stellar.sdk.responses.effects;
 
+import org.stellar.sdk.responses.operations.SetTrustLineFlagsOperationResponse;
+
 /**
+ * @deprecated As of release 0.24.0, replaced by {@link TrustlineFlagsUpdatedEffectResponse}
+ *
  * Represents trustline_authorized effect response.
  * @see <a href="https://www.stellar.org/developers/horizon/reference/resources/effect.html" target="_blank">Effect documentation</a>
  * @see org.stellar.sdk.requests.EffectsRequestBuilder

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineAuthorizedToMaintainLiabilitiesEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineAuthorizedToMaintainLiabilitiesEffectResponse.java
@@ -1,6 +1,8 @@
 package org.stellar.sdk.responses.effects;
 
 /**
+ * @deprecated As of release 0.24.0, replaced by {@link TrustlineFlagsUpdatedEffectResponse}
+ *
  * Represents trustline_authorized_to_maintain_liabilities effect response.
  * @see <a href="https://www.stellar.org/developers/horizon/reference/resources/effect.html" target="_blank">Effect documentation</a>
  * @see org.stellar.sdk.requests.EffectsRequestBuilder

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineDeauthorizedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineDeauthorizedEffectResponse.java
@@ -1,6 +1,8 @@
 package org.stellar.sdk.responses.effects;
 
 /**
+ * @deprecated As of release 0.24.0, replaced by {@link TrustlineFlagsUpdatedEffectResponse}
+ *
  * Represents trustline_deauthorized effect response.
  * @see <a href="https://www.stellar.org/developers/horizon/reference/resources/effect.html" target="_blank">Effect documentation</a>
  * @see org.stellar.sdk.requests.EffectsRequestBuilder

--- a/src/main/java/org/stellar/sdk/responses/operations/AllowTrustOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/AllowTrustOperationResponse.java
@@ -4,7 +4,6 @@ import com.google.gson.annotations.SerializedName;
 
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
-import org.stellar.sdk.SetTrustlineFlagsOperation;
 
 /**
  * @deprecated As of release 0.24.0, replaced by {@link SetTrustLineFlagsOperationResponse}

--- a/src/main/java/org/stellar/sdk/responses/operations/AllowTrustOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/AllowTrustOperationResponse.java
@@ -4,8 +4,11 @@ import com.google.gson.annotations.SerializedName;
 
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
+import org.stellar.sdk.SetTrustlineFlagsOperation;
 
 /**
+ * @deprecated As of release 0.24.0, replaced by {@link SetTrustLineFlagsOperationResponse}
+ *
  * Represents AllowTrust operation response.
  * @see <a href="https://www.stellar.org/developers/horizon/reference/resources/operation.html" target="_blank">Operation documentation</a>
  * @see org.stellar.sdk.requests.OperationsRequestBuilder

--- a/src/test/java/org/stellar/sdk/OperationTest.java
+++ b/src/test/java/org/stellar/sdk/OperationTest.java
@@ -3,6 +3,7 @@ package org.stellar.sdk;
 import com.google.common.collect.Lists;
 import org.junit.Test;
 import org.stellar.sdk.xdr.SignerKey;
+import org.stellar.sdk.xdr.TrustLineFlags;
 import org.stellar.sdk.xdr.XdrDataInputStream;
 
 import com.google.common.io.BaseEncoding;
@@ -10,6 +11,7 @@ import com.google.common.io.BaseEncoding;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.EnumSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -891,5 +893,89 @@ public class OperationTest {
         assertEquals(accountId, parsedOperation.getAccountId());
         assertEquals(source, parsedOperation.getSourceAccount());
         assertEquals(asset, parsedOperation.getAsset());
+    }
+
+    @Test
+    public void testClawbackClaimableBalanceOperation() {
+        String source = "GA2N7NI5WEMJILMK4UPDTF2ZX2BIRQUM3HZUE27TRUNRFN5M5EXU6RQV";
+        String balanceId = "00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf5491072";
+        ClawbackClaimableBalanceOperation operation = new ClawbackClaimableBalanceOperation.Builder(balanceId).setSourceAccount(source).build();
+        assertEquals("AAAAAQAAAAA037UdsRiULYrlHjmXWb6CiMKM2fNCa/ONGxK3rOkvTwAAABQAAAAAkpsgty5YkKtRwk8cxG+gHE8xjY0zNn0k3WFM/fVJEHI=", operation.toXdrBase64());
+
+        org.stellar.sdk.xdr.Operation xdr = operation.toXdr();
+        ClawbackClaimableBalanceOperation parsedOperation = (ClawbackClaimableBalanceOperation) Operation.fromXdr(xdr);
+        assertEquals(balanceId, parsedOperation.getBalanceId());
+        assertEquals(source, parsedOperation.getSourceAccount());
+        assertEquals(operation, parsedOperation);
+    }
+
+    @Test
+    public void testClawbackOperation() {
+        String source = "GA2N7NI5WEMJILMK4UPDTF2ZX2BIRQUM3HZUE27TRUNRFN5M5EXU6RQV";
+        String accountId = "GAGQ7DNQUVQR6OWYOI563L5EMJE6KCAHPQSFCZFLY5PDRYMRCA5UWCMP";
+        Asset asset = new AssetTypeCreditAlphaNum4("DEMO", "GCWPICV6IV35FQ2MVZSEDLORHEMMIAODRQPVDEIKZOW2GC2JGGDCXVVV");
+        String amt = "100";
+        ClawbackOperation operation = new ClawbackOperation.Builder(accountId, asset, amt).setSourceAccount(source).build();
+        assertEquals("AAAAAQAAAAA037UdsRiULYrlHjmXWb6CiMKM2fNCa/ONGxK3rOkvTwAAABMAAAABREVNTwAAAACs9Aq+RXfSw0yuZEGt0TkYxAHDjB9RkQrLraMLSTGGKwAAAAAND42wpWEfOthyO+2vpGJJ5QgHfCRRZKvHXjjhkRA7SwAAAAA7msoA", operation.toXdrBase64());
+
+        org.stellar.sdk.xdr.Operation xdr = operation.toXdr();
+        ClawbackOperation parsedOperation = (ClawbackOperation) Operation.fromXdr(xdr);
+        assertEquals(accountId, parsedOperation.getFrom());
+        assertEquals(asset, parsedOperation.getAsset());
+        assertEquals(amt, parsedOperation.getAmount());
+
+        assertEquals(source, parsedOperation.getSourceAccount());
+        assertEquals(operation, parsedOperation);
+    }
+
+    @Test
+    public void testCantClawbackNativeAsset() {
+        try {
+            String accountId = "GAGQ7DNQUVQR6OWYOI563L5EMJE6KCAHPQSFCZFLY5PDRYMRCA5UWCMP";
+            String amt = "100";
+            new ClawbackOperation.Builder(accountId, Asset.create("native"), amt);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("native assets are not supported", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSetTrustlineFlagsOperation() {
+        String source = "GA2N7NI5WEMJILMK4UPDTF2ZX2BIRQUM3HZUE27TRUNRFN5M5EXU6RQV";
+        String accountId = "GAGQ7DNQUVQR6OWYOI563L5EMJE6KCAHPQSFCZFLY5PDRYMRCA5UWCMP";
+        Asset asset = new AssetTypeCreditAlphaNum4("DEMO", "GCWPICV6IV35FQ2MVZSEDLORHEMMIAODRQPVDEIKZOW2GC2JGGDCXVVV");
+        EnumSet<TrustLineFlags> toClear = EnumSet.of(TrustLineFlags.AUTHORIZED_FLAG);
+        EnumSet<TrustLineFlags> toSet = EnumSet.of(TrustLineFlags.AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG, TrustLineFlags.TRUSTLINE_CLAWBACK_ENABLED_FLAG);
+
+        SetTrustlineFlagsOperation operation = new SetTrustlineFlagsOperation.Builder(accountId, asset, toClear, toSet).setSourceAccount(source).build();
+        assertEquals("AAAAAQAAAAA037UdsRiULYrlHjmXWb6CiMKM2fNCa/ONGxK3rOkvTwAAABUAAAAADQ+NsKVhHzrYcjvtr6RiSeUIB3wkUWSrx1444ZEQO0sAAAABREVNTwAAAACs9Aq+RXfSw0yuZEGt0TkYxAHDjB9RkQrLraMLSTGGKwAAAAEAAAAG", operation.toXdrBase64());
+
+        org.stellar.sdk.xdr.Operation xdr = operation.toXdr();
+        assertEquals(TrustLineFlags.AUTHORIZED_FLAG.getValue(), xdr.getBody().getSetTrustLineFlagsOp().getClearFlags().getUint32().intValue());
+        assertEquals(TrustLineFlags.AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG.getValue() | TrustLineFlags.TRUSTLINE_CLAWBACK_ENABLED_FLAG.getValue(), xdr.getBody().getSetTrustLineFlagsOp().getSetFlags().getUint32().intValue());
+        SetTrustlineFlagsOperation parsedOperation = (SetTrustlineFlagsOperation) Operation.fromXdr(xdr);
+        assertEquals(accountId, parsedOperation.getTrustor());
+        assertEquals(asset, parsedOperation.getAsset());
+        assertEquals(toClear, parsedOperation.getClearFlags());
+        assertEquals(toSet, parsedOperation.getSetFlags());
+
+        assertEquals(source, parsedOperation.getSourceAccount());
+        assertEquals(operation, parsedOperation);
+    }
+
+    @Test
+    public void testCantSetNativeTrustlineFlags() {
+        try {
+            String source = "GA2N7NI5WEMJILMK4UPDTF2ZX2BIRQUM3HZUE27TRUNRFN5M5EXU6RQV";
+            String accountId = "GAGQ7DNQUVQR6OWYOI563L5EMJE6KCAHPQSFCZFLY5PDRYMRCA5UWCMP";
+            EnumSet<TrustLineFlags> toClear = EnumSet.of(TrustLineFlags.AUTHORIZED_FLAG);
+            EnumSet<TrustLineFlags> toSet = EnumSet.of(TrustLineFlags.AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG);
+
+            new SetTrustlineFlagsOperation.Builder(accountId, Asset.create("native"), toClear, toSet).setSourceAccount(source).build();
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("native assets are not supported", e.getMessage());
+        }
     }
 }


### PR DESCRIPTION

This PR adds support for building transactions using the operations introduced in CAP 35. Once this PR is merged then we can close https://github.com/stellar/java-stellar-sdk/issues/322