### PR TITLE
Removed pointless unboxing.

### DIFF
--- a/src/main/java/org/stellar/sdk/SetOptionsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetOptionsOperation.java
@@ -199,23 +199,23 @@ public class SetOptionsOperation extends Operation {
         setFlags = op.getSetFlags().getUint32();
       }
       if (op.getMasterWeight() != null) {
-        masterKeyWeight = op.getMasterWeight().getUint32().intValue();
+        masterKeyWeight = op.getMasterWeight().getUint32();
       }
       if (op.getLowThreshold() != null) {
-        lowThreshold = op.getLowThreshold().getUint32().intValue();
+        lowThreshold = op.getLowThreshold().getUint32();
       }
       if (op.getMedThreshold() != null) {
-        mediumThreshold = op.getMedThreshold().getUint32().intValue();
+        mediumThreshold = op.getMedThreshold().getUint32();
       }
       if (op.getHighThreshold() != null) {
-        highThreshold = op.getHighThreshold().getUint32().intValue();
+        highThreshold = op.getHighThreshold().getUint32();
       }
       if (op.getHomeDomain() != null) {
         homeDomain = op.getHomeDomain().getString32().toString();
       }
       if (op.getSigner() != null) {
         signer = op.getSigner().getKey();
-        signerWeight = op.getSigner().getWeight().getUint32().intValue() & 0xFF;
+        signerWeight = op.getSigner().getWeight().getUint32() & 0xFF;
       }
     }
 


### PR DESCRIPTION
Unboxing is the process of putting a primitive value into an analogous object, such as creating an Integer to hold an int value. Unboxing is the process of retrieving the primitive value from such an object.

Since the original value is unchanged during boxing and unboxing, there's no point in doing either when not needed.