### PR TITLE
util: replaced to/from hex method implementations.

### DIFF
--- a/src/main/java/org/stellar/sdk/Util.java
+++ b/src/main/java/org/stellar/sdk/Util.java
@@ -12,28 +12,16 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
+import javax.xml.bind.DatatypeConverter;
+
 public class Util {
 
-  public static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
-
   public static String bytesToHex(byte[] bytes) {
-    char[] hexChars = new char[bytes.length * 2];
-    for ( int j = 0; j < bytes.length; j++ ) {
-      int v = bytes[j] & 0xFF;
-      hexChars[j * 2] = HEX_ARRAY[v >>> 4];
-      hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
-    }
-    return new String(hexChars);
+    return DatatypeConverter.printHexBinary(bytes);
   }
 
   public static byte[] hexToBytes(String s) {
-    int len = s.length();
-    byte[] data = new byte[len / 2];
-    for (int i = 0; i < len; i += 2) {
-      data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
-          + Character.digit(s.charAt(i+1), 16));
-    }
-    return data;
+    return DatatypeConverter.parseHexBinary(s);
   }
 
   /**


### PR DESCRIPTION
The DataTypeConverter class is supplied with JAXB library. This is part
of the standard library in Java 7.