### PR TITLE
Remove useless String constructors.

### DIFF
--- a/src/main/java/org/stellar/sdk/AssetTypeCreditAlphaNum.java
+++ b/src/main/java/org/stellar/sdk/AssetTypeCreditAlphaNum.java
@@ -16,22 +16,22 @@ public abstract class AssetTypeCreditAlphaNum extends Asset {
     public AssetTypeCreditAlphaNum(String code, String issuer) {
         checkNotNull(code, "code cannot be null");
         checkNotNull(issuer, "issuer cannot be null");
-        mCode = new String(code);
-        mIssuer = new String(issuer);
+        mCode = code;
+        mIssuer = issuer;
     }
 
     /**
      * Returns asset code
      */
     public String getCode() {
-        return new String(mCode);
+        return mCode;
     }
 
     /**
      * Returns asset issuer
      */
     public String getIssuer() {
-        return new String(mIssuer);
+        return mIssuer;
     }
 
     @Override


### PR DESCRIPTION
Constructors for String objects should never be used. Doing so is less clear and uses more memory than simply using the desired value in the case of strings.