### PR TITLE
Use BigInteger for Muxed ID data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ### Breaking changes
 * Changed offer ids to be represented in requests and response models as long data type. ([#386](https://github.com/stellar/java-stellar-sdk/pull/386)).
-* Changed all *MuxedId* attributes to be of data type `java.math.BigInteger` in request and response models ([#386](https://github.com/stellar/java-stellar-sdk/pull/386)).
+* Changed all *MuxedId* attributes to be of data type `java.math.BigInteger` in request and response models ([#388](https://github.com/stellar/java-stellar-sdk/pull/388)).
 
 ## 0.29.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ### Breaking changes
 * Changed offer ids to be represented in requests and response models as long data type. ([#386](https://github.com/stellar/java-stellar-sdk/pull/386)).
-  * `TradesRequestBuilder.offerId()`
-  * `TradeResponse.getOfferId()` 
-  * `TradeResponse.getBaseOfferId()` 
-  * `TradeResponse.getCounterOfferId()` 
-  * `RevokeSponsorshipOperationResponse.getOfferId()`
+* Changed all *MuxedId* attributes to be of data type `java.math.BigInteger` in request and response models ([#386](https://github.com/stellar/java-stellar-sdk/pull/386)).
 
 ## 0.29.0
 

--- a/src/main/java/org/stellar/sdk/responses/MuxedAccount.java
+++ b/src/main/java/org/stellar/sdk/responses/MuxedAccount.java
@@ -2,12 +2,14 @@ package org.stellar.sdk.responses;
 
 import com.google.common.base.Objects;
 
+import java.math.BigInteger;
+
 public class MuxedAccount {
   private final String muxedAddress;
   private final String unmuxedAddress;
-  private final Long id;
+  private final BigInteger id;
 
-  public MuxedAccount(String muxedAddress, String unmuxedAddress, Long id) {
+  public MuxedAccount(String muxedAddress, String unmuxedAddress, BigInteger id) {
     this.muxedAddress = muxedAddress;
     this.unmuxedAddress = unmuxedAddress;
     this.id = id;
@@ -18,7 +20,7 @@ public class MuxedAccount {
     return muxedAddress;
   }
 
-  public Long getId() {
+  public BigInteger getId() {
     return id;
   }
 

--- a/src/main/java/org/stellar/sdk/responses/TransactionResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/TransactionResponse.java
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName;
 
 import org.stellar.sdk.Memo;
 
+import java.math.BigInteger;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -53,11 +54,11 @@ public class TransactionResponse extends Response implements Pageable {
   @SerializedName("account_muxed")
   private String accountMuxed;
   @SerializedName("account_muxed_id")
-  private Long accountMuxedId;
+  private BigInteger accountMuxedId;
   @SerializedName("fee_account_muxed")
   private String feeAccountMuxed;
   @SerializedName("fee_account_muxed_id")
-  private Long feeAccountMuxedId;
+  private BigInteger feeAccountMuxedId;
   @SerializedName("_links")
   private Links links;
 

--- a/src/main/java/org/stellar/sdk/responses/effects/EffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/EffectResponse.java
@@ -2,11 +2,12 @@ package org.stellar.sdk.responses.effects;
 
 import com.google.common.base.Optional;
 import com.google.gson.annotations.SerializedName;
-
 import org.stellar.sdk.responses.Link;
 import org.stellar.sdk.responses.MuxedAccount;
 import org.stellar.sdk.responses.Pageable;
 import org.stellar.sdk.responses.Response;
+
+import java.math.BigInteger;
 
 /**
  * Abstract class for effect responses.
@@ -22,7 +23,7 @@ public abstract class EffectResponse extends Response implements Pageable {
   @SerializedName("account_muxed")
   private String accountMuxed;
   @SerializedName("account_muxed_id")
-  private Long accountMuxedId;
+  private BigInteger accountMuxedId;
   @SerializedName("type")
   private String type;
   @SerializedName("created_at")

--- a/src/main/java/org/stellar/sdk/responses/effects/TradeEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TradeEffectResponse.java
@@ -7,6 +7,8 @@ import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
 import org.stellar.sdk.responses.MuxedAccount;
 
+import java.math.BigInteger;
+
 /**
  * Represents trade effect response.
  * @see <a href="https://developers.stellar.org/api/resources/effects/" target="_blank">Effect documentation</a>
@@ -19,7 +21,7 @@ public class TradeEffectResponse extends EffectResponse {
   @SerializedName("seller_muxed")
   private String sellerMuxed;
   @SerializedName("seller_muxed_id")
-  private Long sellerMuxedId;
+  private BigInteger sellerMuxedId;
 
   @SerializedName("offer_id")
   private Long offerId;

--- a/src/main/java/org/stellar/sdk/responses/operations/AccountMergeOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/AccountMergeOperationResponse.java
@@ -4,6 +4,8 @@ import com.google.common.base.Optional;
 import com.google.gson.annotations.SerializedName;
 import org.stellar.sdk.responses.MuxedAccount;
 
+import java.math.BigInteger;
+
 /**
  * Represents AccountMerge operation response.
  * @see <a href="https://developers.stellar.org/api/resources/operations/" target="_blank">Operation documentation</a>
@@ -16,14 +18,14 @@ public class AccountMergeOperationResponse extends OperationResponse {
   @SerializedName("account_muxed")
   private String accountMuxed;
   @SerializedName("account_muxed_id")
-  private Long accountMuxedId;
+  private BigInteger accountMuxedId;
 
   @SerializedName("into")
   private String into;
   @SerializedName("into_muxed")
   private String intoMuxed;
   @SerializedName("into_muxed_id")
-  private Long intoMuxedId;
+  private BigInteger intoMuxedId;
 
   public Optional<MuxedAccount> getAccountMuxed() {
     if (this.accountMuxed == null || this.accountMuxed.isEmpty()) {

--- a/src/main/java/org/stellar/sdk/responses/operations/AllowTrustOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/AllowTrustOperationResponse.java
@@ -7,6 +7,8 @@ import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
 import org.stellar.sdk.responses.MuxedAccount;
 
+import java.math.BigInteger;
+
 /**
  * @deprecated As of release 0.24.0, replaced by {@link SetTrustLineFlagsOperationResponse}
  *
@@ -23,7 +25,7 @@ public class AllowTrustOperationResponse extends OperationResponse {
   @SerializedName("trustee_muxed")
   private String trusteeMuxed;
   @SerializedName("trustee_muxed_id")
-  private Long trusteeMuxedId;
+  private BigInteger trusteeMuxedId;
   @SerializedName("asset_type")
   private String assetType;
   @SerializedName("asset_code")

--- a/src/main/java/org/stellar/sdk/responses/operations/ChangeTrustOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/ChangeTrustOperationResponse.java
@@ -5,6 +5,8 @@ import com.google.gson.annotations.SerializedName;
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.responses.MuxedAccount;
 
+import java.math.BigInteger;
+
 /**
  * Represents ChangeTrust operation response.
  * @see <a href="https://developers.stellar.org/api/resources/operations/" target="_blank">Operation documentation</a>
@@ -17,7 +19,7 @@ public class ChangeTrustOperationResponse extends OperationResponse {
   @SerializedName("trustor_muxed")
   private String trustorMuxed;
   @SerializedName("trustor_muxed_id")
-  private Long trustorMuxedId;
+  private BigInteger trustorMuxedId;
   @SerializedName("trustee")
   private String trustee;
   @SerializedName("asset_type")

--- a/src/main/java/org/stellar/sdk/responses/operations/ClaimClaimableBalanceOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/ClaimClaimableBalanceOperationResponse.java
@@ -4,6 +4,8 @@ import com.google.common.base.Optional;
 import com.google.gson.annotations.SerializedName;
 import org.stellar.sdk.responses.MuxedAccount;
 
+import java.math.BigInteger;
+
 /**
  * Represents ClaimClaimableBalance operation response.
  * @see org.stellar.sdk.requests.OperationsRequestBuilder
@@ -17,7 +19,7 @@ public class ClaimClaimableBalanceOperationResponse extends OperationResponse {
   @SerializedName("claimant_muxed")
   private String claimantMuxed;
   @SerializedName("claimant_muxed_id")
-  private Long claimantMuxedId;
+  private BigInteger claimantMuxedId;
 
   public Optional<MuxedAccount> getClaimantMuxed() {
     if (this.claimantMuxed == null || this.claimantMuxed.isEmpty()) {

--- a/src/main/java/org/stellar/sdk/responses/operations/ClawbackOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/ClawbackOperationResponse.java
@@ -5,6 +5,8 @@ import com.google.gson.annotations.SerializedName;
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.responses.MuxedAccount;
 
+import java.math.BigInteger;
+
 /**
  * Represents a Clawback operation response.
  *
@@ -25,7 +27,7 @@ public class ClawbackOperationResponse extends OperationResponse {
   @SerializedName("from_muxed")
   private String fromMuxed;
   @SerializedName("from_muxed_id")
-  private Long fromMuxedId;
+  private BigInteger fromMuxedId;
 
   public String getAssetType() {
     return assetType;

--- a/src/main/java/org/stellar/sdk/responses/operations/CreateAccountOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/CreateAccountOperationResponse.java
@@ -4,6 +4,8 @@ import com.google.common.base.Optional;
 import com.google.gson.annotations.SerializedName;
 import org.stellar.sdk.responses.MuxedAccount;
 
+import java.math.BigInteger;
+
 /**
  * Represents CreateAccount operation response.
  * @see <a href="https://developers.stellar.org/api/resources/operations/" target="_blank">Operation documentation</a>
@@ -18,7 +20,7 @@ public class CreateAccountOperationResponse extends OperationResponse {
   @SerializedName("funder_muxed")
   private String funderAccountMuxed;
   @SerializedName("funder_muxed_id")
-  private Long funderAccountMuxedId;
+  private BigInteger funderAccountMuxedId;
   @SerializedName("starting_balance")
   private String startingBalance;
 

--- a/src/main/java/org/stellar/sdk/responses/operations/EndSponsoringFutureReservesOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/EndSponsoringFutureReservesOperationResponse.java
@@ -4,6 +4,8 @@ import com.google.common.base.Optional;
 import com.google.gson.annotations.SerializedName;
 import org.stellar.sdk.responses.MuxedAccount;
 
+import java.math.BigInteger;
+
 /**
  * Represents EndSponsoringFutureReserves operation response.
  * @see org.stellar.sdk.requests.OperationsRequestBuilder
@@ -15,7 +17,7 @@ public class EndSponsoringFutureReservesOperationResponse extends OperationRespo
   @SerializedName("begin_sponsor_muxed")
   private String beginSponsorMuxed;
   @SerializedName("begin_sponsor_muxed_id")
-  private Long beginSponsorMuxedId;
+  private BigInteger beginSponsorMuxedId;
 
   public Optional<MuxedAccount> getBeginSponsorMuxed() {
     if (this.beginSponsorMuxed == null || this.beginSponsorMuxed.isEmpty()) {

--- a/src/main/java/org/stellar/sdk/responses/operations/OperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/OperationResponse.java
@@ -5,6 +5,8 @@ import com.google.gson.annotations.SerializedName;
 
 import org.stellar.sdk.responses.*;
 
+import java.math.BigInteger;
+
 /**
  * Abstract class for operation responses.
  * @see <a href="https://developers.stellar.org/api/resources/operations/" target="_blank">Operation documentation</a>
@@ -19,7 +21,7 @@ public abstract class OperationResponse extends Response implements Pageable {
   @SerializedName("source_account_muxed")
   private String sourceAccountMuxed;
   @SerializedName("source_account_muxed_id")
-  private Long sourceAccountMuxedId;
+  private BigInteger sourceAccountMuxedId;
   @SerializedName("paging_token")
   private String pagingToken;
   @SerializedName("created_at")

--- a/src/main/java/org/stellar/sdk/responses/operations/PathPaymentBaseOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/PathPaymentBaseOperationResponse.java
@@ -7,6 +7,7 @@ import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
 import org.stellar.sdk.responses.MuxedAccount;
 
+import java.math.BigInteger;
 import java.util.List;
 
 public abstract class PathPaymentBaseOperationResponse extends OperationResponse {
@@ -19,13 +20,13 @@ public abstract class PathPaymentBaseOperationResponse extends OperationResponse
   @SerializedName("from_muxed")
   private String fromMuxed;
   @SerializedName("from_muxed_id")
-  private Long fromMuxedId;
+  private BigInteger fromMuxedId;
   @SerializedName("to")
   private String to;
   @SerializedName("to_muxed")
   private String toMuxed;
   @SerializedName("to_muxed_id")
-  private Long toMuxedId;
+  private BigInteger toMuxedId;
 
   @SerializedName("asset_type")
   private String assetType;

--- a/src/test/java/org/stellar/sdk/responses/EffectsPageDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/EffectsPageDeserializerTest.java
@@ -10,6 +10,10 @@ import org.stellar.sdk.responses.effects.EffectResponse;
 import org.stellar.sdk.responses.effects.SignerCreatedEffectResponse;
 import org.stellar.sdk.responses.effects.TradeEffectResponse;
 
+import java.math.BigInteger;
+
+import static java.math.BigInteger.valueOf;
+
 public class EffectsPageDeserializerTest extends TestCase {
   @Test
   public void testDeserialize() {
@@ -36,7 +40,7 @@ public class EffectsPageDeserializerTest extends TestCase {
     assertEquals(first.getAccountMuxed().get(), new MuxedAccount(
       "MBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA6AAAAAAAAAAAPN7BA",
       "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
-      123l
+      new BigInteger("18446744073709551615")
     ));
     assertFalse(second.getAccountMuxed().isPresent());
 
@@ -291,7 +295,7 @@ public class EffectsPageDeserializerTest extends TestCase {
       "        \"paging_token\": \"3697472920621057-1\",\n" +
       "        \"account\": \"GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L\",\n" +
       "        \"account_muxed\": \"MBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA6AAAAAAAAAAAPN7BA\",\n" +
-      "        \"account_muxed_id\": \"123\",\n" +
+      "        \"account_muxed_id\": \"18446744073709551615\",\n" +
       "        \"type\": \"trade\",\n" +
       "        \"type_i\": 33,\n" +
       "        \"created_at\": \"2015-11-18T03:47:47Z\",\n" +

--- a/src/test/java/org/stellar/sdk/responses/OperationDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/OperationDeserializerTest.java
@@ -3,13 +3,14 @@ package org.stellar.sdk.responses;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import junit.framework.TestCase;
-
-import org.stellar.sdk.*;
-
 import org.junit.Test;
+import org.stellar.sdk.*;
 import org.stellar.sdk.responses.operations.*;
 
+import java.math.BigInteger;
 import java.util.Arrays;
+
+import static java.math.BigInteger.valueOf;
 
 public class OperationDeserializerTest extends TestCase {
   @Test
@@ -46,7 +47,7 @@ public class OperationDeserializerTest extends TestCase {
 
     assertEquals(operation.getSourceAccount(), "GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD");
     assertEquals(operation.getPagingToken(), "3936840037961729");
-    assertEquals(operation.getId(), new Long(3936840037961729L));
+    assertEquals(operation.getId().longValue(), 3936840037961729L);
     assertNull(operation.isTransactionSuccessful());
     assertFalse(operation.getFunderMuxed().isPresent());
 
@@ -85,7 +86,7 @@ public class OperationDeserializerTest extends TestCase {
         "  \"account\": \"GAR4DDXYNSN2CORG3XQFLAPWYKTUMLZYHYWV4Y2YJJ4JO6ZJFXMJD7PT\",\n" +
         "  \"funder\": \"GAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472ZM7G\",\n" +
         "  \"funder_muxed\": \"MAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472YAAAAAAAAAABUSON4\",\n" +
-        "  \"funder_muxed_id\": \"420\",\n" +
+        "  \"funder_muxed_id\": \"18446744073709551615\",\n" +
         "  \"id\": 3936840037961729,\n" +
         "  \"paging_token\": \"3936840037961729\",\n" +
         "  \"source_account\": \"GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L\",\n" +
@@ -102,13 +103,13 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getSourceAccountMuxed().get(), new MuxedAccount(
         "MBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA6AAAAAAAAAAAPN7BA",
         "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
-        123l
+            valueOf(123l)
     ));
 
     assertEquals(operation.getFunder(), "GAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472ZM7G");
     assertEquals(operation.getFunderMuxed().get().getUnmuxedAddress(), "GAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472ZM7G");
     assertEquals(operation.getFunderMuxed().get().toString(), "MAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472YAAAAAAAAAABUSON4");
-    assertEquals(operation.getFunderMuxed().get().getId().longValue(), 420l);
+    assertEquals(operation.getFunderMuxed().get().getId(), new BigInteger("18446744073709551615"));
   }
 
   @Test
@@ -146,8 +147,8 @@ public class OperationDeserializerTest extends TestCase {
     PaymentOperationResponse operation = (PaymentOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
     assertEquals(operation.getSourceAccount(), "GB6NVEN5HSUBKMYCE5ZOWSK5K23TBWRUQLZY3KNMXUZ3AQ2ESC4MY4AQ");
-    assertEquals(operation.getId(), new Long(3940808587743233L));
-    assertEquals(operation.isTransactionSuccessful(), new Boolean(false));
+    assertEquals(operation.getId().longValue(), 3940808587743233L);
+    assertEquals(operation.isTransactionSuccessful().booleanValue(), false);
 
     assertEquals(operation.getFrom(), "GB6NVEN5HSUBKMYCE5ZOWSK5K23TBWRUQLZY3KNMXUZ3AQ2ESC4MY4AQ");
     assertEquals(operation.getTo(), "GDWNY2POLGK65VVKIH5KQSH7VWLKRTQ5M6ADLJAYC2UEHEBEARCZJWWI");
@@ -191,7 +192,7 @@ public class OperationDeserializerTest extends TestCase {
 
     PaymentOperationResponse operation = (PaymentOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.isTransactionSuccessful(), new Boolean(true));
+    assertEquals(operation.isTransactionSuccessful().booleanValue(),true);
 
     assertEquals(operation.getFrom(), "GAZN3PPIDQCSP5JD4ETQQQ2IU2RMFYQTAL4NNQZUGLLO2XJJJ3RDSDGA");
     assertEquals(operation.getTo(), "GBHUSIZZ7FS2OMLZVZ4HLWJMXQ336NFSXHYERD7GG54NRITDTEWWBBI6");
@@ -634,11 +635,11 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getAccountMuxed().get(), new MuxedAccount(
         "MBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA6AAAAAAAAAAAPN7BA",
         "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
-        123l
+        valueOf(123l)
     ));
     assertEquals(operation.getIntoMuxed().get().getUnmuxedAddress(), "GAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472ZM7G");
     assertEquals(operation.getIntoMuxed().get().toString(), "MAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472YAAAAAAAAAABUSON4");
-    assertEquals(operation.getIntoMuxed().get().getId().longValue(), 420l);
+    assertEquals(operation.getIntoMuxed().get().getId(), valueOf(420l));
   }
 
   @Test
@@ -844,13 +845,13 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getFromMuxed().get(), new MuxedAccount(
         "MBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA6AAAAAAAAAAAPN7BA",
         "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
-        123l
+        valueOf(123l)
     ));
 
     assertEquals(operation.getTo(), "GAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472ZM7G");
     assertEquals(operation.getToMuxed().get().getUnmuxedAddress(), "GAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472ZM7G");
     assertEquals(operation.getToMuxed().get().toString(), "MAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472YAAAAAAAAAABUSON4");
-    assertEquals(operation.getToMuxed().get().getId().longValue(), 420l);
+    assertEquals(operation.getToMuxed().get().getId(), valueOf(420l));
   }
 
   @Test
@@ -931,7 +932,7 @@ public class OperationDeserializerTest extends TestCase {
 
     InflationOperationResponse operation = (InflationOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.getId(), new Long(12884914177L));
+    assertEquals(operation.getId().longValue(), 12884914177L);
   }
 
   @Test
@@ -965,7 +966,7 @@ public class OperationDeserializerTest extends TestCase {
 
     ManageDataOperationResponse operation = (ManageDataOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.getId(), new Long(14336188517191688L));
+    assertEquals(operation.getId().longValue(), 14336188517191688L);
     assertEquals(operation.getName(), "CollateralValue");
     assertEquals(operation.getValue(), "MjAwMA==");
   }
@@ -1034,8 +1035,8 @@ public class OperationDeserializerTest extends TestCase {
 
     BumpSequenceOperationResponse operation = (BumpSequenceOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.getId(), new Long(12884914177L));
-    assertEquals(operation.getBumpTo(), new Long(79473726952833048L));
+    assertEquals(operation.getId().longValue(), 12884914177L);
+    assertEquals(operation.getBumpTo().longValue(), 79473726952833048L);
   }
 
   @Test
@@ -1068,7 +1069,7 @@ public class OperationDeserializerTest extends TestCase {
 
     EndSponsoringFutureReservesOperationResponse operation = (EndSponsoringFutureReservesOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.getId(), new Long(12884914177L));
+    assertEquals(operation.getId().longValue(), 12884914177L);
     assertEquals(operation.getBeginSponsor(), "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD");
     assertFalse(operation.getBeginSponsorMuxed().isPresent());
     assertEquals(operation.getType(), "end_sponsoring_future_reserves");
@@ -1106,7 +1107,7 @@ public class OperationDeserializerTest extends TestCase {
 
     EndSponsoringFutureReservesOperationResponse operation = (EndSponsoringFutureReservesOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.getId(), new Long(12884914177L));
+    assertEquals(operation.getId().longValue(), 12884914177L);
     assertEquals(operation.getBeginSponsor(), "GAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472ZM7G");
     assertEquals(operation.getBeginSponsorMuxed().get().toString(), "MAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472YAAAAAAAAAABUSON4");
     assertEquals(operation.getBeginSponsorMuxed().get().getId().longValue(), 420l);
@@ -1144,7 +1145,7 @@ public class OperationDeserializerTest extends TestCase {
 
     ClaimClaimableBalanceOperationResponse operation = (ClaimClaimableBalanceOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.getId(), new Long(12884914177L));
+    assertEquals(operation.getId().longValue(), 12884914177L);
     assertEquals(operation.getBalanceId(), "00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9");
     assertEquals(operation.getClaimant(), "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD");
     assertFalse(operation.getClaimantMuxed().isPresent());
@@ -1184,13 +1185,13 @@ public class OperationDeserializerTest extends TestCase {
 
     ClaimClaimableBalanceOperationResponse operation = (ClaimClaimableBalanceOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.getId(), new Long(12884914177L));
+    assertEquals(operation.getId().longValue(), 12884914177L);
     assertEquals(operation.getBalanceId(), "00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9");
     assertEquals(operation.getClaimant(), "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L");
     assertEquals(operation.getClaimantMuxed().get(), new MuxedAccount(
         "MBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA6AAAAAAAAAAAPN7BA",
         "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
-        123l
+        valueOf(123l)
     ));
     assertEquals(operation.getType(), "claim_claimable_balance");
   }
@@ -1226,7 +1227,7 @@ public class OperationDeserializerTest extends TestCase {
 
     ClawbackClaimableBalanceOperationResponse operation = (ClawbackClaimableBalanceOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.getId(), new Long(12884914177L));
+    assertEquals(operation.getId().longValue(), 12884914177L);
     assertEquals(operation.getBalanceId(), "00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9");
     assertEquals(operation.getType(), "clawback_claimable_balance");
   }
@@ -1264,7 +1265,7 @@ public class OperationDeserializerTest extends TestCase {
 
     ClawbackOperationResponse operation = (ClawbackOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.getId(), new Long(12884914177L));
+    assertEquals(operation.getId().longValue(), 12884914177L);
     assertEquals(operation.getFrom(), "GDPFGP4IPE5DXG6XRXC4ZBUI43PAGRQ5VVNJ3LJTBXDBZ4ITO6HBHNSF");
     assertEquals(operation.getType(), "clawback");
     assertEquals(operation.getAsset(), Asset.createNonNativeAsset("EUR", "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS"));
@@ -1313,7 +1314,7 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getFromMuxed().get(), new MuxedAccount(
         "MBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA6AAAAAAAAAAAPN7BA",
         "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
-        123l
+        valueOf(123l)
     ));
   }
 
@@ -1362,7 +1363,7 @@ public class OperationDeserializerTest extends TestCase {
 
     SetTrustLineFlagsOperationResponse operation = (SetTrustLineFlagsOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.getId(), new Long(12884914177L));
+    assertEquals(operation.getId().longValue(), 12884914177L);
     assertEquals(operation.getTrustor(), "GDPFGP4IPE5DXG6XRXC4ZBUI43PAGRQ5VVNJ3LJTBXDBZ4ITO6HBHNSF");
     assertEquals(operation.getType(), "set_trust_line_flags");
     assertEquals(operation.getAsset(), Asset.createNonNativeAsset("EUR", "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS"));
@@ -1439,7 +1440,7 @@ public class OperationDeserializerTest extends TestCase {
 
     LiquidityPoolDepositOperationResponse operation = (LiquidityPoolDepositOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.getId(), new Long(2278153733029889L));
+    assertEquals(operation.getId().longValue(), 2278153733029889L);
     assertEquals(operation.getType(), "liquidity_pool_deposit");
     assertEquals(operation.getSharesReceived(), "1367.4794331");
     assertEquals(operation.getLiquidityPoolId().toString(), "1df1380108ca32e96650074db1f3e1e10541ab8768c9eba7ec3b6f9315f9faee");
@@ -1511,7 +1512,7 @@ public class OperationDeserializerTest extends TestCase {
 
     LiquidityPoolWithdrawOperationResponse operation = (LiquidityPoolWithdrawOperationResponse) GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
-    assertEquals(operation.getId(), new Long(2313539968573441L));
+    assertEquals(operation.getId().longValue(), 2313539968573441L);
     assertEquals(operation.getType(), "liquidity_pool_withdraw");
     assertEquals(operation.getShares(), "1367.4794331");
     assertEquals(operation.getLiquidityPoolId().toString(), "1df1380108ca32e96650074db1f3e1e10541ab8768c9eba7ec3b6f9315f9faee");

--- a/src/test/java/org/stellar/sdk/responses/TransactionDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/TransactionDeserializerTest.java
@@ -3,10 +3,11 @@ package org.stellar.sdk.responses;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import junit.framework.TestCase;
-
 import org.junit.Test;
 import org.stellar.sdk.MemoHash;
 import org.stellar.sdk.MemoNone;
+
+import static java.math.BigInteger.valueOf;
 
 public class TransactionDeserializerTest extends TestCase {
   @Test
@@ -76,18 +77,18 @@ public class TransactionDeserializerTest extends TestCase {
     assertEquals(transaction.getSourceAccountMuxed().get(), new MuxedAccount(
         "MBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA6AAAAAAAAAAAPN7BA",
         "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
-        123l
+        valueOf(123l)
     ));
     assertEquals(transaction.getFeeAccountMuxed().get().getUnmuxedAddress(), "GAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472ZM7G");
     assertEquals(transaction.getFeeAccountMuxed().get().toString(), "MAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472YAAAAAAAAAABUSON4");
-    assertEquals(transaction.getFeeAccountMuxed().get().getId().longValue(), 420l);
+    assertEquals(transaction.getFeeAccountMuxed().get().getId(), valueOf(420l));
   }
 
     @Test
   public void testDeserializeWithoutMemo() {
     TransactionResponse transaction = GsonSingleton.getInstance().fromJson(jsonMemoNone, TransactionResponse.class);
     assertTrue(transaction.getMemo() instanceof MemoNone);
-    assertEquals(transaction.isSuccessful(), new Boolean(false));
+    assertEquals(transaction.isSuccessful().booleanValue(), false);
   }
 
   String json = "{\n" +


### PR DESCRIPTION
Problem: the muxed id values from horizon API is a uint64, java was mapping these into `long` which is signed int64 data types which left possibility of overflow. 

Proposed Solution: to safely handle these muxed id values, use the BigInteger data type.

Closes: #384 