### PR TITLE
Removed uneccessary null check. instanceof returns false for nulls

### DIFF
--- a/src/main/java/org/stellar/sdk/Account.java
+++ b/src/main/java/org/stellar/sdk/Account.java
@@ -56,7 +56,7 @@ public class Account implements TransactionBuilderAccount {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Account)) {
+    if (!(object instanceof Account)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/AccountMergeOperation.java
+++ b/src/main/java/org/stellar/sdk/AccountMergeOperation.java
@@ -82,7 +82,7 @@ public class AccountMergeOperation extends Operation {
 
     @Override
     public boolean equals(Object object) {
-        if (object == null || !(object instanceof AccountMergeOperation)) {
+        if (!(object instanceof AccountMergeOperation)) {
             return false;
         }
 

--- a/src/main/java/org/stellar/sdk/AllowTrustOperation.java
+++ b/src/main/java/org/stellar/sdk/AllowTrustOperation.java
@@ -172,7 +172,7 @@ public class AllowTrustOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof AllowTrustOperation)) {
+    if (!(object instanceof AllowTrustOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/BeginSponsoringFutureReservesOperation.java
+++ b/src/main/java/org/stellar/sdk/BeginSponsoringFutureReservesOperation.java
@@ -78,7 +78,7 @@ public class BeginSponsoringFutureReservesOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof BeginSponsoringFutureReservesOperation)) {
+    if (!(object instanceof BeginSponsoringFutureReservesOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/BumpSequenceOperation.java
+++ b/src/main/java/org/stellar/sdk/BumpSequenceOperation.java
@@ -85,7 +85,7 @@ public class BumpSequenceOperation extends Operation  {
 
     @Override
     public boolean equals(Object object) {
-        if (object == null || !(object instanceof BumpSequenceOperation)) {
+        if (!(object instanceof BumpSequenceOperation)) {
             return false;
         }
 

--- a/src/main/java/org/stellar/sdk/ChangeTrustOperation.java
+++ b/src/main/java/org/stellar/sdk/ChangeTrustOperation.java
@@ -105,7 +105,7 @@ public class ChangeTrustOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ChangeTrustOperation)) {
+    if (!(object instanceof ChangeTrustOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/ClaimClaimableBalanceOperation.java
+++ b/src/main/java/org/stellar/sdk/ClaimClaimableBalanceOperation.java
@@ -77,7 +77,7 @@ public class ClaimClaimableBalanceOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ClaimClaimableBalanceOperation)) {
+    if (!(object instanceof ClaimClaimableBalanceOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/ClawbackClaimableBalanceOperation.java
+++ b/src/main/java/org/stellar/sdk/ClawbackClaimableBalanceOperation.java
@@ -94,7 +94,7 @@ public class ClawbackClaimableBalanceOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ClawbackClaimableBalanceOperation)) {
+    if (!(object instanceof ClawbackClaimableBalanceOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/ClawbackOperation.java
+++ b/src/main/java/org/stellar/sdk/ClawbackOperation.java
@@ -126,7 +126,7 @@ public class ClawbackOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ClawbackOperation)) {
+    if (!(object instanceof ClawbackOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/CreateAccountOperation.java
+++ b/src/main/java/org/stellar/sdk/CreateAccountOperation.java
@@ -108,7 +108,7 @@ public class CreateAccountOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof CreateAccountOperation)) {
+    if (!(object instanceof CreateAccountOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/CreateClaimableBalanceOperation.java
+++ b/src/main/java/org/stellar/sdk/CreateClaimableBalanceOperation.java
@@ -124,7 +124,7 @@ public class CreateClaimableBalanceOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof CreateClaimableBalanceOperation)) {
+    if (!(object instanceof CreateClaimableBalanceOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/CreatePassiveSellOfferOperation.java
+++ b/src/main/java/org/stellar/sdk/CreatePassiveSellOfferOperation.java
@@ -149,7 +149,7 @@ public class CreatePassiveSellOfferOperation extends Operation {
 
     @Override
     public boolean equals(Object object) {
-        if (object == null || !(object instanceof CreatePassiveSellOfferOperation)) {
+        if (!(object instanceof CreatePassiveSellOfferOperation)) {
             return false;
         }
 

--- a/src/main/java/org/stellar/sdk/EndSponsoringFutureReservesOperation.java
+++ b/src/main/java/org/stellar/sdk/EndSponsoringFutureReservesOperation.java
@@ -29,7 +29,7 @@ public class EndSponsoringFutureReservesOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof EndSponsoringFutureReservesOperation)) {
+    if (!(object instanceof EndSponsoringFutureReservesOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/FeeBumpTransaction.java
+++ b/src/main/java/org/stellar/sdk/FeeBumpTransaction.java
@@ -201,7 +201,7 @@ public class FeeBumpTransaction extends AbstractTransaction {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof FeeBumpTransaction)) {
+    if (!(object instanceof FeeBumpTransaction)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/InflationOperation.java
+++ b/src/main/java/org/stellar/sdk/InflationOperation.java
@@ -22,7 +22,7 @@ public class InflationOperation extends Operation {
 
     @Override
     public boolean equals(Object object) {
-        if (object == null || !(object instanceof InflationOperation)) {
+        if (!(object instanceof InflationOperation)) {
             return false;
         }
 

--- a/src/main/java/org/stellar/sdk/KeyPair.java
+++ b/src/main/java/org/stellar/sdk/KeyPair.java
@@ -267,7 +267,7 @@ public class KeyPair {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof KeyPair)) {
+    if (!(object instanceof KeyPair)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/ManageBuyOfferOperation.java
+++ b/src/main/java/org/stellar/sdk/ManageBuyOfferOperation.java
@@ -177,7 +177,7 @@ public class ManageBuyOfferOperation extends Operation {
 
     @Override
     public boolean equals(Object object) {
-        if (object == null || !(object instanceof ManageBuyOfferOperation)) {
+        if (!(object instanceof ManageBuyOfferOperation)) {
             return false;
         }
 

--- a/src/main/java/org/stellar/sdk/ManageDataOperation.java
+++ b/src/main/java/org/stellar/sdk/ManageDataOperation.java
@@ -120,7 +120,7 @@ public class ManageDataOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof ManageDataOperation)) {
+    if (!(object instanceof ManageDataOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/ManageSellOfferOperation.java
+++ b/src/main/java/org/stellar/sdk/ManageSellOfferOperation.java
@@ -171,7 +171,7 @@ public class ManageSellOfferOperation extends Operation {
 
     @Override
     public boolean equals(Object object) {
-        if (object == null || !(object instanceof ManageSellOfferOperation)) {
+        if (!(object instanceof ManageSellOfferOperation)) {
             return false;
         }
 

--- a/src/main/java/org/stellar/sdk/Network.java
+++ b/src/main/java/org/stellar/sdk/Network.java
@@ -50,7 +50,7 @@ public class Network {
 
     @Override
     public boolean equals(Object object) {
-        if (object == null || !(object instanceof Network)) {
+        if (!(object instanceof Network)) {
             return false;
         }
 

--- a/src/main/java/org/stellar/sdk/PathPaymentStrictReceiveOperation.java
+++ b/src/main/java/org/stellar/sdk/PathPaymentStrictReceiveOperation.java
@@ -209,7 +209,7 @@ public class PathPaymentStrictReceiveOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PathPaymentStrictReceiveOperation)) {
+    if (!(object instanceof PathPaymentStrictReceiveOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/PathPaymentStrictSendOperation.java
+++ b/src/main/java/org/stellar/sdk/PathPaymentStrictSendOperation.java
@@ -209,7 +209,7 @@ public class PathPaymentStrictSendOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PathPaymentStrictSendOperation)) {
+    if (!(object instanceof PathPaymentStrictSendOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/PaymentOperation.java
+++ b/src/main/java/org/stellar/sdk/PaymentOperation.java
@@ -132,7 +132,7 @@ public class PaymentOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PaymentOperation)) {
+    if (!(object instanceof PaymentOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/Price.java
+++ b/src/main/java/org/stellar/sdk/Price.java
@@ -123,7 +123,7 @@ public class Price {
 
     @Override
     public boolean equals(Object object) {
-        if (object == null || !(object instanceof Price)) {
+        if (!(object instanceof Price)) {
             return false;
         }
 

--- a/src/main/java/org/stellar/sdk/RevokeAccountSponsorshipOperation.java
+++ b/src/main/java/org/stellar/sdk/RevokeAccountSponsorshipOperation.java
@@ -84,7 +84,7 @@ public class RevokeAccountSponsorshipOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof RevokeAccountSponsorshipOperation)) {
+    if (!(object instanceof RevokeAccountSponsorshipOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/RevokeClaimableBalanceSponsorshipOperation.java
+++ b/src/main/java/org/stellar/sdk/RevokeClaimableBalanceSponsorshipOperation.java
@@ -85,7 +85,7 @@ public class RevokeClaimableBalanceSponsorshipOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof RevokeClaimableBalanceSponsorshipOperation)) {
+    if (!(object instanceof RevokeClaimableBalanceSponsorshipOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/RevokeDataSponsorshipOperation.java
+++ b/src/main/java/org/stellar/sdk/RevokeDataSponsorshipOperation.java
@@ -98,7 +98,7 @@ public class RevokeDataSponsorshipOperation extends org.stellar.sdk.Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof RevokeDataSponsorshipOperation)) {
+    if (!(object instanceof RevokeDataSponsorshipOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/RevokeOfferSponsorshipOperation.java
+++ b/src/main/java/org/stellar/sdk/RevokeOfferSponsorshipOperation.java
@@ -98,7 +98,7 @@ public class RevokeOfferSponsorshipOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof RevokeOfferSponsorshipOperation)) {
+    if (!(object instanceof RevokeOfferSponsorshipOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/RevokeSignerSponsorshipOperation.java
+++ b/src/main/java/org/stellar/sdk/RevokeSignerSponsorshipOperation.java
@@ -93,7 +93,7 @@ public class RevokeSignerSponsorshipOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof RevokeSignerSponsorshipOperation)) {
+    if (!(object instanceof RevokeSignerSponsorshipOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/RevokeTrustlineSponsorshipOperation.java
+++ b/src/main/java/org/stellar/sdk/RevokeTrustlineSponsorshipOperation.java
@@ -96,7 +96,7 @@ public class RevokeTrustlineSponsorshipOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof RevokeTrustlineSponsorshipOperation)) {
+    if (!(object instanceof RevokeTrustlineSponsorshipOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/SetOptionsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetOptionsOperation.java
@@ -364,7 +364,7 @@ public class SetOptionsOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SetOptionsOperation)) {
+    if (!(object instanceof SetOptionsOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/SetTrustlineFlagsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetTrustlineFlagsOperation.java
@@ -157,7 +157,7 @@ public class SetTrustlineFlagsOperation extends Operation {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof SetTrustlineFlagsOperation)) {
+    if (!(object instanceof SetTrustlineFlagsOperation)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/Transaction.java
+++ b/src/main/java/org/stellar/sdk/Transaction.java
@@ -424,7 +424,7 @@ public class Transaction extends AbstractTransaction {
 
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof Transaction)) {
+    if (!(object instanceof Transaction)) {
       return false;
     }
 

--- a/src/main/java/org/stellar/sdk/xdr/PathPaymentResult.java
+++ b/src/main/java/org/stellar/sdk/xdr/PathPaymentResult.java
@@ -86,7 +86,7 @@ public class PathPaymentResult  {
   }
   @Override
   public boolean equals(Object object) {
-    if (object == null || !(object instanceof PathPaymentResult)) {
+    if (!(object instanceof PathPaymentResult)) {
       return false;
     }
 
@@ -134,7 +134,7 @@ public class PathPaymentResult  {
     }
     @Override
     public boolean equals(Object object) {
-      if (object == null || !(object instanceof PathPaymentResultSuccess)) {
+      if (!(object instanceof PathPaymentResultSuccess)) {
         return false;
       }
 

--- a/src/main/java/org/stellar/sdk/xdr/XdrString.java
+++ b/src/main/java/org/stellar/sdk/xdr/XdrString.java
@@ -43,7 +43,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public boolean equals(Object object) {
-        if (object == null || !(object instanceof XdrString)) {
+        if (!(object instanceof XdrString)) {
           return false;
         }
 


### PR DESCRIPTION
There's no need to null test in conjunction with an instanceof test. null is not an instanceof anything, so a null check is redundant.