### PR TITLE
assettypenative: assert that passed object is not null.

### DIFF
--- a/src/main/java/org/stellar/sdk/AssetTypeNative.java
+++ b/src/main/java/org/stellar/sdk/AssetTypeNative.java
@@ -22,7 +22,11 @@ public final class AssetTypeNative extends Asset {
 
   @Override
   public boolean equals(Object object) {
-    return this.getClass().equals(object.getClass());
+    if (object != null) {
+      return this.getClass().equals(object.getClass());
+    } else {
+      return false;
+    }
   }
 
   @Override


### PR DESCRIPTION
A reference to null should never be dereferenced/accessed. The `Object`
in this equals() method could be `null` which would cause a
NullPointerException