### PR TITLE
#369 Rename test method

### DIFF
--- a/src/test/java/org/stellar/sdk/requests/AssetsRequestBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/requests/AssetsRequestBuilderTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertEquals;
 
 public class AssetsRequestBuilderTest {
     @Test
-    public void testAccounts() {
+    public void testAssets() {
         Server server = new Server("https://horizon-testnet.stellar.org");
         HttpUrl uri = server.assets()
                 .assetCode("USD")


### PR DESCRIPTION
In AssetsRequestBuilderTest the method was erroneously called `testAccounts`, it is now renamed