### PR TITLE
account: remove useless Long constructor.

### DIFF
--- a/src/main/java/org/stellar/sdk/Account.java
+++ b/src/main/java/org/stellar/sdk/Account.java
@@ -40,7 +40,7 @@ public class Account implements TransactionBuilderAccount {
 
   @Override
   public Long getIncrementedSequenceNumber() {
-    return new Long(mSequenceNumber + 1);
+    return mSequenceNumber + 1;
   }
 
   /**


### PR DESCRIPTION
Constructors for objects used to wrap primitives should never be used. Doing so is less clear and uses more memory than simply using the desired value.