### PR TITLE
#307: change offer ids to be represented in requests and response as long data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,16 @@
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
 ## Unreleased
-
+### Changes
 * Fix missing Liquidity Pool ID in AccountResponse Balance ([#379](https://github.com/stellar/java-stellar-sdk/pull/379)).
 * Fix null pointer when calling ChangeTrustOperationResponse.getAsset() for LiquidityPool trust line ([#378](https://github.com/stellar/java-stellar-sdk/pull/378)).
-* Change offer ids to be represented in requests and response models as long data type. 
+### Breaking changes
+* Changed offer ids to be represented in requests and response models as long data type. ([#386](https://github.com/stellar/java-stellar-sdk/pull/386)).
+  * `TradesRequestBuilder.offerId()`
+  * `TradeResponse.getOfferId()` 
+  * `TradeResponse.getBaseOfferId()` 
+  * `TradeResponse.getCounterOfferId()` 
+  * `RevokeSponsorshipOperationResponse.getOfferId()`
 
 ## 0.29.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 * Fix missing Liquidity Pool ID in AccountResponse Balance ([#379](https://github.com/stellar/java-stellar-sdk/pull/379)).
 * Fix null pointer when calling ChangeTrustOperationResponse.getAsset() for LiquidityPool trust line ([#378](https://github.com/stellar/java-stellar-sdk/pull/378)).
+* Change offer ids to be represented in requests and response models as long data type. 
 
 ## 0.29.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
 ## Unreleased
+
 ### Changes
 * Fix missing Liquidity Pool ID in AccountResponse Balance ([#379](https://github.com/stellar/java-stellar-sdk/pull/379)).
 * Fix null pointer when calling ChangeTrustOperationResponse.getAsset() for LiquidityPool trust line ([#378](https://github.com/stellar/java-stellar-sdk/pull/378)).
+
 ### Breaking changes
 * Changed offer ids to be represented in requests and response models as long data type. ([#386](https://github.com/stellar/java-stellar-sdk/pull/386)).
   * `TradesRequestBuilder.offerId()`

--- a/src/main/java/org/stellar/sdk/requests/TradesRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/TradesRequestBuilder.java
@@ -1,7 +1,6 @@
 package org.stellar.sdk.requests;
 
 import com.google.gson.reflect.TypeToken;
-import java.io.IOException;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -11,6 +10,8 @@ import org.stellar.sdk.AssetTypeCreditAlphaNum;
 import org.stellar.sdk.LiquidityPoolID;
 import org.stellar.sdk.responses.Page;
 import org.stellar.sdk.responses.TradeResponse;
+
+import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -77,7 +78,7 @@ public class TradesRequestBuilder extends RequestBuilder {
     /**
      * Returns all trades that of a specific type.
      *
-     * @param trade type
+     * @param tradeType type
      * @return current {@link TradesRequestBuilder} instance
      * @see <a href="https://developers.stellar.org/api/resources/trades/list/">List All Trades</a>
      */
@@ -103,8 +104,11 @@ public class TradesRequestBuilder extends RequestBuilder {
         return this.execute(this.httpClient, this.buildUri());
     }
 
-    public TradesRequestBuilder offerId(String offerId) {
-        uriBuilder.setQueryParameter("offer_id", offerId);
+    public TradesRequestBuilder offerId(Long offerId) {
+        if (offerId == null) {
+            return this;
+        }
+        uriBuilder.setQueryParameter("offer_id",  offerId.toString());
         return this;
     }
 

--- a/src/main/java/org/stellar/sdk/requests/TradesRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/TradesRequestBuilder.java
@@ -106,6 +106,7 @@ public class TradesRequestBuilder extends RequestBuilder {
 
     public TradesRequestBuilder offerId(Long offerId) {
         if (offerId == null) {
+            uriBuilder.removeAllQueryParameters("offer_id");
             return this;
         }
         uriBuilder.setQueryParameter("offer_id",  offerId.toString());

--- a/src/main/java/org/stellar/sdk/responses/TradeResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/TradeResponse.java
@@ -21,7 +21,7 @@ public class TradeResponse extends Response implements Pageable {
     private final String ledgerCloseTime;
 
     @SerializedName("offer_id")
-    private final String offerId;
+    private final Long offerId;
 
     @SerializedName("base_is_seller")
     protected final boolean baseIsSeller;
@@ -31,7 +31,7 @@ public class TradeResponse extends Response implements Pageable {
     @SerializedName("base_liquidity_pool_id")
     protected LiquidityPoolID baseLiquidityPoolID;
     @SerializedName("base_offer_id")
-    private String baseOfferId;
+    private Long baseOfferId;
     @SerializedName("base_amount")
     protected final String baseAmount;
     @SerializedName("base_asset_type")
@@ -46,7 +46,7 @@ public class TradeResponse extends Response implements Pageable {
     @SerializedName("counter_liquidity_pool_id")
     protected LiquidityPoolID counterLiquidityPoolID;
     @SerializedName("counter_offer_id")
-    private String counterOfferId;
+    private Long counterOfferId;
     @SerializedName("counter_amount")
     protected final String counterAmount;
     @SerializedName("counter_asset_type")
@@ -62,7 +62,7 @@ public class TradeResponse extends Response implements Pageable {
     @SerializedName("_links")
     private TradeResponse.Links links;
 
-    public TradeResponse(String id, String pagingToken, String ledgerCloseTime, String offerId, boolean baseIsSeller, String baseAccount, LiquidityPoolID baseLiquidityPoolID, String baseOfferId, String baseAmount, String baseAssetType, String baseAssetCode, String baseAssetIssuer, String counterAccount, LiquidityPoolID counterLiquidityPoolID, String counterOfferId, String counterAmount, String counterAssetType, String counterAssetCode, String counterAssetIssuer, TradePrice price) {
+    public TradeResponse(String id, String pagingToken, String ledgerCloseTime, Long offerId, boolean baseIsSeller, String baseAccount, LiquidityPoolID baseLiquidityPoolID, Long baseOfferId, String baseAmount, String baseAssetType, String baseAssetCode, String baseAssetIssuer, String counterAccount, LiquidityPoolID counterLiquidityPoolID, Long counterOfferId, String counterAmount, String counterAssetType, String counterAssetCode, String counterAssetIssuer, TradePrice price) {
         this.id = id;
         this.pagingToken = pagingToken;
         this.ledgerCloseTime = ledgerCloseTime;
@@ -97,7 +97,7 @@ public class TradeResponse extends Response implements Pageable {
         return ledgerCloseTime;
     }
 
-    public String getOfferId() {
+    public Long getOfferId() {
         return offerId;
     }
 
@@ -105,7 +105,7 @@ public class TradeResponse extends Response implements Pageable {
         return baseIsSeller;
     }
 
-    public Optional<String> getBaseOfferId() {
+    public Optional<Long> getBaseOfferId() {
         return Optional.fromNullable(baseOfferId);
     }
 
@@ -145,7 +145,7 @@ public class TradeResponse extends Response implements Pageable {
         return Optional.fromNullable(counterLiquidityPoolID);
     }
 
-    public Optional<String> getCounterOfferId() {
+    public Optional<Long> getCounterOfferId() {
         return Optional.fromNullable(counterOfferId);
     }
 

--- a/src/main/java/org/stellar/sdk/responses/operations/RevokeSponsorshipOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/RevokeSponsorshipOperationResponse.java
@@ -22,7 +22,7 @@ public class RevokeSponsorshipOperationResponse extends OperationResponse {
   private final String dataName;
 
   @SerializedName("offer_id")
-  private final String offerId;
+  private final Long offerId;
 
   @SerializedName("trustline_account_id")
   private final String trustlineAccountId;
@@ -37,7 +37,7 @@ public class RevokeSponsorshipOperationResponse extends OperationResponse {
   private final String signerKey;
 
 
-  public RevokeSponsorshipOperationResponse(String accountId, String claimableBalanceId, String dataAccountId, String dataName, String offerId, String trustlineAccountId, String trustlineAsset, String signerAccountId, String signerKey) {
+  public RevokeSponsorshipOperationResponse(String accountId, String claimableBalanceId, String dataAccountId, String dataName, Long offerId, String trustlineAccountId, String trustlineAsset, String signerAccountId, String signerKey) {
     this.accountId = accountId;
     this.claimableBalanceId = claimableBalanceId;
     this.dataAccountId = dataAccountId;
@@ -65,7 +65,7 @@ public class RevokeSponsorshipOperationResponse extends OperationResponse {
     return Optional.fromNullable(dataName);
   }
 
-  public Optional<String> getOfferId() {
+  public Optional<Long> getOfferId() {
     return Optional.fromNullable(offerId);
   }
 

--- a/src/test/java/org/stellar/sdk/requests/TradesRequestBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/requests/TradesRequestBuilderTest.java
@@ -18,6 +18,7 @@ public class TradesRequestBuilderTest {
                 .baseAsset(Asset.createNonNativeAsset("EUR", "GAUPA4HERNBDPVO4IUA3MJXBCRRK5W54EVXTDK6IIUTGDQRB6D5W242W"))
                 .counterAsset(Asset.createNonNativeAsset("USD", "GDRRHSJMHXDTQBT4JTCILNGF5AS54FEMTXL7KOLMF6TFTHRK6SSUSUZZ"))
                 .cursor("13537736921089")
+                .offerId(123L)
                 .limit(200)
                 .order(RequestBuilder.Order.ASC)
                 .buildUri();
@@ -30,6 +31,7 @@ public class TradesRequestBuilderTest {
                 "counter_asset_code=USD&" +
                 "counter_asset_issuer=GDRRHSJMHXDTQBT4JTCILNGF5AS54FEMTXL7KOLMF6TFTHRK6SSUSUZZ&" +
                 "cursor=13537736921089&" +
+                "offer_id=123&" +
                 "limit=200&" +
                 "order=asc", uri.toString());
     }
@@ -58,4 +60,15 @@ public class TradesRequestBuilderTest {
             .buildUri();
     assertEquals("https://horizon-testnet.stellar.org/liquidity_pools/67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9/trades", uri.toString());
   }
+
+    @Test
+    public void testForNullOfferId() {
+        Server server = new Server("https://horizon-testnet.stellar.org");
+        HttpUrl uri = server.trades()
+                .cursor("13537736921089")
+                .offerId(null)
+                .limit(200)
+                .buildUri();
+        assertEquals("https://horizon-testnet.stellar.org/trades?cursor=13537736921089&limit=200", uri.toString());
+    }
 }

--- a/src/test/java/org/stellar/sdk/requests/TradesRequestBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/requests/TradesRequestBuilderTest.java
@@ -65,6 +65,7 @@ public class TradesRequestBuilderTest {
     public void testForNullOfferId() {
         Server server = new Server("https://horizon-testnet.stellar.org");
         HttpUrl uri = server.trades()
+                .offerId(12345L)
                 .cursor("13537736921089")
                 .offerId(null)
                 .limit(200)

--- a/src/test/java/org/stellar/sdk/responses/OperationsPageDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/OperationsPageDeserializerTest.java
@@ -12,6 +12,8 @@ import org.stellar.sdk.responses.operations.OperationResponse;
 import org.stellar.sdk.responses.operations.PaymentOperationResponse;
 import org.stellar.sdk.responses.operations.RevokeSponsorshipOperationResponse;
 
+import static java.lang.Long.valueOf;
+
 public class OperationsPageDeserializerTest extends TestCase {
   @Test
   public void testDeserialize() {
@@ -50,7 +52,7 @@ public class OperationsPageDeserializerTest extends TestCase {
 
     TransactionResponse transaction = createAccountOperation.getTransaction().get();
     assertEquals(transaction.getHash(), "749e4f8933221b9942ef38a02856803f379789ec8d971f1f60535db70135673e");
-    assertEquals(transaction.getLedger(), Long.valueOf(193));
+    assertEquals(transaction.getLedger(), valueOf(193));
     assertEquals(transaction.getMemo(), Memo.none());
   }
 
@@ -67,7 +69,7 @@ public class OperationsPageDeserializerTest extends TestCase {
     assertFalse(revokeOp.getSignerKey().isPresent());
     assertFalse(revokeOp.getTrustlineAccountId().isPresent());
     assertFalse(revokeOp.getTrustlineAsset().isPresent());
-    assertEquals(revokeOp.getOfferId().get(), "8822470");
+    assertEquals(revokeOp.getOfferId().get(), valueOf(8822470));
     assertEquals(revokeOp.getSourceAccount(), "GB6QDNU47MYBR4NDTRP7M3FW27DAFOEADN5KDQI2DAVWW6YVKKG4QJS7");
   }
 

--- a/src/test/java/org/stellar/sdk/responses/TradesPageDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/TradesPageDeserializerTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
 
+import static java.lang.Long.valueOf;
+
 public class TradesPageDeserializerTest extends TestCase {
     @Test
     public void testDeserialize() {
@@ -19,13 +21,13 @@ public class TradesPageDeserializerTest extends TestCase {
         assertEquals(tradesPage.getRecords().get(0).getId(), "3697472920621057-0");
         assertEquals(tradesPage.getRecords().get(0).getPagingToken(), "3697472920621057-0");
         assertEquals(tradesPage.getRecords().get(0).getLedgerCloseTime(), "2015-11-18T03:47:47Z");
-        assertEquals(tradesPage.getRecords().get(0).getOfferId(), "9");
-        assertEquals(tradesPage.getRecords().get(0).getBaseOfferId(), Optional.of("10"));
-        assertEquals(tradesPage.getRecords().get(0).getCounterOfferId(), Optional.of("11"));
+        assertEquals(tradesPage.getRecords().get(0).getOfferId(), valueOf(9));
+        assertEquals(tradesPage.getRecords().get(0).getBaseOfferId(), Optional.of(valueOf(10)));
+        assertEquals(tradesPage.getRecords().get(0).getCounterOfferId(), Optional.of(valueOf(11)));
         assertEquals(tradesPage.getRecords().get(0).getBaseAsset(), new AssetTypeNative());
         assertEquals(tradesPage.getRecords().get(0).getCounterAsset(), Asset.createNonNativeAsset("JPY", "GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM"));
-        assertEquals(tradesPage.getRecords().get(0).getPrice().getNumerator(), Long.valueOf(267));
-        assertEquals(tradesPage.getRecords().get(0).getPrice().getDenominator(), Long.valueOf(1000));
+        assertEquals(tradesPage.getRecords().get(0).getPrice().getNumerator(), valueOf(267));
+        assertEquals(tradesPage.getRecords().get(0).getPrice().getDenominator(), valueOf(1000));
 
         assertEquals(tradesPage.getRecords().get(1).getBaseAccount(), Optional.of("GAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472ZM7G"));
     }


### PR DESCRIPTION
Problem: some offer id values were modeled as string and others as integral longs in request and paired response objects. 

Fix: make the offer id consistently modeled as integral long type in request and response objects.

Note: to achieve the consistency, this introduces breaking changes on existing public classes - changed some existing method signatures for offer ids on request and response models to use long data type instead of string, details in CHANGELOG. Looking for feedback on the approach, if it's worth it or not.

Closes #307 