### PR TITLE
#374: added CHANGELOG entry for prior fix of ChangeTrustOperation.getAsset null pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ## Unreleased
 
-* Fixed missing Liquidity Pool ID in AccountResponse Balance ([#379](https://github.com/stellar/java-stellar-sdk/pull/379)).
+* Fix missing Liquidity Pool ID in AccountResponse Balance ([#379](https://github.com/stellar/java-stellar-sdk/pull/379)).
+* Fix null pointer when ChangeTrustOperationResponse.getAsset for LiquidityPool trust line ([#378](https://github.com/stellar/java-stellar-sdk/pull/378)).
 
 ## 0.29.0
 


### PR DESCRIPTION
Add an entry to CHANGELOG to cover prior PR that was merged with fix [#378 ](https://github.com/stellar/java-stellar-sdk/pull/378)