### PR TITLE
#354: added custom deserializer for extended ISO 8601 formatted date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 * Fix missing Liquidity Pool ID in AccountResponse Balance ([#379](https://github.com/stellar/java-stellar-sdk/pull/379)).
 * Fix null pointer when calling ChangeTrustOperationResponse.getAsset() for LiquidityPool trust line ([#378](https://github.com/stellar/java-stellar-sdk/pull/378)).
+* Fix exception when parsing huge datetime values from responses with ClaimableBalance AbsBefore Predicate ([#382](https://github.com/stellar/java-stellar-sdk/pull/382)).
 
 ## 0.29.0
 

--- a/src/main/java/org/stellar/sdk/responses/EffectDeserializer.java
+++ b/src/main/java/org/stellar/sdk/responses/EffectDeserializer.java
@@ -16,6 +16,9 @@ import org.stellar.sdk.xdr.LiquidityPoolType;
 import java.lang.reflect.Type;
 
 class EffectDeserializer implements JsonDeserializer<EffectResponse> {
+
+  private final FormattedDateStringDeserializer iso8601Deserializer = new ISO8601ExtendedDeserialzer();
+
   @Override
   public EffectResponse deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
     // Create new Gson object with adapters needed in Operation
@@ -23,7 +26,7 @@ class EffectDeserializer implements JsonDeserializer<EffectResponse> {
         .registerTypeAdapter(Asset.class, new AssetDeserializer())
         .registerTypeAdapter(LiquidityPoolID.class, new LiquidityPoolIDDeserializer())
         .registerTypeAdapter(LiquidityPoolType.class, new LiquidityPoolTypeDeserializer())
-        .registerTypeAdapter(Predicate.class, new PredicateDeserializer())
+        .registerTypeAdapter(Predicate.class, new PredicateDeserializer(iso8601Deserializer))
         .create();
 
 

--- a/src/main/java/org/stellar/sdk/responses/FormattedDateStringDeserializer.java
+++ b/src/main/java/org/stellar/sdk/responses/FormattedDateStringDeserializer.java
@@ -1,0 +1,16 @@
+package org.stellar.sdk.responses;
+
+/**
+ * Deserializes iso 8601 formatted strings into epochs
+ */
+public interface FormattedDateStringDeserializer {
+    /**
+     * deserialization of datetime string formats
+     *
+     * @param formmattedDateString formatted datetime string
+     * @param defaultEpoch         default return value if formmattedDateString is invalid
+     * @return                     unix epoch seconds represented by formmattedDateString
+     * @throws IllegalArgumentException
+     */
+    long unixEpochSeconds(String formmattedDateString, long defaultEpoch);
+}

--- a/src/main/java/org/stellar/sdk/responses/GsonSingleton.java
+++ b/src/main/java/org/stellar/sdk/responses/GsonSingleton.java
@@ -33,7 +33,7 @@ public class GsonSingleton {
 
       instance = new GsonBuilder()
                       .registerTypeAdapter(Asset.class, new AssetDeserializer())
-                      .registerTypeAdapter(Predicate.class, new PredicateDeserializer())
+                      .registerTypeAdapter(Predicate.class, new PredicateDeserializer(new ISO8601ExtendedDeserialzer()))
                       .registerTypeAdapter(OperationResponse.class, new OperationDeserializer())
                       .registerTypeAdapter(EffectResponse.class, new EffectDeserializer())
                       .registerTypeAdapter(LiquidityPoolID.class, new LiquidityPoolIDDeserializer())

--- a/src/main/java/org/stellar/sdk/responses/ISO8601ExtendedDeserialzer.java
+++ b/src/main/java/org/stellar/sdk/responses/ISO8601ExtendedDeserialzer.java
@@ -1,0 +1,75 @@
+package org.stellar.sdk.responses;
+
+import org.threeten.bp.LocalDate;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ISO8601ExtendedDeserialzer implements FormattedDateStringDeserializer {
+
+    @Override
+    public long unixEpochSeconds(String is8601DateString, long defaultEpoch) {
+
+        Pattern pattern = Pattern.compile(
+                "^(?<epochsign>[-+]?)" +
+                        "(?<year>\\d{4,})" +
+                        "-(?<month>\\d{2})" +
+                        "-(?<day>\\d{2})T" +
+                        "(?<hour>2[0-3]|[01][0-9]):" +
+                        "(?<minute>[0-5][0-9]):" +
+                        "(?<second>[0-5][0-9])" +
+                        ".*",
+                Pattern.CASE_INSENSITIVE);
+
+        Matcher matcher = pattern.matcher(is8601DateString);
+        if (!matcher.find()) {
+            return defaultEpoch;
+        }
+        int epochNegative = matcher.group(1) != null && matcher.group(1).equals("-") ? -1 : 1;
+        long gregorianYear = epochNegative * Long.parseLong(matcher.group(2));
+        int leapDaysEndYear = getLeapDaysModulo(gregorianYear, Integer.parseInt(matcher.group(3)), Integer.parseInt(matcher.group(4)));
+
+        return totalLeapSeconds(Integer.parseInt(matcher.group(7)),
+                Integer.parseInt(matcher.group(6)),
+                Integer.parseInt(matcher.group(5)),
+                leapDaysEndYear, gregorianYear);
+
+    }
+
+    private long totalLeapSeconds(int seconds, int minutes, int hours, int daysInYear, long gregorianYear) {
+        // condensed unix epoch seconds including leap year calcs,
+        long allSeconds = (seconds + (minutes*60L) +
+                (hours*3600L)) +
+                (daysInYear*86400L) +
+                ((gregorianYear-1970)*31536000);
+
+        if (gregorianYear > 1969) {
+            return allSeconds + ((gregorianYear - 1969) / 4) * 86400
+                    - ((gregorianYear - 1901) / 100) * 86400
+                    + ((gregorianYear - 1601) / 400) * 86400;
+        } else {
+            return allSeconds + ((gregorianYear - 1971) / 4) * 86400
+                    - ((gregorianYear - 1999) / 100) * 86400
+                    + ((gregorianYear - 1999) / 400) * 86400;
+        }
+    }
+
+    private int getLeapDaysModulo(long gregorianYear, int month, int day) {
+        // this applies extra leap year day if current gregorianYear is leap
+        // and offset days of year has crossed over the 2/29 date
+        int yearDays = LocalDate.of(2006, month, day).getDayOfYear() - 1;
+
+        if (gregorianYear > 1969 && isLeapYear(gregorianYear) && yearDays > 59) {
+            yearDays+=1;
+        }
+        if (gregorianYear < 1970 && isLeapYear(gregorianYear) && yearDays < 60) {
+            yearDays+=1;
+        }
+
+        return yearDays;
+    }
+
+    private boolean isLeapYear(long gregorianYear) {
+        return gregorianYear % 400 == 0 || ((gregorianYear % 4) == 0 && (gregorianYear % 100) > 0);
+    }
+}

--- a/src/main/java/org/stellar/sdk/responses/OperationDeserializer.java
+++ b/src/main/java/org/stellar/sdk/responses/OperationDeserializer.java
@@ -24,7 +24,7 @@ class OperationDeserializer implements JsonDeserializer<OperationResponse> {
     // Create new Gson object with adapters needed in Operation
     Gson gson = new GsonBuilder()
             .registerTypeAdapter(Asset.class, new AssetDeserializer())
-            .registerTypeAdapter(Predicate.class, new PredicateDeserializer())
+            .registerTypeAdapter(Predicate.class, new PredicateDeserializer(new ISO8601ExtendedDeserialzer()))
             .registerTypeAdapter(TransactionResponse.class, new TransactionDeserializer())
             .registerTypeAdapter(ImmutableList.class, new ImmutableListDeserializer())
             .registerTypeAdapter(LiquidityPoolID.class, new LiquidityPoolIDDeserializer())

--- a/src/main/java/org/stellar/sdk/responses/PageDeserializer.java
+++ b/src/main/java/org/stellar/sdk/responses/PageDeserializer.java
@@ -40,7 +40,7 @@ class PageDeserializer<E> implements JsonDeserializer<Page<E>> {
     // Create new Gson object with adapters needed in Page
     Gson gson = new GsonBuilder()
             .registerTypeAdapter(Asset.class, new AssetDeserializer())
-            .registerTypeAdapter(Predicate.class, new PredicateDeserializer())
+            .registerTypeAdapter(Predicate.class, new PredicateDeserializer(new ISO8601ExtendedDeserialzer()))
             .registerTypeAdapter(OperationResponse.class, new OperationDeserializer())
             .registerTypeAdapter(EffectResponse.class, new EffectDeserializer())
             .registerTypeAdapter(LiquidityPoolResponse.class, new LiquidityPoolDeserializer())

--- a/src/main/java/org/stellar/sdk/responses/PredicateDeserializer.java
+++ b/src/main/java/org/stellar/sdk/responses/PredicateDeserializer.java
@@ -3,12 +3,17 @@ package org.stellar.sdk.responses;
 import com.google.common.collect.Lists;
 import com.google.gson.*;
 import org.stellar.sdk.Predicate;
-import org.threeten.bp.Instant;
 
 import java.lang.reflect.Type;
 import java.util.List;
 
 public class PredicateDeserializer implements JsonDeserializer<Predicate> {
+
+  private final FormattedDateStringDeserializer formattedDateStringDeserializer;
+  public PredicateDeserializer(FormattedDateStringDeserializer formattedDateStringDeserializer) {
+    this.formattedDateStringDeserializer = formattedDateStringDeserializer;
+  }
+
   @Override
   public Predicate deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
     JsonObject obj = json.getAsJsonObject();
@@ -37,8 +42,8 @@ public class PredicateDeserializer implements JsonDeserializer<Predicate> {
     }
 
     if (obj.has("abs_before")) {
-      String formattedDate = obj.get("abs_before").getAsString();
-      return new Predicate.AbsBefore(Instant.parse(formattedDate).getEpochSecond());
+      return new Predicate.AbsBefore(
+              formattedDateStringDeserializer.unixEpochSeconds(obj.get("abs_before").getAsString(), Long.MAX_VALUE));
     }
 
     if (obj.has("rel_before")) {

--- a/src/test/java/org/stellar/sdk/responses/EffectDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/EffectDeserializerTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetAmount;
 import org.stellar.sdk.AssetTypeNative;
+import org.stellar.sdk.Predicate;
 import org.stellar.sdk.responses.effects.*;
 import org.stellar.sdk.xdr.LiquidityPoolType;
 
@@ -782,6 +783,45 @@ public class EffectDeserializerTest extends TestCase {
     assertEquals(effect.getBalanceId(), "00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9");
     assertEquals(effect.getType(), "claimable_balance_clawed_back");
   }
+
+  @Test
+  public void testDeserializeClaimableBalanceClaimantCreatedEffect() {
+    String json = "{\n" +
+            "        \"_links\": {\n" +
+            "          \"operation\": {\n" +
+            "            \"href\": \"https://horizon.stellar.org/operations/158104892991700993\"\n" +
+            "          },\n" +
+            "          \"succeeds\": {\n" +
+            "            \"href\": \"https://horizon.stellar.org/effects?order=desc&cursor=158104892991700993-2\"\n" +
+            "          },\n" +
+            "          \"precedes\": {\n" +
+            "            \"href\": \"https://horizon.stellar.org/effects?order=asc&cursor=158104892991700993-2\"\n" +
+            "          }\n" +
+            "        },\n" +
+            "        \"id\": \"0158104892991700993-0000000002\",\n" +
+            "        \"paging_token\": \"158104892991700993-2\",\n" +
+            "        \"account\": \"GBQECQVAS2FJ7DLCUXDASZAJQLWPXNTCR2DGBPKQDO3QS66TJXLRHFIK\",\n" +
+            "        \"type\": \"claimable_balance_claimant_created\",\n" +
+            "        \"type_i\": 51,\n" +
+            "        \"created_at\": \"2021-08-11T16:16:32Z\",\n" +
+            "        \"asset\": \"KES:GA2MSSZKJOU6RNL3EJKH3S5TB5CDYTFQFWRYFGUJVIN5I6AOIRTLUHTO\",\n" +
+            "        \"balance_id\": \"0000000071d3336fa6b6cf81fcbeda85a503ccfabc786ab1066594716f3f9551ea4b89ca\",\n" +
+            "        \"amount\": \"0.0012200\",\n" +
+            "        \"predicate\": {\n" +
+            "          \"abs_before\": \"+39121901036-03-29T15:30:22Z\"\n" +
+            "        }\n" +
+            "      }\n";
+
+    ClaimableBalanceClaimantCreatedEffectResponse effect = (ClaimableBalanceClaimantCreatedEffectResponse) GsonSingleton.getInstance().fromJson(json, EffectResponse.class);
+
+    assertEquals(effect.getAccount(), "GBQECQVAS2FJ7DLCUXDASZAJQLWPXNTCR2DGBPKQDO3QS66TJXLRHFIK");
+    assertEquals(effect.getCreatedAt(), "2021-08-11T16:16:32Z");
+    assertEquals(effect.getBalanceId(), "0000000071d3336fa6b6cf81fcbeda85a503ccfabc786ab1066594716f3f9551ea4b89ca");
+    assertEquals(effect.getType(), "claimable_balance_claimant_created");
+    assertSame(effect.getPredicate().getClass(), Predicate.AbsBefore.class);
+    assertEquals(((Predicate.AbsBefore)effect.getPredicate()).getTimestampSeconds(), 1234567890982222222L);
+  }
+
 
   @Test
   public void testDeserializeTrustlineFlagsUpdatedEffect() {

--- a/src/test/java/org/stellar/sdk/responses/ISO8601ExtendedDeserialzerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/ISO8601ExtendedDeserialzerTest.java
@@ -1,0 +1,29 @@
+package org.stellar.sdk.responses;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+public class ISO8601ExtendedDeserialzerTest extends TestCase {
+
+    @Test
+    public void testDeSerializesEpochs() {
+        ISO8601ExtendedDeserialzer deser = new ISO8601ExtendedDeserialzer();
+        // verify a large negative epoch that falls on non-leap year, it triggers the 100 and 400 year counters
+        assertEquals(deser.unixEpochSeconds("-7025-12-23T00:00:00Z",0), -283824000000L);
+        // verify a large negative epoch that falls on leap year and it triggers the 100 and 400 year counters
+        assertEquals(deser.unixEpochSeconds("-7024-12-22T00:00:00Z",0), -283792464000L);
+        // verify a small negative epoch that falls on non-leap year, triggers no 100 or 400 year counts
+        assertEquals( deser.unixEpochSeconds("1969-12-31T23:59:50Z",0), -10L);
+        // verify a small negative epoch that falls on leap year, triggers no 100 or 400 year counter
+        assertEquals(deser.unixEpochSeconds("1968-12-31T23:59:50Z", 0),-31536010L);
+
+        // verify a large epoch that falls on non-leap year, it triggers the 100 and 400 year counters
+        assertEquals(deser.unixEpochSeconds("2869-05-27T00:00:00Z",0), 28382400000L);
+        // verify a large epoch that falls on leap year, it triggers the 100 and 400 year counters
+        assertEquals(deser.unixEpochSeconds("+39121901036-03-29T15:30:22Z",0), 1234567890982222222L);
+        // verify a small epoch that falls on non-leap year and no 100 or 400 year counters
+        assertEquals(deser.unixEpochSeconds("+2021-11-21T07:24:10Z",0), 1637479450L);
+        // verify a small epoch that falls on leap year and no 100 or 400 year counters
+        assertEquals(deser.unixEpochSeconds("+2024-06-21T23:59:50Z",0), 1719014390L);
+    }
+}

--- a/src/test/java/org/stellar/sdk/responses/OperationDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/OperationDeserializerTest.java
@@ -1152,6 +1152,50 @@ public class OperationDeserializerTest extends TestCase {
   }
 
   @Test
+  public void testDeserializeCreateClaimableBalanceOperation() {
+    String json = "{\n" +
+            "  \n" +
+            "  \"id\": \"158104892991700993\",\n" +
+            "  \"paging_token\": \"158104892991700993\",\n" +
+            "  \"transaction_successful\": true,\n" +
+            "  \"source_account\": \"GAKFBRS24U3PEN6XDMEX4JEV5NGBARS2ZFF5O4CF3JL464SQSD4MDCPF\",\n" +
+            "  \"type\": \"create_claimable_balance\",\n" +
+            "  \"type_i\": 14,\n" +
+            "  \"created_at\": \"2021-08-11T16:16:32Z\",\n" +
+            "  \"transaction_hash\": \"c78e86007a0ee0bb0c717b02f5e306e524b4913b892e9983e7db4664a0c29841\",\n" +
+            "  \"sponsor\": \"GAKFBRS24U3PEN6XDMEX4JEV5NGBARS2ZFF5O4CF3JL464SQSD4MDCPF\",\n" +
+            "  \"asset\": \"KES:GA2MSSZKJOU6RNL3EJKH3S5TB5CDYTFQFWRYFGUJVIN5I6AOIRTLUHTO\",\n" +
+            "  \"amount\": \"0.0012200\",\n" +
+            "  \"claimants\": [\n" +
+            "    {\n" +
+            "      \"destination\": \"GBQECQVAS2FJ7DLCUXDASZAJQLWPXNTCR2DGBPKQDO3QS66TJXLRHFIK\",\n" +
+            "      \"predicate\": {\n" +
+            "        \"abs_before\": \"+39121901036-03-29T15:30:22Z\"\n" +
+            "      }\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"destination\": \"GAKFBRS24U3PEN6XDMEX4JEV5NGBARS2ZFF5O4CF3JL464SQSD4MDCPF\",\n" +
+            "      \"predicate\": {\n" +
+            "        \"unconditional\": true\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    CreateClaimableBalanceOperationResponse operation = (CreateClaimableBalanceOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
+
+    assertEquals(operation.getId().longValue(), 158104892991700993L);
+    assertEquals(operation.getClaimants().size(), 2);
+    assertEquals(operation.getClaimants().get(0).getDestination(), "GBQECQVAS2FJ7DLCUXDASZAJQLWPXNTCR2DGBPKQDO3QS66TJXLRHFIK");
+    assertSame(operation.getClaimants().get(0).getPredicate().getClass(), Predicate.AbsBefore.class);
+    assertEquals(((Predicate.AbsBefore)operation.getClaimants().get(0).getPredicate()).getTimestampSeconds(), 1234567890982222222L);
+    assertEquals(operation.getClaimants().get(1).getDestination(), "GAKFBRS24U3PEN6XDMEX4JEV5NGBARS2ZFF5O4CF3JL464SQSD4MDCPF");
+    assertSame(operation.getClaimants().get(1).getPredicate().getClass(), Predicate.Unconditional.class);
+    assertEquals(operation.getType(), "create_claimable_balance");
+  }
+
+
+  @Test
   public void testDeserializeMuxedClaimClaimableBalanceOperation() {
     String json = "{\n" +
         "  \"_links\": {\n" +


### PR DESCRIPTION
**Problem:** The Claimable Balance Claimant AbsBefore Predicate in API response has a formatted datetime string value which follows a custom extended format on top of ISO 8601 [per the changes done in horizon API last year](https://github.com/stellar/go/pull/3183/files). By default ISO 8601 formatted dates support 4 digit years up to 9999. However, with this change in Horizon API, the custom formatted datetime strings for Predicate AbsBefore are based on a unix epoch value expressed as int64. This means it has a huge date range with a max of year 292277026596 into future and -292471206707 year back in past. 

An example of value that could be in the json `abs_before` field:
```"+39121901036-03-29T15:30:22Z"```

The Java datetime libraries can't handle years this big, limit is 9 digits years or 999,999,999, so if AbsBefore Predicate datetime values with years greater than that are received from API, the Java SDK throws an error and stops parsing the API response.

**Solution:** this PR shows alternative to avoid using the Java datetime libraries and use a custom method to manually parse the AbsBefore Predicate datetime value if present in Horizon API response, apply conversion to unix epoch with minor algorithm to include leap year adjustments.The end result should be that Claimable Balances AbsBefore Predicate in responses should reflect the same integral epoch value as what was entered on operation for CreateClaimableBalance Claimant AbsBefore Predicate in Transaction. 

closes #354 

**Request from Reviewers:** Would like to get feedback here if this approach seems correct to move forward with now, or if it's going wrong direction? Another option is to hold off on this custom change, and wait and see if new [Horizon API Feature Request #4095](https://github.com/stellar/go/issues/4095) to add new attribute `absBeforeEpoch` to API response gets accepted, at which point, these custom changes here become obsolete, since the whole point of Java deserializing absBefore is to just get back to the integral epoch value.