### PR TITLE
removed unused imports.

### DIFF
--- a/src/main/java/org/stellar/sdk/Claimant.java
+++ b/src/main/java/org/stellar/sdk/Claimant.java
@@ -1,7 +1,6 @@
 package org.stellar.sdk;
 
 import com.google.gson.annotations.SerializedName;
-import org.stellar.sdk.Predicate;
 
 /**
  * Represents an entity who is eligible to claim the claimable balance.

--- a/src/main/java/org/stellar/sdk/PaymentOperation.java
+++ b/src/main/java/org/stellar/sdk/PaymentOperation.java
@@ -1,7 +1,7 @@
 package org.stellar.sdk;
 
 import com.google.common.base.Objects;
-import org.stellar.sdk.xdr.AccountID;
+
 import org.stellar.sdk.xdr.Int64;
 import org.stellar.sdk.xdr.OperationType;
 import org.stellar.sdk.xdr.PaymentOp;

--- a/src/main/java/org/stellar/sdk/Server.java
+++ b/src/main/java/org/stellar/sdk/Server.java
@@ -7,7 +7,6 @@ import okhttp3.Response;
 import org.stellar.sdk.requests.*;
 import org.stellar.sdk.responses.*;
 import org.stellar.sdk.xdr.CryptoKeyType;
-import org.stellar.sdk.xdr.MuxedAccount;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/src/main/java/org/stellar/sdk/requests/StrictReceivePathsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/StrictReceivePathsRequestBuilder.java
@@ -1,7 +1,5 @@
 package org.stellar.sdk.requests;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
 import com.google.gson.reflect.TypeToken;
 
 import okhttp3.HttpUrl;

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineSponsorshipCreatedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineSponsorshipCreatedEffectResponse.java
@@ -2,7 +2,6 @@ package org.stellar.sdk.responses.effects;
 
 import com.google.gson.annotations.SerializedName;
 import org.stellar.sdk.Asset;
-import org.stellar.sdk.Predicate;
 
 /**
  * Represents trustline_sponsorship_created effect response.

--- a/src/main/java/org/stellar/sdk/responses/operations/PathPaymentStrictReceiveOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/PathPaymentStrictReceiveOperationResponse.java
@@ -2,7 +2,6 @@ package org.stellar.sdk.responses.operations;
 
 import com.google.gson.annotations.SerializedName;
 import org.stellar.sdk.Asset;
-import org.stellar.sdk.AssetTypeNative;
 
 import java.util.List;
 

--- a/src/main/java/org/stellar/sdk/responses/operations/PathPaymentStrictSendOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/PathPaymentStrictSendOperationResponse.java
@@ -2,7 +2,6 @@ package org.stellar.sdk.responses.operations;
 
 import com.google.gson.annotations.SerializedName;
 import org.stellar.sdk.Asset;
-import org.stellar.sdk.AssetTypeNative;
 
 import java.util.List;
 

--- a/src/main/java/org/stellar/sdk/xdr/XdrDataInputStream.java
+++ b/src/main/java/org/stellar/sdk/xdr/XdrDataInputStream.java
@@ -3,7 +3,6 @@ package org.stellar.sdk.xdr;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
 
 public class XdrDataInputStream extends DataInputStream {
 

--- a/src/main/java/org/stellar/sdk/xdr/XdrDataOutputStream.java
+++ b/src/main/java/org/stellar/sdk/xdr/XdrDataOutputStream.java
@@ -3,7 +3,6 @@ package org.stellar.sdk.xdr;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
 
 public class XdrDataOutputStream extends DataOutputStream {
 


### PR DESCRIPTION
Leaving them in reduces the code's readability, since their presence can be confusing.