### PR TITLE
#396: streamlined Asset creation to be consistent for all asset types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
 ## Unreleased
+* Fixed NPE on TrustlineCreatedEffectResponse.getAsset() for liquidity pool asset type.
+  Consolidated Asset factory creation pattern, made consistent for all asset types including native, alpha4, alpha12, liquidity pool shares.
+  ([#398](https://github.com/stellar/java-stellar-sdk/pull/398)).
+
+### Breaking changes
+* org.stellar.sdk.Asset.createNonNativeAsset() is now private. ([#398](https://github.com/stellar/java-stellar-sdk/pull/398)).
+* org.stellar.sdk.responses.effects.TrustlineCUDResponse, removed non-default public constructor, it wasn't needed. ([#398](https://github.com/stellar/java-stellar-sdk/pull/398)).
 
 ## 0.30.0
 

--- a/src/main/java/org/stellar/sdk/ChangeTrustAsset.java
+++ b/src/main/java/org/stellar/sdk/ChangeTrustAsset.java
@@ -14,25 +14,53 @@ public abstract class ChangeTrustAsset implements Comparable<ChangeTrustAsset> {
    * The asset string is expected to either be "native" or a string of the form "CODE:ISSUER"
    *
    * @param canonicalForm Canonical string representation of an asset
+   * @return ChangeTrustAsset
    */
   public static ChangeTrustAsset create(String canonicalForm) {
     return new Wrapper(Asset.create(canonicalForm));
   }
 
+  /**
+   * Create ChangeTrustAsset from asset primitive values
+   *
+   * @param type the asset type
+   * @param code the asset code
+   * @param issuer the asset issuer
+   * @return ChangeTrustAsset
+   */
   public static ChangeTrustAsset create(String type, String code, String issuer) {
     return new Wrapper(Asset.create(type, code, issuer));
   }
+
+  /**
+   * Create ChangeTrustAsset from another Asset
+   *
+   * @param asset the Asset
+   * @return ChangeTrustAsset
+   */
   public static ChangeTrustAsset create(Asset asset) {
     return new Wrapper(asset);
   }
+
+  /**
+   * Create a ChangeTrustAsset from LiquidityPoolParameters
+   *
+   * @param params the LiquidityPoolParameters
+   * @return ChangeTrustAsset
+   */
   public static ChangeTrustAsset create(LiquidityPoolParameters params) {
     return new LiquidityPoolShareChangeTrustAsset(params);
   }
+
+  /**
+   * Create a ChangeTrustAsset from TrustLineAsset
+   *
+   * @param wrapper the TrustLineAsset wrapper
+   * @return ChangeTrustAsset
+   */
   public static ChangeTrustAsset create(TrustLineAsset.Wrapper wrapper) {
     return new Wrapper(wrapper.getAsset());
   }
-  // Cannot convert from LiquidityPoolShareTrustLineAsset, as that only has a
-  // liquidity pool id, not parameters.
 
   /**
    * Creates one of AssetTypeCreditAlphaNum4 or AssetTypeCreditAlphaNum12 object based on a <code>code</code> length
@@ -40,12 +68,14 @@ public abstract class ChangeTrustAsset implements Comparable<ChangeTrustAsset> {
    * @param issuer ChangeTrustAsset issuer
    */
   public static ChangeTrustAsset createNonNativeAsset(String code, String issuer) {
-    return ChangeTrustAsset.create(Asset.createNonNativeAsset(code, issuer));
+    return create(Asset.create(null, code, issuer));
   }
 
   /**
    * Generates ChangeTrustAsset object from a given XDR object
+   *
    * @param xdr XDR object
+   * @return    ChangeTrustAsset
    */
   public static ChangeTrustAsset fromXdr(org.stellar.sdk.xdr.ChangeTrustAsset xdr) {
     // TODO: Figure out how we can re-use Asset.fromXdr here
@@ -68,8 +98,6 @@ public abstract class ChangeTrustAsset implements Comparable<ChangeTrustAsset> {
     }
   }
 
-  public abstract String getType();
-
   @Override
   public abstract boolean equals(Object object);
 
@@ -77,7 +105,14 @@ public abstract class ChangeTrustAsset implements Comparable<ChangeTrustAsset> {
   public abstract int compareTo(ChangeTrustAsset other);
 
   /**
+   * Get the asset type
+   * @return the asset type
+   */
+  public abstract String getType();
+
+  /**
    * Generates XDR object from a given ChangeTrustAsset object
+   * @return xdr model
    */
   public abstract org.stellar.sdk.xdr.ChangeTrustAsset toXdr();
 

--- a/src/main/java/org/stellar/sdk/LiquidityPoolShareChangeTrustAsset.java
+++ b/src/main/java/org/stellar/sdk/LiquidityPoolShareChangeTrustAsset.java
@@ -1,10 +1,9 @@
 package org.stellar.sdk;
 
 import com.google.common.base.Objects;
+import org.stellar.sdk.xdr.AssetType;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-
-import org.stellar.sdk.xdr.*;
 
 /**
  * Class for LiquidityPoolShareChangeTrustAsset
@@ -13,15 +12,30 @@ import org.stellar.sdk.xdr.*;
 public final class LiquidityPoolShareChangeTrustAsset extends ChangeTrustAsset {
   protected final LiquidityPoolParameters mParams;
 
+  /**
+   * Constructor
+   *
+   * @param params the liquidity pool parameters
+   */
   public LiquidityPoolShareChangeTrustAsset(LiquidityPoolParameters params) {
     checkNotNull(params, "params cannot be null");
     mParams = params;
   }
 
+  /**
+   * Get the liquidity pool id
+   *
+   * @return LiquidityPoolID
+   */
   public LiquidityPoolID getLiquidityPoolID() {
     return mParams.getId();
   }
 
+  /**
+   * Get the liquidity pool parameters
+   *
+   * @return LiquidityPoolParameters
+   */
   public LiquidityPoolParameters getLiquidityPoolParams() {
     return mParams;
   }

--- a/src/main/java/org/stellar/sdk/LiquidityPoolShareTrustLineAsset.java
+++ b/src/main/java/org/stellar/sdk/LiquidityPoolShareTrustLineAsset.java
@@ -1,10 +1,9 @@
 package org.stellar.sdk;
 
 import com.google.common.base.Objects;
+import org.stellar.sdk.xdr.AssetType;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-
-import org.stellar.sdk.xdr.*;
 
 /**
  * Class for LiquidityPoolShareTrustLineAsset
@@ -13,16 +12,31 @@ import org.stellar.sdk.xdr.*;
 public final class LiquidityPoolShareTrustLineAsset extends TrustLineAsset {
   protected final LiquidityPoolID mId;
 
+  /**
+   * Constructor
+   *
+   * @param params the LiquidityPoolParameters
+   */
   public LiquidityPoolShareTrustLineAsset(LiquidityPoolParameters params) {
     checkNotNull(params, "params cannot be null");
     mId = params.getId();
   }
 
+  /**
+   * Constructor
+   *
+   * @param id the LiquidityPoolID
+   */
   public LiquidityPoolShareTrustLineAsset(LiquidityPoolID id) {
     checkNotNull(id, "id cannot be null");
     mId = id;
   }
 
+  /**
+   * Get the liquidity pool id
+   *
+   * @return LiquidityPoolID
+   */
   public LiquidityPoolID getLiquidityPoolID() {
     return mId;
   }

--- a/src/main/java/org/stellar/sdk/TrustLineAsset.java
+++ b/src/main/java/org/stellar/sdk/TrustLineAsset.java
@@ -19,32 +19,69 @@ public abstract class TrustLineAsset implements Comparable<TrustLineAsset> {
     return new Wrapper(Asset.create(canonicalForm));
   }
 
+  /**
+   * Parses type, code, issuer and returns the equivalent TrustLineAsset instance.
+   * @param type the asset type
+   * @param code the asset code
+   * @param issuer the assset issuer
+   * @return TrustLineAsset
+   */
   public static TrustLineAsset create(String type, String code, String issuer) {
     return new Wrapper(Asset.create(type, code, issuer));
   }
+
+  /**
+   * Converts Asset to TrustLineAsset
+   * @param asset the Asset
+   * @return TrustLineAsset
+   */
   public static TrustLineAsset create(Asset asset) {
     return new Wrapper(asset);
   }
+
+  /**
+   * Creates a TrustLineAsset from LiquidityPoolParameters
+   * @param params the LiquidityPoolParameters
+   * @return TrustLineAsset
+   */
   public static TrustLineAsset create(LiquidityPoolParameters params) {
     return new LiquidityPoolShareTrustLineAsset(params);
   }
+
+  /**
+   * Creates a TrustLineAsset from LiquidityPoolID
+   * @param id the LiquidityPoolID
+   * @return TrustLineAsset
+   */
   public static TrustLineAsset create(LiquidityPoolID id) {
     return new LiquidityPoolShareTrustLineAsset(id);
   }
+
+  /**
+   * Creates a TrustLineAsset from ChangeTrustAsset
+   * @param wrapper the ChangeTrustAsset wrapper
+   * @return TrustLineAsset
+   */
   public static TrustLineAsset create(ChangeTrustAsset.Wrapper wrapper) {
     return new Wrapper(wrapper.getAsset());
   }
+
+  /**
+   * Create TrustLineAsset from LiquidityPoolShareChangeTrustAsset
+   * @param share the LiquidityPoolShareChangeTrustAsset
+   * @return TrustLineAsset
+   */
   public static TrustLineAsset create(LiquidityPoolShareChangeTrustAsset share) {
     return new LiquidityPoolShareTrustLineAsset(share.getLiquidityPoolParams());
   }
 
   /**
-   * Creates one of AssetTypeCreditAlphaNum4 or AssetTypeCreditAlphaNum12 object based on a <code>code</code> length
-   * @param code TrustLineAsset code
-   * @param issuer TrustLineAsset issuer
+   * Creates TrustLineAsset based on a <code>code</code> length and issuer only
+   * @param code the TrustLineAsset code
+   * @param issuer the TrustLineAsset issuer
    */
   public static TrustLineAsset createNonNativeAsset(String code, String issuer) {
-    return TrustLineAsset.create(Asset.createNonNativeAsset(code, issuer));
+    return create(Asset.create(null, code, issuer));
   }
 
   /**
@@ -72,8 +109,6 @@ public abstract class TrustLineAsset implements Comparable<TrustLineAsset> {
     }
   }
 
-  public abstract String getType();
-
   @Override
   public abstract boolean equals(Object object);
 
@@ -81,7 +116,16 @@ public abstract class TrustLineAsset implements Comparable<TrustLineAsset> {
   public abstract int compareTo(TrustLineAsset other);
 
   /**
+   * Get the asset type
+   *
+   * @return the asset type
+   */
+  public abstract String getType();
+
+  /**
    * Generates XDR object from a given TrustLineAsset object
+   *
+   * @return xdr model
    */
   public abstract org.stellar.sdk.xdr.TrustLineAsset toXdr();
 

--- a/src/main/java/org/stellar/sdk/responses/AccountResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/AccountResponse.java
@@ -3,16 +3,14 @@ package org.stellar.sdk.responses;
 import com.google.common.base.Optional;
 import com.google.common.io.BaseEncoding;
 import com.google.gson.annotations.SerializedName;
-
 import org.stellar.sdk.Asset;
-import org.stellar.sdk.AssetTypeNative;
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.LiquidityPoolID;
-import org.stellar.sdk.TrustLineAsset;
 
 import java.util.HashMap;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.stellar.sdk.Asset.create;
 
 /**
  * Represents account response.
@@ -240,14 +238,7 @@ public class AccountResponse extends Response implements org.stellar.sdk.Transac
     }
 
     public Optional<Asset> getAsset() {
-      if (assetType.equals("native")) {
-        return Optional.of((Asset)new AssetTypeNative());
-      } else if (assetType.equals("liquidity_pool_shares")) {
-        // TODO: Decide if this is the right way to handle this...
-        return Optional.absent();
-      } else {
-        return Optional.of(Asset.createNonNativeAsset(assetCode, assetIssuer));
-      }
+      return Optional.of(create(assetType, assetCode, assetIssuer, liquidityPoolID.toString()));
     }
 
     public String getAssetType() {

--- a/src/main/java/org/stellar/sdk/responses/PathResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/PathResponse.java
@@ -1,11 +1,11 @@
 package org.stellar.sdk.responses;
 
 import com.google.gson.annotations.SerializedName;
-
 import org.stellar.sdk.Asset;
-import org.stellar.sdk.AssetTypeNative;
 
 import java.util.ArrayList;
+
+import static org.stellar.sdk.Asset.create;
 
 /**
  * Represents path response.
@@ -66,19 +66,11 @@ public class PathResponse extends Response {
   }
 
   public Asset getDestinationAsset() {
-    if (destinationAssetType.equals("native")) {
-      return new AssetTypeNative();
-    } else {
-      return Asset.createNonNativeAsset(destinationAssetCode, destinationAssetIssuer);
-    }
+    return create(destinationAssetType, destinationAssetCode, destinationAssetIssuer);
   }
 
   public Asset getSourceAsset() {
-    if (sourceAssetType.equals("native")) {
-      return new AssetTypeNative();
-    } else {
-      return Asset.createNonNativeAsset(sourceAssetCode, sourceAssetIssuer);
-    }
+    return create(sourceAssetType,sourceAssetCode, sourceAssetIssuer);
   }
 
   public Links getLinks() {

--- a/src/main/java/org/stellar/sdk/responses/effects/AccountCreditedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/AccountCreditedEffectResponse.java
@@ -1,9 +1,9 @@
 package org.stellar.sdk.responses.effects;
 
 import com.google.gson.annotations.SerializedName;
-
 import org.stellar.sdk.Asset;
-import org.stellar.sdk.AssetTypeNative;
+
+import static org.stellar.sdk.Asset.create;
 
 
 /**
@@ -34,10 +34,6 @@ public class AccountCreditedEffectResponse extends EffectResponse {
   }
 
   public Asset getAsset() {
-    if (assetType.equals("native")) {
-      return new AssetTypeNative();
-    } else {
-      return Asset.createNonNativeAsset(assetCode, assetIssuer);
-    }
+      return create(assetType, assetCode, assetIssuer);
   }
 }

--- a/src/main/java/org/stellar/sdk/responses/effects/AccountDebitedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/AccountDebitedEffectResponse.java
@@ -1,9 +1,9 @@
 package org.stellar.sdk.responses.effects;
 
 import com.google.gson.annotations.SerializedName;
-
 import org.stellar.sdk.Asset;
-import org.stellar.sdk.AssetTypeNative;
+
+import static org.stellar.sdk.Asset.create;
 
 /**
  * Represents account_debited effect response.
@@ -33,10 +33,6 @@ public class AccountDebitedEffectResponse extends EffectResponse {
   }
 
   public Asset getAsset() {
-    if (assetType.equals("native")) {
-      return new AssetTypeNative();
-    } else {
-      return Asset.createNonNativeAsset(assetCode, assetIssuer);
-    }
+    return create(assetType, assetCode, assetIssuer);
   }
 }

--- a/src/main/java/org/stellar/sdk/responses/effects/TradeEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TradeEffectResponse.java
@@ -2,12 +2,12 @@ package org.stellar.sdk.responses.effects;
 
 import com.google.common.base.Optional;
 import com.google.gson.annotations.SerializedName;
-
 import org.stellar.sdk.Asset;
-import org.stellar.sdk.AssetTypeNative;
 import org.stellar.sdk.responses.MuxedAccount;
 
 import java.math.BigInteger;
+
+import static org.stellar.sdk.Asset.create;
 
 /**
  * Represents trade effect response.
@@ -68,18 +68,10 @@ public class TradeEffectResponse extends EffectResponse {
   }
 
   public Asset getSoldAsset() {
-    if (soldAssetType.equals("native")) {
-      return new AssetTypeNative();
-    } else {
-      return Asset.createNonNativeAsset(soldAssetCode, soldAssetIssuer);
-    }
+    return create(soldAssetType, soldAssetCode, soldAssetIssuer);
   }
 
   public Asset getBoughtAsset() {
-    if (boughtAssetType.equals("native")) {
-      return new AssetTypeNative();
-    } else {
-      return Asset.createNonNativeAsset(boughtAssetCode, boughtAssetIssuer);
-    }
+    return create(boughtAssetType, boughtAssetCode, boughtAssetIssuer);
   }
 }

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineCUDResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineCUDResponse.java
@@ -18,14 +18,6 @@ abstract class TrustlineCUDResponse extends EffectResponse {
   @SerializedName("liquidity_pool_id")
   private String liquidityPoolId;
 
-  public TrustlineCUDResponse(String limit, String assetType, String assetCode, String assetIssuer, String liquidityPoolId) {
-    this.limit = limit;
-    this.assetType = assetType;
-    this.assetCode = assetCode;
-    this.assetIssuer = assetIssuer;
-    this.liquidityPoolId = liquidityPoolId;
-  }
-
   public String getLimit() {
     return limit;
   }

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineCUDResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineCUDResponse.java
@@ -1,25 +1,29 @@
 package org.stellar.sdk.responses.effects;
 
 import com.google.gson.annotations.SerializedName;
-
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
 
+import static org.stellar.sdk.Asset.create;
+
 abstract class TrustlineCUDResponse extends EffectResponse {
   @SerializedName("limit")
-  protected final String limit;
+  private String limit;
   @SerializedName("asset_type")
-  protected final String assetType;
+  private String assetType;
   @SerializedName("asset_code")
-  protected final String assetCode;
+  private String assetCode;
   @SerializedName("asset_issuer")
-  protected final String assetIssuer;
+  private String assetIssuer;
+  @SerializedName("liquidity_pool_id")
+  private String liquidityPoolId;
 
-  public TrustlineCUDResponse(String limit, String assetType, String assetCode, String assetIssuer) {
+  public TrustlineCUDResponse(String limit, String assetType, String assetCode, String assetIssuer, String liquidityPoolId) {
     this.limit = limit;
     this.assetType = assetType;
     this.assetCode = assetCode;
     this.assetIssuer = assetIssuer;
+    this.liquidityPoolId = liquidityPoolId;
   }
 
   public String getLimit() {
@@ -30,7 +34,7 @@ abstract class TrustlineCUDResponse extends EffectResponse {
     if (assetType.equals("native")) {
       return new AssetTypeNative();
     } else {
-      return Asset.createNonNativeAsset(assetCode, assetIssuer);
+      return create(assetType, assetCode, assetIssuer, liquidityPoolId);
     }
   }
 }

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineCreatedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineCreatedEffectResponse.java
@@ -7,7 +7,7 @@ package org.stellar.sdk.responses.effects;
  * @see org.stellar.sdk.Server#effects()
  */
 public class TrustlineCreatedEffectResponse extends TrustlineCUDResponse {
-  TrustlineCreatedEffectResponse(String limit, String assetType, String assetCode, String assetIssuer) {
-    super(limit, assetType, assetCode, assetIssuer);
+  TrustlineCreatedEffectResponse(String limit, String assetType, String assetCode, String assetIssuer, String liquidityPoolId) {
+    super(limit, assetType, assetCode, assetIssuer, liquidityPoolId);
   }
 }

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineCreatedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineCreatedEffectResponse.java
@@ -6,8 +6,4 @@ package org.stellar.sdk.responses.effects;
  * @see org.stellar.sdk.requests.EffectsRequestBuilder
  * @see org.stellar.sdk.Server#effects()
  */
-public class TrustlineCreatedEffectResponse extends TrustlineCUDResponse {
-  TrustlineCreatedEffectResponse(String limit, String assetType, String assetCode, String assetIssuer, String liquidityPoolId) {
-    super(limit, assetType, assetCode, assetIssuer, liquidityPoolId);
-  }
-}
+public class TrustlineCreatedEffectResponse extends TrustlineCUDResponse { }

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineFlagsUpdatedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineFlagsUpdatedEffectResponse.java
@@ -3,6 +3,8 @@ package org.stellar.sdk.responses.effects;
 import com.google.gson.annotations.SerializedName;
 import org.stellar.sdk.Asset;
 
+import static org.stellar.sdk.Asset.create;
+
 /**
  * Represents trustline_flags_updated effect response.
  *
@@ -55,7 +57,7 @@ public class TrustlineFlagsUpdatedEffectResponse extends EffectResponse {
   }
 
   public Asset getAsset() {
-    return Asset.createNonNativeAsset(assetCode, assetIssuer);
+    return create(assetType, assetCode, assetIssuer);
   }
 
   public boolean getAuthorized() {

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineRemovedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineRemovedEffectResponse.java
@@ -6,8 +6,4 @@ package org.stellar.sdk.responses.effects;
  * @see org.stellar.sdk.requests.EffectsRequestBuilder
  * @see org.stellar.sdk.Server#effects()
  */
-public class TrustlineRemovedEffectResponse extends TrustlineCUDResponse {
-  TrustlineRemovedEffectResponse(String limit, String assetType, String assetCode, String assetIssuer, String liquidityPoolId) {
-    super(limit, assetType, assetCode, assetIssuer, liquidityPoolId);
-  }
-}
+public class TrustlineRemovedEffectResponse extends TrustlineCUDResponse { }

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineRemovedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineRemovedEffectResponse.java
@@ -7,7 +7,7 @@ package org.stellar.sdk.responses.effects;
  * @see org.stellar.sdk.Server#effects()
  */
 public class TrustlineRemovedEffectResponse extends TrustlineCUDResponse {
-  TrustlineRemovedEffectResponse(String limit, String assetType, String assetCode, String assetIssuer) {
-    super(limit, assetType, assetCode, assetIssuer);
+  TrustlineRemovedEffectResponse(String limit, String assetType, String assetCode, String assetIssuer, String liquidityPoolId) {
+    super(limit, assetType, assetCode, assetIssuer, liquidityPoolId);
   }
 }

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineUpdatedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineUpdatedEffectResponse.java
@@ -6,8 +6,4 @@ package org.stellar.sdk.responses.effects;
  * @see org.stellar.sdk.requests.EffectsRequestBuilder
  * @see org.stellar.sdk.Server#effects()
  */
-public class TrustlineUpdatedEffectResponse extends TrustlineCUDResponse {
-  TrustlineUpdatedEffectResponse(String limit, String assetType, String assetCode, String assetIssuer, String liquidityPoolId) {
-    super(limit, assetType, assetCode, assetIssuer, liquidityPoolId);
-  }
-}
+public class TrustlineUpdatedEffectResponse extends TrustlineCUDResponse { }

--- a/src/main/java/org/stellar/sdk/responses/effects/TrustlineUpdatedEffectResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/effects/TrustlineUpdatedEffectResponse.java
@@ -7,7 +7,7 @@ package org.stellar.sdk.responses.effects;
  * @see org.stellar.sdk.Server#effects()
  */
 public class TrustlineUpdatedEffectResponse extends TrustlineCUDResponse {
-  TrustlineUpdatedEffectResponse(String limit, String assetType, String assetCode, String assetIssuer) {
-    super(limit, assetType, assetCode, assetIssuer);
+  TrustlineUpdatedEffectResponse(String limit, String assetType, String assetCode, String assetIssuer, String liquidityPoolId) {
+    super(limit, assetType, assetCode, assetIssuer, liquidityPoolId);
   }
 }

--- a/src/main/java/org/stellar/sdk/responses/operations/AllowTrustOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/AllowTrustOperationResponse.java
@@ -2,12 +2,13 @@ package org.stellar.sdk.responses.operations;
 
 import com.google.common.base.Optional;
 import com.google.gson.annotations.SerializedName;
-
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
 import org.stellar.sdk.responses.MuxedAccount;
 
 import java.math.BigInteger;
+
+import static org.stellar.sdk.Asset.create;
 
 /**
  * @deprecated As of release 0.24.0, replaced by {@link SetTrustLineFlagsOperationResponse}
@@ -65,7 +66,7 @@ public class AllowTrustOperationResponse extends OperationResponse {
     if (assetType.equals("native")) {
       return new AssetTypeNative();
     } else {
-      return Asset.createNonNativeAsset(assetCode, assetIssuer);
+      return create(assetType, assetCode, assetIssuer);
     }
   }
 }

--- a/src/main/java/org/stellar/sdk/responses/operations/ChangeTrustOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/ChangeTrustOperationResponse.java
@@ -7,6 +7,8 @@ import org.stellar.sdk.responses.MuxedAccount;
 
 import java.math.BigInteger;
 
+import static org.stellar.sdk.Asset.create;
+
 /**
  * Represents ChangeTrust operation response.
  * @see <a href="https://developers.stellar.org/api/resources/operations/" target="_blank">Operation documentation</a>
@@ -53,7 +55,7 @@ public class ChangeTrustOperationResponse extends OperationResponse {
   }
 
   public Asset getAsset() {
-    return Asset.create(assetType, assetCode, assetIssuer, liquidityPoolId);
+    return create(assetType, assetCode, assetIssuer, liquidityPoolId);
   }
 
 }

--- a/src/main/java/org/stellar/sdk/responses/operations/ClawbackOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/ClawbackOperationResponse.java
@@ -7,6 +7,8 @@ import org.stellar.sdk.responses.MuxedAccount;
 
 import java.math.BigInteger;
 
+import static org.stellar.sdk.Asset.create;
+
 /**
  * Represents a Clawback operation response.
  *
@@ -42,7 +44,7 @@ public class ClawbackOperationResponse extends OperationResponse {
   }
 
   public Asset getAsset() {
-    return Asset.createNonNativeAsset(assetCode, assetIssuer);
+    return create(assetType, assetCode, assetIssuer);
   }
 
   public String getAmount() {

--- a/src/main/java/org/stellar/sdk/responses/operations/CreatePassiveSellOfferOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/CreatePassiveSellOfferOperationResponse.java
@@ -1,9 +1,10 @@
 package org.stellar.sdk.responses.operations;
 
 import com.google.gson.annotations.SerializedName;
-
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
+
+import static org.stellar.sdk.Asset.create;
 
 /**
  * Represents CreatePassiveSellOffer operation response.
@@ -63,7 +64,7 @@ public class CreatePassiveSellOfferOperationResponse extends OperationResponse {
     if (buyingAssetType.equals("native")) {
       return new AssetTypeNative();
     } else {
-      return Asset.createNonNativeAsset(buyingAssetCode, buyingAssetIssuer);
+      return create(buyingAssetType, buyingAssetCode, buyingAssetIssuer);
     }
   }
 
@@ -71,7 +72,7 @@ public class CreatePassiveSellOfferOperationResponse extends OperationResponse {
     if (sellingAssetType.equals("native")) {
       return new AssetTypeNative();
     } else {
-      return Asset.createNonNativeAsset(sellingAssetCode, sellingAssetIssuer);
+      return create(sellingAssetType, sellingAssetCode, sellingAssetIssuer);
     }
   }
 }

--- a/src/main/java/org/stellar/sdk/responses/operations/ManageBuyOfferOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/ManageBuyOfferOperationResponse.java
@@ -4,6 +4,8 @@ import com.google.gson.annotations.SerializedName;
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
 
+import static org.stellar.sdk.Asset.create;
+
 /**
  * Represents ManageBuyOffer operation response.
  * @see <a href="https://developers.stellar.org/api/resources/operations/" target="_blank">Operation documentation</a>
@@ -62,7 +64,7 @@ public class ManageBuyOfferOperationResponse extends OperationResponse {
     if (buyingAssetType.equals("native")) {
       return new AssetTypeNative();
     } else {
-      return Asset.createNonNativeAsset(buyingAssetCode, buyingAssetIssuer);
+      return create(buyingAssetType, buyingAssetCode, buyingAssetIssuer);
     }
   }
 
@@ -70,7 +72,7 @@ public class ManageBuyOfferOperationResponse extends OperationResponse {
     if (sellingAssetType.equals("native")) {
       return new AssetTypeNative();
     } else {
-      return Asset.createNonNativeAsset(sellingAssetCode, sellingAssetIssuer);
+      return create(sellingAssetType, sellingAssetCode, sellingAssetIssuer);
     }
   }
 }

--- a/src/main/java/org/stellar/sdk/responses/operations/ManageSellOfferOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/ManageSellOfferOperationResponse.java
@@ -1,9 +1,10 @@
 package org.stellar.sdk.responses.operations;
 
 import com.google.gson.annotations.SerializedName;
-
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
+
+import static org.stellar.sdk.Asset.create;
 
 /**
  * Represents ManageSellOffer operation response.
@@ -63,7 +64,7 @@ public class ManageSellOfferOperationResponse extends OperationResponse {
     if (buyingAssetType.equals("native")) {
       return new AssetTypeNative();
     } else {
-      return Asset.createNonNativeAsset(buyingAssetCode, buyingAssetIssuer);
+      return create(buyingAssetType, buyingAssetCode, buyingAssetIssuer);
     }
   }
 
@@ -71,7 +72,7 @@ public class ManageSellOfferOperationResponse extends OperationResponse {
     if (sellingAssetType.equals("native")) {
       return new AssetTypeNative();
     } else {
-      return Asset.createNonNativeAsset(sellingAssetCode, sellingAssetIssuer);
+      return create(sellingAssetType, sellingAssetCode, sellingAssetIssuer);
     }
   }
 }

--- a/src/main/java/org/stellar/sdk/responses/operations/PathPaymentBaseOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/PathPaymentBaseOperationResponse.java
@@ -10,6 +10,8 @@ import org.stellar.sdk.responses.MuxedAccount;
 import java.math.BigInteger;
 import java.util.List;
 
+import static org.stellar.sdk.Asset.create;
+
 public abstract class PathPaymentBaseOperationResponse extends OperationResponse {
   @SerializedName("amount")
   private String amount;
@@ -83,7 +85,7 @@ public abstract class PathPaymentBaseOperationResponse extends OperationResponse
     if (assetType.equals("native")) {
       return new AssetTypeNative();
     } else {
-      return Asset.createNonNativeAsset(assetCode, assetIssuer);
+      return create(assetType, assetCode, assetIssuer);
     }
   }
 
@@ -91,7 +93,7 @@ public abstract class PathPaymentBaseOperationResponse extends OperationResponse
     if (sourceAssetType.equals("native")) {
       return new AssetTypeNative();
     } else {
-      return Asset.createNonNativeAsset(sourceAssetCode, sourceAssetIssuer);
+      return create(sourceAssetType, sourceAssetCode, sourceAssetIssuer);
     }
   }
 }

--- a/src/main/java/org/stellar/sdk/responses/operations/PaymentOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/PaymentOperationResponse.java
@@ -1,9 +1,10 @@
 package org.stellar.sdk.responses.operations;
 
 import com.google.gson.annotations.SerializedName;
-
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
+
+import static org.stellar.sdk.Asset.create;
 
 /**
  * Represents Payment operation response.
@@ -42,7 +43,7 @@ public class PaymentOperationResponse extends OperationResponse {
     if (assetType.equals("native")) {
       return new AssetTypeNative();
     } else {
-      return Asset.createNonNativeAsset(assetCode, assetIssuer);
+      return create(assetType, assetCode, assetIssuer);
     }
   }
 

--- a/src/main/java/org/stellar/sdk/responses/operations/SetTrustLineFlagsOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/SetTrustLineFlagsOperationResponse.java
@@ -5,6 +5,8 @@ import org.stellar.sdk.Asset;
 
 import java.util.List;
 
+import static org.stellar.sdk.Asset.create;
+
 /**
  * Represents a Set Trustine Flags operation response.
  *
@@ -18,6 +20,8 @@ public class SetTrustLineFlagsOperationResponse extends OperationResponse {
   protected final String assetCode;
   @SerializedName("asset_issuer")
   protected final String assetIssuer;
+  @SerializedName("liquidity_pool_id")
+  protected final String liquidityPoolId;
 
   @SerializedName("clear_flags")
   protected final List<Integer> clearFlags;
@@ -32,7 +36,9 @@ public class SetTrustLineFlagsOperationResponse extends OperationResponse {
   @SerializedName("trustor")
   private final String trustor;
 
-  public SetTrustLineFlagsOperationResponse(String assetType, String assetCode, String assetIssuer, List<Integer> clearFlags, List<String> clearFlagStings, List<Integer> setFlags, List<String> setFlagStrings, String trustor) {
+  public SetTrustLineFlagsOperationResponse(String assetType, String assetCode, String assetIssuer,
+                                            List<Integer> clearFlags, List<String> clearFlagStings, List<Integer> setFlags,
+                                            List<String> setFlagStrings, String trustor, String LiquidityPoolId) {
     this.assetType = assetType;
     this.assetCode = assetCode;
     this.assetIssuer = assetIssuer;
@@ -41,6 +47,7 @@ public class SetTrustLineFlagsOperationResponse extends OperationResponse {
     this.setFlags = setFlags;
     this.setFlagStrings = setFlagStrings;
     this.trustor = trustor;
+    this.liquidityPoolId = LiquidityPoolId;
   }
 
   public String getAssetType() {
@@ -56,7 +63,7 @@ public class SetTrustLineFlagsOperationResponse extends OperationResponse {
   }
 
   public Asset getAsset() {
-    return Asset.createNonNativeAsset(assetCode, assetIssuer);
+    return create(assetType, assetCode, assetIssuer, liquidityPoolId);
   }
 
   public String getTrustor() {

--- a/src/main/java/org/stellar/sdk/responses/operations/SetTrustLineFlagsOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/SetTrustLineFlagsOperationResponse.java
@@ -20,8 +20,6 @@ public class SetTrustLineFlagsOperationResponse extends OperationResponse {
   protected final String assetCode;
   @SerializedName("asset_issuer")
   protected final String assetIssuer;
-  @SerializedName("liquidity_pool_id")
-  protected final String liquidityPoolId;
 
   @SerializedName("clear_flags")
   protected final List<Integer> clearFlags;
@@ -36,9 +34,7 @@ public class SetTrustLineFlagsOperationResponse extends OperationResponse {
   @SerializedName("trustor")
   private final String trustor;
 
-  public SetTrustLineFlagsOperationResponse(String assetType, String assetCode, String assetIssuer,
-                                            List<Integer> clearFlags, List<String> clearFlagStings, List<Integer> setFlags,
-                                            List<String> setFlagStrings, String trustor, String LiquidityPoolId) {
+  public SetTrustLineFlagsOperationResponse(String assetType, String assetCode, String assetIssuer, List<Integer> clearFlags, List<String> clearFlagStings, List<Integer> setFlags, List<String> setFlagStrings, String trustor) {
     this.assetType = assetType;
     this.assetCode = assetCode;
     this.assetIssuer = assetIssuer;
@@ -47,7 +43,6 @@ public class SetTrustLineFlagsOperationResponse extends OperationResponse {
     this.setFlags = setFlags;
     this.setFlagStrings = setFlagStrings;
     this.trustor = trustor;
-    this.liquidityPoolId = LiquidityPoolId;
   }
 
   public String getAssetType() {
@@ -63,7 +58,7 @@ public class SetTrustLineFlagsOperationResponse extends OperationResponse {
   }
 
   public Asset getAsset() {
-    return create(assetType, assetCode, assetIssuer, liquidityPoolId);
+    return create(assetType, assetCode, assetIssuer);
   }
 
   public String getTrustor() {

--- a/src/test/java/org/stellar/sdk/AccountFlagTest.java
+++ b/src/test/java/org/stellar/sdk/AccountFlagTest.java
@@ -1,12 +1,34 @@
 package org.stellar.sdk;
 
 import org.junit.Test;
+import org.stellar.sdk.responses.LedgerResponse;
+import org.stellar.sdk.responses.Page;
+import org.stellar.sdk.responses.effects.EffectResponse;
+import org.stellar.sdk.responses.effects.TrustlineCreatedEffectResponse;
 
 import static org.junit.Assert.assertEquals;
 
 public class AccountFlagTest {
   @Test
-  public void testValues() {
+  public void testValues() throws Exception {
+
+    Server server = new Server("https://horizon.stellar.org");
+    LedgerResponse resposne = server.ledgers()
+            .ledger(38115883);
+
+    Page<EffectResponse> resposnes = server.effects()
+            .forLedger(38115883).limit(200).execute();
+
+    for (EffectResponse effectResponse : resposnes.getRecords()) {
+         if (effectResponse.getType().equals("trustline_created")) {
+             TrustlineCreatedEffectResponse changeTrustOperation = (TrustlineCreatedEffectResponse)effectResponse;
+             Asset asset = changeTrustOperation.getAsset();
+             System.out.print(asset);
+         }
+    }
+
+
+
     assertEquals(1, AccountFlag.AUTH_REQUIRED_FLAG.getValue());
     assertEquals(2, AccountFlag.AUTH_REVOCABLE_FLAG.getValue());
     assertEquals(4, AccountFlag.AUTH_IMMUTABLE_FLAG.getValue());

--- a/src/test/java/org/stellar/sdk/AccountFlagTest.java
+++ b/src/test/java/org/stellar/sdk/AccountFlagTest.java
@@ -1,34 +1,12 @@
 package org.stellar.sdk;
 
 import org.junit.Test;
-import org.stellar.sdk.responses.LedgerResponse;
-import org.stellar.sdk.responses.Page;
-import org.stellar.sdk.responses.effects.EffectResponse;
-import org.stellar.sdk.responses.effects.TrustlineCreatedEffectResponse;
 
 import static org.junit.Assert.assertEquals;
 
 public class AccountFlagTest {
   @Test
   public void testValues() throws Exception {
-
-    Server server = new Server("https://horizon.stellar.org");
-    LedgerResponse resposne = server.ledgers()
-            .ledger(38115883);
-
-    Page<EffectResponse> resposnes = server.effects()
-            .forLedger(38115883).limit(200).execute();
-
-    for (EffectResponse effectResponse : resposnes.getRecords()) {
-         if (effectResponse.getType().equals("trustline_created")) {
-             TrustlineCreatedEffectResponse changeTrustOperation = (TrustlineCreatedEffectResponse)effectResponse;
-             Asset asset = changeTrustOperation.getAsset();
-             System.out.print(asset);
-         }
-    }
-
-
-
     assertEquals(1, AccountFlag.AUTH_REQUIRED_FLAG.getValue());
     assertEquals(2, AccountFlag.AUTH_REVOCABLE_FLAG.getValue());
     assertEquals(4, AccountFlag.AUTH_IMMUTABLE_FLAG.getValue());

--- a/src/test/java/org/stellar/sdk/AssetTest.java
+++ b/src/test/java/org/stellar/sdk/AssetTest.java
@@ -10,12 +10,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.stellar.sdk.Asset.create;
 
 /**
  * Created by andrewrogers on 7/1/15.
  */
 public class AssetTest {
-  Asset xlm = Asset.create("native");
+  Asset xlm = create("native");
 
   @Test
   public void testAssetTypeNative() {
@@ -87,12 +88,12 @@ public class AssetTest {
 
   @Test
   public void testAssetCompareTo0IfAssetsEqual() {
-    Asset assetA = Asset.createNonNativeAsset(
+    Asset assetA = create(null,
 			"ARST",
 			"GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"
 		);
 
-		Asset assetB = Asset.createNonNativeAsset(
+		Asset assetB = create(null,
 			"USD",
 			"GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ"
 		);
@@ -104,11 +105,11 @@ public class AssetTest {
 
   @Test
   public void testAssetCompareToOrderingByType() {
-		Asset anum4 = Asset.createNonNativeAsset(
+		Asset anum4 = create(null,
 			"ARSZ",
 			"GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"
 		);
-		Asset anum12 = Asset.createNonNativeAsset(
+		Asset anum12 = create(null,
 			"ARSTANUM12",
 			"GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"
 		);
@@ -128,11 +129,11 @@ public class AssetTest {
 
   @Test
   public void testAssetCompareToOrderingByCode() {
-    Asset assetARST = Asset.createNonNativeAsset(
+    Asset assetARST = create(null,
       "ARST",
       "GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"
     );
-    Asset assetUSDX = Asset.createNonNativeAsset(
+    Asset assetUSDX = create(null,
       "USDX",
       "GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"
     );
@@ -146,11 +147,11 @@ public class AssetTest {
 
   @Test
   public void testAssetCompareToOrderingByIssuer() {
-		Asset assetIssuerA = Asset.createNonNativeAsset(
+		Asset assetIssuerA = create(null,
 			"ARST",
 			"GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"
 		);
-		Asset assetIssuerB = Asset.createNonNativeAsset(
+		Asset assetIssuerB = create(null,
 			"ARST",
 			"GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ"
 		);
@@ -165,18 +166,18 @@ public class AssetTest {
   @Test
   public void testAssetsAreSortable()	{
     // Native is always first
-    Asset a = Asset.create("native");
+    Asset a = create("native");
     // Type is Alphanum4
-    Asset b = Asset.createNonNativeAsset("BCDE",  "GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO");
+    Asset b = create(null,"BCDE",  "GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO");
 
     // Type is Alphanum12
-    Asset c = Asset.createNonNativeAsset("ABCD1", "GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO");
+    Asset c = create(null,"ABCD1", "GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO");
 
     // Code is >
-    Asset d = Asset.createNonNativeAsset("ABCD2", "GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO");
+    Asset d = create(null,"ABCD2", "GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO");
 
     // Issuer is >
-    Asset e = Asset.createNonNativeAsset("ABCD2", "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ");
+    Asset e = create(null,"ABCD2", "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ");
 
     Asset[] expected = {a, b, c, d, e};
 

--- a/src/test/java/org/stellar/sdk/LiquidityPoolDepositOperationTest.java
+++ b/src/test/java/org/stellar/sdk/LiquidityPoolDepositOperationTest.java
@@ -5,12 +5,13 @@ import org.stellar.sdk.xdr.LiquidityPoolType;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.stellar.sdk.Asset.create;
 
 public class LiquidityPoolDepositOperationTest {
     // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF
     KeyPair source = KeyPair.fromSecretSeed("SC4CGETADVYTCR5HEAVZRB3DZQY5Y4J7RFNJTRA6ESMHIPEZUSTE2QDK");
-    Asset nativeAsset = Asset.create("native");
-    Asset creditAsset = Asset.createNonNativeAsset("ABC", "GCRA6COW27CY5MTKIA7POQ2326C5ABYCXODBN4TFF5VL4FMBRHOT3YHU");
+    Asset nativeAsset = create("native");
+    Asset creditAsset = create(null, "ABC", "GCRA6COW27CY5MTKIA7POQ2326C5ABYCXODBN4TFF5VL4FMBRHOT3YHU");
     LiquidityPoolID liquidityPoolID = new LiquidityPoolID(
         LiquidityPoolType.LIQUIDITY_POOL_CONSTANT_PRODUCT,
         nativeAsset,

--- a/src/test/java/org/stellar/sdk/LiquidityPoolIDTest.java
+++ b/src/test/java/org/stellar/sdk/LiquidityPoolIDTest.java
@@ -5,11 +5,12 @@ import org.junit.Test;
 import org.stellar.sdk.xdr.LiquidityPoolType;
 
 import static org.junit.Assert.*;
+import static org.stellar.sdk.Asset.create;
 
 public class LiquidityPoolIDTest {
-  private final Asset a = Asset.create("native");
-  private final Asset b = Asset.createNonNativeAsset("ABC", "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3");
-  private final Asset c = Asset.createNonNativeAsset("ABCD", "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3");
+  private final Asset a = create("native");
+  private final Asset b = create(null,"ABC", "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3");
+  private final Asset c = create(null,"ABCD", "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3");
 
   @Test
   public void testLiquidityPoolID() {

--- a/src/test/java/org/stellar/sdk/LiquidityPoolWithdrawOperationTest.java
+++ b/src/test/java/org/stellar/sdk/LiquidityPoolWithdrawOperationTest.java
@@ -5,12 +5,13 @@ import org.stellar.sdk.xdr.LiquidityPoolType;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.stellar.sdk.Asset.create;
 
 public class LiquidityPoolWithdrawOperationTest {
     // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF
     KeyPair source = KeyPair.fromSecretSeed("SC4CGETADVYTCR5HEAVZRB3DZQY5Y4J7RFNJTRA6ESMHIPEZUSTE2QDK");
-    Asset nativeAsset = Asset.create("native");
-    Asset creditAsset = Asset.createNonNativeAsset("ABC", "GCRA6COW27CY5MTKIA7POQ2326C5ABYCXODBN4TFF5VL4FMBRHOT3YHU");
+    Asset nativeAsset = create("native");
+    Asset creditAsset = create(null,"ABC", "GCRA6COW27CY5MTKIA7POQ2326C5ABYCXODBN4TFF5VL4FMBRHOT3YHU");
     LiquidityPoolID liquidityPoolID = new LiquidityPoolID(
         LiquidityPoolType.LIQUIDITY_POOL_CONSTANT_PRODUCT,
         nativeAsset,

--- a/src/test/java/org/stellar/sdk/OperationTest.java
+++ b/src/test/java/org/stellar/sdk/OperationTest.java
@@ -16,6 +16,7 @@ import java.util.EnumSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.stellar.sdk.Asset.create;
 
 public class OperationTest {
 
@@ -559,7 +560,7 @@ public class OperationTest {
         KeyPair issuer = KeyPair.fromSecretSeed("SA64U7C5C7BS5IHWEPA7YWFN3Z6FE5L6KAMYUIT4AQ7KVTVLD23C6HEZ");
 
         Asset selling = new AssetTypeNative();
-        Asset buying = Asset.createNonNativeAsset("USD", issuer.getAccountId());
+        Asset buying = create(null,"USD", issuer.getAccountId());
         String amount = "0.00001";
         String price = "0.85334384"; // n=5333399 d=6250000
         Price priceObj = Price.fromString(price);
@@ -596,7 +597,7 @@ public class OperationTest {
         KeyPair issuer = KeyPair.fromSecretSeed("SA64U7C5C7BS5IHWEPA7YWFN3Z6FE5L6KAMYUIT4AQ7KVTVLD23C6HEZ");
 
         Asset selling = new AssetTypeNative();
-        Asset buying = Asset.createNonNativeAsset("USD", issuer.getAccountId());
+        Asset buying = create(null,"USD", issuer.getAccountId());
         String amount = "0.00001";
         String price = "0.85334384"; // n=5333399 d=6250000
         Price priceObj = Price.fromString(price);
@@ -665,7 +666,7 @@ public class OperationTest {
         KeyPair issuer = KeyPair.fromSecretSeed("SA64U7C5C7BS5IHWEPA7YWFN3Z6FE5L6KAMYUIT4AQ7KVTVLD23C6HEZ");
 
         Asset selling = new AssetTypeNative();
-        Asset buying = Asset.createNonNativeAsset("USD", issuer.getAccountId());
+        Asset buying = create(null,"USD", issuer.getAccountId());
         String amount = "0.00001";
         String price = "2.93850088"; // n=36731261 d=12500000
         Price priceObj = Price.fromString(price);
@@ -1073,7 +1074,7 @@ public class OperationTest {
         try {
             String accountId = "GAGQ7DNQUVQR6OWYOI563L5EMJE6KCAHPQSFCZFLY5PDRYMRCA5UWCMP";
             String amt = "100";
-            new ClawbackOperation.Builder(accountId, Asset.create("native"), amt);
+            new ClawbackOperation.Builder(accountId, create("native"), amt);
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals("native assets are not supported", e.getMessage());
@@ -1112,7 +1113,7 @@ public class OperationTest {
             EnumSet<TrustLineFlags> toClear = EnumSet.of(TrustLineFlags.AUTHORIZED_FLAG);
             EnumSet<TrustLineFlags> toSet = EnumSet.of(TrustLineFlags.AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG);
 
-            new SetTrustlineFlagsOperation.Builder(accountId, Asset.create("native"), toClear, toSet).setSourceAccount(source).build();
+            new SetTrustlineFlagsOperation.Builder(accountId, create("native"), toClear, toSet).setSourceAccount(source).build();
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals("native assets are not supported", e.getMessage());

--- a/src/test/java/org/stellar/sdk/requests/OrderBookRequestBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/requests/OrderBookRequestBuilderTest.java
@@ -8,14 +8,15 @@ import org.stellar.sdk.Network;
 import org.stellar.sdk.Server;
 
 import static org.junit.Assert.assertEquals;
+import static org.stellar.sdk.Asset.create;
 
 public class OrderBookRequestBuilderTest {
   @Test
   public void testOrderBook() {
     Server server = new Server("https://horizon-testnet.stellar.org");
     HttpUrl uri = server.orderBook()
-            .buyingAsset(Asset.createNonNativeAsset("EUR", "GAUPA4HERNBDPVO4IUA3MJXBCRRK5W54EVXTDK6IIUTGDQRB6D5W242W"))
-            .sellingAsset(Asset.createNonNativeAsset("USD", "GDRRHSJMHXDTQBT4JTCILNGF5AS54FEMTXL7KOLMF6TFTHRK6SSUSUZZ"))
+            .buyingAsset(create(null,"EUR", "GAUPA4HERNBDPVO4IUA3MJXBCRRK5W54EVXTDK6IIUTGDQRB6D5W242W"))
+            .sellingAsset(create(null,"USD", "GDRRHSJMHXDTQBT4JTCILNGF5AS54FEMTXL7KOLMF6TFTHRK6SSUSUZZ"))
             .buildUri();
 
     assertEquals(

--- a/src/test/java/org/stellar/sdk/requests/PathsRequestBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/requests/PathsRequestBuilderTest.java
@@ -8,7 +8,10 @@ import org.stellar.sdk.Server;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.stellar.sdk.Asset.create;
 
 public class PathsRequestBuilderTest {
   @Test
@@ -18,7 +21,7 @@ public class PathsRequestBuilderTest {
             .destinationAccount("GB24QI3BJNKBY4YNJZ2I37HFIYK56BL2OURFML76X46RQQKDLVT7WKJF")
             .sourceAccount("GD4KO3IOYYWIYVI236Y35K2DU6VNYRH3BPNFJSH57J5BLLCQHBIOK3IN")
             .destinationAmount("20.50")
-            .destinationAsset(Asset.createNonNativeAsset("USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"))
+            .destinationAsset(create(null,"USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"))
             .cursor("13537736921089")
             .limit(200)
             .order(RequestBuilder.Order.ASC)
@@ -39,16 +42,16 @@ public class PathsRequestBuilderTest {
   @Test
   public void testStrictReceiveWithSourceAssets() {
     List<Asset> assets = Lists.newArrayList(
-        Asset.create("native", "", ""),
-        Asset.create("credit_alphanum4", "USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"),
-        Asset.create("credit_alphanum4", "EUR", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH")
+        create("native", "", ""),
+        create("credit_alphanum4", "USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"),
+        create("credit_alphanum4", "EUR", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH")
     );
     Server server = new Server("https://horizon-testnet.stellar.org");
     HttpUrl uri = server.strictReceivePaths()
         .destinationAccount("GB24QI3BJNKBY4YNJZ2I37HFIYK56BL2OURFML76X46RQQKDLVT7WKJF")
         .sourceAssets(assets)
         .destinationAmount("20.50")
-        .destinationAsset(Asset.createNonNativeAsset("USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"))
+        .destinationAsset(create(null,"USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"))
         .cursor("13537736921089")
         .limit(3)
         .order(RequestBuilder.Order.ASC)
@@ -69,9 +72,9 @@ public class PathsRequestBuilderTest {
   @Test
   public void testStrictReceiveWithSourceAccountAndSourceAssets() {
     List<Asset> assets = Lists.newArrayList(
-        Asset.create("native", "", ""),
-        Asset.create("credit_alphanum4", "USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"),
-        Asset.create("credit_alphanum4", "EUR", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH")
+        create("native", "", ""),
+        create("credit_alphanum4", "USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"),
+        create("credit_alphanum4", "EUR", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH")
     );
     Server server = new Server("https://horizon-testnet.stellar.org");
 
@@ -96,7 +99,7 @@ public class PathsRequestBuilderTest {
     HttpUrl uri = server.strictSendPaths()
         .destinationAccount("GB24QI3BJNKBY4YNJZ2I37HFIYK56BL2OURFML76X46RQQKDLVT7WKJF")
         .sourceAmount("20.50")
-        .sourceAsset(Asset.createNonNativeAsset("USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"))
+        .sourceAsset(create(null,"USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"))
         .cursor("13537736921089")
         .limit(200)
         .order(RequestBuilder.Order.ASC)
@@ -116,15 +119,15 @@ public class PathsRequestBuilderTest {
   @Test
   public void testStrictSendWithDestinationAssets() {
     List<Asset> assets = Lists.newArrayList(
-        Asset.create("native", "", ""),
-        Asset.create("credit_alphanum4", "USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"),
-        Asset.create("credit_alphanum4", "EUR", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH")
+        create("native", "", ""),
+        create("credit_alphanum4", "USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"),
+        create("credit_alphanum4", "EUR", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH")
     );
     Server server = new Server("https://horizon-testnet.stellar.org");
     HttpUrl uri = server.strictSendPaths()
         .destinationAssets(assets)
         .sourceAmount("20.50")
-        .sourceAsset(Asset.createNonNativeAsset("USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"))
+        .sourceAsset(create(null,"USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"))
         .cursor("13537736921089")
         .limit(3)
         .order(RequestBuilder.Order.ASC)
@@ -144,9 +147,9 @@ public class PathsRequestBuilderTest {
   @Test
   public void testStrictSendWithDestinationAccountAndDestinationAssets() {
     List<Asset> assets = Lists.newArrayList(
-        Asset.create("native", "", ""),
-        Asset.create("credit_alphanum4", "USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"),
-        Asset.create("credit_alphanum4", "EUR", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH")
+        create("native", "", ""),
+        create("credit_alphanum4", "USD", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH"),
+        create("credit_alphanum4", "EUR", "GAYSHLG75RPSMXWJ5KX7O7STE6RSZTD6NE4CTWAXFZYYVYIFRUVJIBJH")
     );
     Server server = new Server("https://horizon-testnet.stellar.org");
 

--- a/src/test/java/org/stellar/sdk/requests/TradeAggregationsRequestBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/requests/TradeAggregationsRequestBuilderTest.java
@@ -2,9 +2,11 @@ package org.stellar.sdk.requests;
 
 import okhttp3.HttpUrl;
 import org.junit.Test;
-import org.stellar.sdk.*;
+import org.stellar.sdk.AssetTypeNative;
+import org.stellar.sdk.Server;
 
 import static org.junit.Assert.assertEquals;
+import static org.stellar.sdk.Asset.create;
 
 public class TradeAggregationsRequestBuilderTest {
     @Test
@@ -12,7 +14,7 @@ public class TradeAggregationsRequestBuilderTest {
         Server server = new Server("https://horizon-testnet.stellar.org");
         HttpUrl uri = server.tradeAggregations(
                 new AssetTypeNative(),
-                Asset.createNonNativeAsset("BTC", "GATEMHCCKCY67ZUCKTROYN24ZYT5GK4EQZ65JJLDHKHRUZI3EUEKMTCH"),
+                create(null,"BTC", "GATEMHCCKCY67ZUCKTROYN24ZYT5GK4EQZ65JJLDHKHRUZI3EUEKMTCH"),
                 1512689100000L,
                 1512775500000L,
                 300000L,

--- a/src/test/java/org/stellar/sdk/requests/TradesRequestBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/requests/TradesRequestBuilderTest.java
@@ -2,21 +2,19 @@ package org.stellar.sdk.requests;
 
 import okhttp3.HttpUrl;
 import org.junit.Test;
-import org.stellar.sdk.Asset;
 import org.stellar.sdk.LiquidityPoolID;
-import org.stellar.sdk.KeyPair;
-import org.stellar.sdk.Network;
 import org.stellar.sdk.Server;
 
 import static org.junit.Assert.assertEquals;
+import static org.stellar.sdk.Asset.create;
 
 public class TradesRequestBuilderTest {
     @Test
     public void testTrades() {
         Server server = new Server("https://horizon-testnet.stellar.org");
         HttpUrl uri = server.trades()
-                .baseAsset(Asset.createNonNativeAsset("EUR", "GAUPA4HERNBDPVO4IUA3MJXBCRRK5W54EVXTDK6IIUTGDQRB6D5W242W"))
-                .counterAsset(Asset.createNonNativeAsset("USD", "GDRRHSJMHXDTQBT4JTCILNGF5AS54FEMTXL7KOLMF6TFTHRK6SSUSUZZ"))
+                .baseAsset(create(null,"EUR", "GAUPA4HERNBDPVO4IUA3MJXBCRRK5W54EVXTDK6IIUTGDQRB6D5W242W"))
+                .counterAsset(create(null,"USD", "GDRRHSJMHXDTQBT4JTCILNGF5AS54FEMTXL7KOLMF6TFTHRK6SSUSUZZ"))
                 .cursor("13537736921089")
                 .offerId(123L)
                 .limit(200)

--- a/src/test/java/org/stellar/sdk/responses/EffectDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/EffectDeserializerTest.java
@@ -12,6 +12,8 @@ import org.stellar.sdk.xdr.LiquidityPoolType;
 
 import java.util.Arrays;
 
+import static org.stellar.sdk.Asset.create;
+
 public class EffectDeserializerTest extends TestCase {
   @Test
   public void testDeserializeAccountCreatedEffect() {
@@ -481,12 +483,40 @@ public class EffectDeserializerTest extends TestCase {
     TrustlineCreatedEffectResponse effect = (TrustlineCreatedEffectResponse) GsonSingleton.getInstance().fromJson(json, EffectResponse.class);
 
     assertEquals(effect.getAccount(), "GA6U5X6WOPNKKDKQULBR7IDHDBAQKOWPHYEC7WSXHZBFEYFD3XVZAKOO");
-    TestCase.assertEquals(effect.getAsset(), Asset.createNonNativeAsset("EUR", "GAZN3PPIDQCSP5JD4ETQQQ2IU2RMFYQTAL4NNQZUGLLO2XJJJ3RDSDGA"));
+    TestCase.assertEquals(effect.getAsset(), create(null, "EUR", "GAZN3PPIDQCSP5JD4ETQQQ2IU2RMFYQTAL4NNQZUGLLO2XJJJ3RDSDGA"));
     assertEquals(effect.getLimit(), "1000.0");
 
     assertEquals(effect.getLinks().getOperation().getHref(), "http://horizon-testnet.stellar.org/operations/33788507721730");
     assertEquals(effect.getLinks().getSucceeds().getHref(), "http://horizon-testnet.stellar.org/effects?order=desc&cursor=33788507721730-2");
     assertEquals(effect.getLinks().getPrecedes().getHref(), "http://horizon-testnet.stellar.org/effects?order=asc&cursor=33788507721730-2");
+  }
+
+  @Test
+  public void testDeserializeLiquidityPoolTrustlineCreatedEffect() {
+    String json = "{\n" +
+            "        \"_links\": {\n" +
+            "          \"operation\": {\n" +
+            "            \"href\": \"http://horizon-testnet.stellar.org/operations/33788507721730\"\n" +
+            "          },\n" +
+            "          \"succeeds\": {\n" +
+            "            \"href\": \"http://horizon-testnet.stellar.org/effects?order=desc\\u0026cursor=33788507721730-2\"\n" +
+            "          },\n" +
+            "          \"precedes\": {\n" +
+            "            \"href\": \"http://horizon-testnet.stellar.org/effects?order=asc\\u0026cursor=33788507721730-2\"\n" +
+            "          }\n" +
+            "        },\n" +
+            "        \"id\": \"0000033788507721730-0000000002\",\n" +
+            "        \"paging_token\": \"33788507721730-2\",\n" +
+            "        \"account\": \"GA6U5X6WOPNKKDKQULBR7IDHDBAQKOWPHYEC7WSXHZBFEYFD3XVZAKOO\",\n" +
+            "        \"type\": \"trustline_created\",\n" +
+            "        \"type_i\": 20,\n" +
+            "        \"asset_type\": \"liquidity_pool_shares\",\n" +
+            "        \"liquidity_pool_id\": \"02449937ed825805b7a945bb6c027b53dfaf140983c1a1a64c42a81edd89b5e0\",\n" +
+            "        \"limit\": \"1000.0\"\n" +
+            "      }";
+
+    TrustlineCreatedEffectResponse effect = (TrustlineCreatedEffectResponse) GsonSingleton.getInstance().fromJson(json, EffectResponse.class);
+    TestCase.assertEquals(effect.getAsset(), create("liquidity_pool_shares", null, null, "02449937ed825805b7a945bb6c027b53dfaf140983c1a1a64c42a81edd89b5e0"));
   }
 
   @Test
@@ -517,12 +547,40 @@ public class EffectDeserializerTest extends TestCase {
     TrustlineRemovedEffectResponse effect = (TrustlineRemovedEffectResponse) GsonSingleton.getInstance().fromJson(json, EffectResponse.class);
 
     assertEquals(effect.getAccount(), "GA6U5X6WOPNKKDKQULBR7IDHDBAQKOWPHYEC7WSXHZBFEYFD3XVZAKOO");
-    assertEquals(effect.getAsset(), Asset.createNonNativeAsset("EUR", "GAZN3PPIDQCSP5JD4ETQQQ2IU2RMFYQTAL4NNQZUGLLO2XJJJ3RDSDGA"));
+    assertEquals(effect.getAsset(), create(null,"EUR", "GAZN3PPIDQCSP5JD4ETQQQ2IU2RMFYQTAL4NNQZUGLLO2XJJJ3RDSDGA"));
     assertEquals(effect.getLimit(), "0.0");
 
     assertEquals(effect.getLinks().getOperation().getHref(), "http://horizon-testnet.stellar.org/operations/33788507721730");
     assertEquals(effect.getLinks().getSucceeds().getHref(), "http://horizon-testnet.stellar.org/effects?order=desc&cursor=33788507721730-2");
     assertEquals(effect.getLinks().getPrecedes().getHref(), "http://horizon-testnet.stellar.org/effects?order=asc&cursor=33788507721730-2");
+  }
+
+  @Test
+  public void testDeserializeLiquidityPoolTrustlineRemovedEffect() {
+    String json = "{\n" +
+            "        \"_links\": {\n" +
+            "          \"operation\": {\n" +
+            "            \"href\": \"http://horizon-testnet.stellar.org/operations/33788507721730\"\n" +
+            "          },\n" +
+            "          \"succeeds\": {\n" +
+            "            \"href\": \"http://horizon-testnet.stellar.org/effects?order=desc\\u0026cursor=33788507721730-2\"\n" +
+            "          },\n" +
+            "          \"precedes\": {\n" +
+            "            \"href\": \"http://horizon-testnet.stellar.org/effects?order=asc\\u0026cursor=33788507721730-2\"\n" +
+            "          }\n" +
+            "        },\n" +
+            "        \"id\": \"0000033788507721730-0000000002\",\n" +
+            "        \"paging_token\": \"33788507721730-2\",\n" +
+            "        \"account\": \"GA6U5X6WOPNKKDKQULBR7IDHDBAQKOWPHYEC7WSXHZBFEYFD3XVZAKOO\",\n" +
+            "        \"type\": \"trustline_removed\",\n" +
+            "        \"type_i\": 21,\n" +
+            "        \"asset_type\": \"liquidity_pool_shares\",\n" +
+            "        \"liquidity_pool_id\": \"02449937ed825805b7a945bb6c027b53dfaf140983c1a1a64c42a81edd89b5e0\",\n" +
+            "        \"limit\": \"0.0\"\n" +
+            "      }";
+
+    TrustlineRemovedEffectResponse effect = (TrustlineRemovedEffectResponse) GsonSingleton.getInstance().fromJson(json, EffectResponse.class);
+    TestCase.assertEquals(effect.getAsset(), create("liquidity_pool_shares", null, null, "02449937ed825805b7a945bb6c027b53dfaf140983c1a1a64c42a81edd89b5e0"));
   }
 
   @Test
@@ -553,12 +611,40 @@ public class EffectDeserializerTest extends TestCase {
     TrustlineUpdatedEffectResponse effect = (TrustlineUpdatedEffectResponse) GsonSingleton.getInstance().fromJson(json, EffectResponse.class);
 
     assertEquals(effect.getAccount(), "GA6U5X6WOPNKKDKQULBR7IDHDBAQKOWPHYEC7WSXHZBFEYFD3XVZAKOO");
-    assertEquals(effect.getAsset(), Asset.createNonNativeAsset("TESTTEST", "GAZN3PPIDQCSP5JD4ETQQQ2IU2RMFYQTAL4NNQZUGLLO2XJJJ3RDSDGA"));
+    assertEquals(effect.getAsset(), create(null,"TESTTEST", "GAZN3PPIDQCSP5JD4ETQQQ2IU2RMFYQTAL4NNQZUGLLO2XJJJ3RDSDGA"));
     assertEquals(effect.getLimit(), "100.0");
 
     assertEquals(effect.getLinks().getOperation().getHref(), "http://horizon-testnet.stellar.org/operations/33788507721730");
     assertEquals(effect.getLinks().getSucceeds().getHref(), "http://horizon-testnet.stellar.org/effects?order=desc&cursor=33788507721730-2");
     assertEquals(effect.getLinks().getPrecedes().getHref(), "http://horizon-testnet.stellar.org/effects?order=asc&cursor=33788507721730-2");
+  }
+
+  @Test
+  public void testDeserializeLiquidityPoolTrustlineUpdatedEffect() {
+    String json = "{\n" +
+            "        \"_links\": {\n" +
+            "          \"operation\": {\n" +
+            "            \"href\": \"http://horizon-testnet.stellar.org/operations/33788507721730\"\n" +
+            "          },\n" +
+            "          \"succeeds\": {\n" +
+            "            \"href\": \"http://horizon-testnet.stellar.org/effects?order=desc\\u0026cursor=33788507721730-2\"\n" +
+            "          },\n" +
+            "          \"precedes\": {\n" +
+            "            \"href\": \"http://horizon-testnet.stellar.org/effects?order=asc\\u0026cursor=33788507721730-2\"\n" +
+            "          }\n" +
+            "        },\n" +
+            "        \"id\": \"0000033788507721730-0000000002\",\n" +
+            "        \"paging_token\": \"33788507721730-2\",\n" +
+            "        \"account\": \"GA6U5X6WOPNKKDKQULBR7IDHDBAQKOWPHYEC7WSXHZBFEYFD3XVZAKOO\",\n" +
+            "        \"type\": \"trustline_updated\",\n" +
+            "        \"type_i\": 22,\n" +
+            "        \"asset_type\": \"liquidity_pool_shares\",\n" +
+            "        \"liquidity_pool_id\": \"02449937ed825805b7a945bb6c027b53dfaf140983c1a1a64c42a81edd89b5e0\",\n" +
+            "        \"limit\": \"100.0\"\n" +
+            "      }";
+
+    TrustlineUpdatedEffectResponse effect = (TrustlineUpdatedEffectResponse) GsonSingleton.getInstance().fromJson(json, EffectResponse.class);
+    TestCase.assertEquals(effect.getAsset(), create("liquidity_pool_shares", null, null, "02449937ed825805b7a945bb6c027b53dfaf140983c1a1a64c42a81edd89b5e0"));
   }
 
   @Test
@@ -707,9 +793,9 @@ public class EffectDeserializerTest extends TestCase {
     assertEquals(effect.getSeller(), "GCVHDLN6EHZBYW2M3BQIY32C23E4GPIRZZDBNF2Q73DAZ5VJDRGSMYRB");
     assertEquals(effect.getOfferId(), new Long(1));
     assertEquals(effect.getSoldAmount(), "1000.0");
-    assertEquals(effect.getSoldAsset(), Asset.createNonNativeAsset("EUR", "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS"));
+    assertEquals(effect.getSoldAsset(), create(null,"EUR", "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS"));
     assertEquals(effect.getBoughtAmount(), "60.0");
-    assertEquals(effect.getBoughtAsset(), Asset.createNonNativeAsset("TESTTEST", "GAHXPUDP3AK6F2QQM4FIRBGPNGKLRDDSTQCVKEXXKKRHJZUUQ23D5BU7"));
+    assertEquals(effect.getBoughtAsset(), create(null,"TESTTEST", "GAHXPUDP3AK6F2QQM4FIRBGPNGKLRDDSTQCVKEXXKKRHJZUUQ23D5BU7"));
 
     assertEquals(effect.getLinks().getOperation().getHref(), "http://horizon-testnet.stellar.org/operations/33788507721730");
     assertEquals(effect.getLinks().getSucceeds().getHref(), "http://horizon-testnet.stellar.org/effects?order=desc&cursor=33788507721730-2");
@@ -900,7 +986,7 @@ public class EffectDeserializerTest extends TestCase {
     assertTrue(effect.getClawbackEnabled());
     assertFalse(effect.getAuthorizedToMaintainLiabilities());
 
-    assertEquals(effect.getAsset(), Asset.createNonNativeAsset("EUR", "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS"));
+    assertEquals(effect.getAsset(), create(null,"EUR", "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS"));
     assertEquals(effect.getAssetIssuer(), "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS");
     assertEquals(effect.getAssetCode(), "EUR");
     assertEquals(effect.getAssetType(), "credit_alphanum4");
@@ -964,10 +1050,10 @@ public class EffectDeserializerTest extends TestCase {
     assertEquals(effect.getLiquidityPool().getTotalTrustlines(), Long.valueOf(3));
     assertEquals(effect.getLiquidityPool().getTotalShares(), "18560.5392046");
     assertTrue(Arrays.equals(effect.getLiquidityPool().getReserves(), new AssetAmount[]{
-        new AssetAmount(Asset.create("native"), "6080.9091224"),
-        new AssetAmount(Asset.create("ARST:GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"), "56817.1796745")
+        new AssetAmount(create("native"), "6080.9091224"),
+        new AssetAmount(create("ARST:GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"), "56817.1796745")
     }));
-    assertEquals(effect.getSold(), new AssetAmount(Asset.create("native"), "0.1067066"));
-    assertEquals(effect.getBought(), new AssetAmount(Asset.create("ARST:GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"), "1.0000000"));
+    assertEquals(effect.getSold(), new AssetAmount(create("native"), "0.1067066"));
+    assertEquals(effect.getBought(), new AssetAmount(create("ARST:GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"), "1.0000000"));
   }
 }

--- a/src/test/java/org/stellar/sdk/responses/OfferPageDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/OfferPageDeserializerTest.java
@@ -7,6 +7,8 @@ import junit.framework.TestCase;
 import org.junit.Test;
 import org.stellar.sdk.Asset;
 
+import static org.stellar.sdk.Asset.create;
+
 public class OfferPageDeserializerTest extends TestCase {
   @Test
   public void testDeserialize() {
@@ -15,8 +17,8 @@ public class OfferPageDeserializerTest extends TestCase {
     assertEquals(offerPage.getRecords().get(0).getId(), new Long(241));
     assertEquals(offerPage.getRecords().get(0).getSeller(), "GA2IYMIZSAMDD6QQTTSIEL73H2BKDJQTA7ENDEEAHJ3LMVF7OYIZPXQD");
     assertEquals(offerPage.getRecords().get(0).getPagingToken(), "241");
-    assertEquals(offerPage.getRecords().get(0).getSelling(), Asset.createNonNativeAsset("INR", "GA2IYMIZSAMDD6QQTTSIEL73H2BKDJQTA7ENDEEAHJ3LMVF7OYIZPXQD"));
-    assertEquals(offerPage.getRecords().get(0).getBuying(), Asset.createNonNativeAsset("USD", "GA2IYMIZSAMDD6QQTTSIEL73H2BKDJQTA7ENDEEAHJ3LMVF7OYIZPXQD"));
+    assertEquals(offerPage.getRecords().get(0).getSelling(), create(null,"INR", "GA2IYMIZSAMDD6QQTTSIEL73H2BKDJQTA7ENDEEAHJ3LMVF7OYIZPXQD"));
+    assertEquals(offerPage.getRecords().get(0).getBuying(), create(null,"USD", "GA2IYMIZSAMDD6QQTTSIEL73H2BKDJQTA7ENDEEAHJ3LMVF7OYIZPXQD"));
     assertEquals(offerPage.getRecords().get(0).getAmount(), "10.0000000");
     assertEquals(offerPage.getRecords().get(0).getPrice(), "11.0000000");
     assertEquals(offerPage.getRecords().get(0).getLastModifiedLedger(), new Integer(22200794));
@@ -35,8 +37,8 @@ public class OfferPageDeserializerTest extends TestCase {
     assertEquals(offerPage.getRecords().get(0).getId(), new Long(241));
     assertEquals(offerPage.getRecords().get(0).getSeller(), "GA2IYMIZSAMDD6QQTTSIEL73H2BKDJQTA7ENDEEAHJ3LMVF7OYIZPXQD");
     assertEquals(offerPage.getRecords().get(0).getPagingToken(), "241");
-    assertEquals(offerPage.getRecords().get(0).getSelling(), Asset.createNonNativeAsset("INR", "GA2IYMIZSAMDD6QQTTSIEL73H2BKDJQTA7ENDEEAHJ3LMVF7OYIZPXQD"));
-    assertEquals(offerPage.getRecords().get(0).getBuying(), Asset.createNonNativeAsset("USD", "GA2IYMIZSAMDD6QQTTSIEL73H2BKDJQTA7ENDEEAHJ3LMVF7OYIZPXQD"));
+    assertEquals(offerPage.getRecords().get(0).getSelling(), create(null,"INR", "GA2IYMIZSAMDD6QQTTSIEL73H2BKDJQTA7ENDEEAHJ3LMVF7OYIZPXQD"));
+    assertEquals(offerPage.getRecords().get(0).getBuying(), create(null,"USD", "GA2IYMIZSAMDD6QQTTSIEL73H2BKDJQTA7ENDEEAHJ3LMVF7OYIZPXQD"));
     assertEquals(offerPage.getRecords().get(0).getAmount(), "10.0000000");
     assertEquals(offerPage.getRecords().get(0).getPrice(), "11.0000000");
     assertEquals(offerPage.getRecords().get(0).getLastModifiedLedger(), new Integer(22200794));

--- a/src/test/java/org/stellar/sdk/responses/OperationDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/OperationDeserializerTest.java
@@ -11,6 +11,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 
 import static java.math.BigInteger.valueOf;
+import static org.stellar.sdk.Asset.create;
 
 public class OperationDeserializerTest extends TestCase {
   @Test
@@ -197,7 +198,7 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getFrom(), "GAZN3PPIDQCSP5JD4ETQQQ2IU2RMFYQTAL4NNQZUGLLO2XJJJ3RDSDGA");
     assertEquals(operation.getTo(), "GBHUSIZZ7FS2OMLZVZ4HLWJMXQ336NFSXHYERD7GG54NRITDTEWWBBI6");
     assertEquals(operation.getAmount(), "1000000000.0");
-    assertEquals(operation.getAsset(), Asset.createNonNativeAsset("EUR", "GAZN3PPIDQCSP5JD4ETQQQ2IU2RMFYQTAL4NNQZUGLLO2XJJJ3RDSDGA"));
+    assertEquals(operation.getAsset(), create(null,"EUR", "GAZN3PPIDQCSP5JD4ETQQQ2IU2RMFYQTAL4NNQZUGLLO2XJJJ3RDSDGA"));
   }
 
   @Test
@@ -240,7 +241,7 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getTrustor(), "GDZ55LVXECRTW4G36EZPTHI4XIYS5JUC33TUS22UOETVFVOQ77JXWY4F");
     assertEquals(operation.isAuthorize(), true);
     assertEquals(operation.isAuthorizedToMaintainLiabilities(), false);
-    assertEquals(operation.getAsset(), Asset.createNonNativeAsset("EUR", "GDIROJW2YHMSFZJJ4R5XWWNUVND5I45YEWS5DSFKXCHMADZ5V374U2LM"));
+    assertEquals(operation.getAsset(), create(null,"EUR", "GDIROJW2YHMSFZJJ4R5XWWNUVND5I45YEWS5DSFKXCHMADZ5V374U2LM"));
     assertFalse(operation.getTrusteeMuxed().isPresent());
   }
 
@@ -329,7 +330,7 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getTrustor(), "GDZ55LVXECRTW4G36EZPTHI4XIYS5JUC33TUS22UOETVFVOQ77JXWY4F");
     assertEquals(operation.isAuthorize(), false);
     assertEquals(operation.isAuthorizedToMaintainLiabilities(), true);
-    assertEquals(operation.getAsset(), Asset.createNonNativeAsset("EUR", "GDIROJW2YHMSFZJJ4R5XWWNUVND5I45YEWS5DSFKXCHMADZ5V374U2LM"));
+    assertEquals(operation.getAsset(), create(null,"EUR", "GDIROJW2YHMSFZJJ4R5XWWNUVND5I45YEWS5DSFKXCHMADZ5V374U2LM"));
   }
 
   @Test
@@ -371,7 +372,7 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getTrustee(), "GDIROJW2YHMSFZJJ4R5XWWNUVND5I45YEWS5DSFKXCHMADZ5V374U2LM");
     assertEquals(operation.getTrustor(), "GDZ55LVXECRTW4G36EZPTHI4XIYS5JUC33TUS22UOETVFVOQ77JXWY4F");
     assertEquals(operation.getLimit(), "922337203685.4775807");
-    assertEquals(operation.getAsset(), Asset.createNonNativeAsset("EUR", "GDIROJW2YHMSFZJJ4R5XWWNUVND5I45YEWS5DSFKXCHMADZ5V374U2LM"));
+    assertEquals(operation.getAsset(), create(null,"EUR", "GDIROJW2YHMSFZJJ4R5XWWNUVND5I45YEWS5DSFKXCHMADZ5V374U2LM"));
     assertFalse(operation.getTrustorMuxed().isPresent());
   }
 
@@ -679,7 +680,7 @@ public class OperationDeserializerTest extends TestCase {
 
     assertEquals(operation.getOfferId(), Long.valueOf(0));
     assertEquals(operation.getAmount(), "100.0");
-    assertEquals(operation.getBuyingAsset(), Asset.createNonNativeAsset("CNY", "GAZWSWPDQTBHFIPBY4FEDFW2J6E2LE7SZHJWGDZO6Q63W7DBSRICO2KN"));
+    assertEquals(operation.getBuyingAsset(), create(null,"CNY", "GAZWSWPDQTBHFIPBY4FEDFW2J6E2LE7SZHJWGDZO6Q63W7DBSRICO2KN"));
     assertEquals(operation.getSellingAsset(), new AssetTypeNative());
   }
 
@@ -732,10 +733,10 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getAsset(), new AssetTypeNative());
     assertEquals(operation.getPath(), ImmutableList.<Asset>of(
             new AssetTypeNative(),
-            Asset.createNonNativeAsset("CNY", "GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX"),
-            Asset.createNonNativeAsset("CNYMNL", "GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX")
+            create(null,"CNY", "GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX"),
+            create(null,"CNYMNL", "GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX")
     ));
-    assertEquals(operation.getSourceAsset(), Asset.createNonNativeAsset("XRP", "GBVOL67TMUQBGL4TZYNMY3ZQ5WGQYFPFD5VJRWXR72VA33VFNL225PL5"));
+    assertEquals(operation.getSourceAsset(), create(null,"XRP", "GBVOL67TMUQBGL4TZYNMY3ZQ5WGQYFPFD5VJRWXR72VA33VFNL225PL5"));
   }
 
   @Test
@@ -790,10 +791,10 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getAsset(), new AssetTypeNative());
     assertEquals(operation.getPath(), ImmutableList.<Asset>of(
             new AssetTypeNative(),
-            Asset.createNonNativeAsset("CNY", "GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX"),
-            Asset.createNonNativeAsset("CNYMNL", "GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX")
+            create(null,"CNY", "GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX"),
+            create(null,"CNYMNL", "GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX")
     ));
-    assertEquals(operation.getSourceAsset(), Asset.createNonNativeAsset("XRP", "GBVOL67TMUQBGL4TZYNMY3ZQ5WGQYFPFD5VJRWXR72VA33VFNL225PL5"));
+    assertEquals(operation.getSourceAsset(), create(null,"XRP", "GBVOL67TMUQBGL4TZYNMY3ZQ5WGQYFPFD5VJRWXR72VA33VFNL225PL5"));
   }
 
   @Test
@@ -900,7 +901,7 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getSourceMax(), "1.1779523");
     assertEquals(operation.getSourceAsset(), new AssetTypeNative());
     assertEquals(operation.getPath(), ImmutableList.<Asset>of());
-    assertEquals(operation.getAsset(), Asset.createNonNativeAsset("XRP", "GBVOL67TMUQBGL4TZYNMY3ZQ5WGQYFPFD5VJRWXR72VA33VFNL225PL5"));
+    assertEquals(operation.getAsset(), create(null,"XRP", "GBVOL67TMUQBGL4TZYNMY3ZQ5WGQYFPFD5VJRWXR72VA33VFNL225PL5"));
   }
 
   @Test
@@ -1268,7 +1269,7 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getId().longValue(), 12884914177L);
     assertEquals(operation.getFrom(), "GDPFGP4IPE5DXG6XRXC4ZBUI43PAGRQ5VVNJ3LJTBXDBZ4ITO6HBHNSF");
     assertEquals(operation.getType(), "clawback");
-    assertEquals(operation.getAsset(), Asset.createNonNativeAsset("EUR", "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS"));
+    assertEquals(operation.getAsset(), create(null,"EUR", "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS"));
     assertEquals(operation.getAssetIssuer(), "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS");
     assertEquals(operation.getAssetCode(), "EUR");
     assertEquals(operation.getAssetType(), "credit_alphanum4");
@@ -1366,7 +1367,7 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getId().longValue(), 12884914177L);
     assertEquals(operation.getTrustor(), "GDPFGP4IPE5DXG6XRXC4ZBUI43PAGRQ5VVNJ3LJTBXDBZ4ITO6HBHNSF");
     assertEquals(operation.getType(), "set_trust_line_flags");
-    assertEquals(operation.getAsset(), Asset.createNonNativeAsset("EUR", "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS"));
+    assertEquals(operation.getAsset(), create(null,"EUR", "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS"));
     assertEquals(operation.getAssetIssuer(), "GCWVFBJ24754I5GXG4JOEB72GJCL3MKWC7VAEYWKGQHPVH3ENPNBSKWS");
     assertEquals(operation.getAssetCode(), "EUR");
     assertEquals(operation.getAssetType(), "credit_alphanum4");
@@ -1449,12 +1450,12 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getMinPrice(), "53.4759358");
     assertEquals(operation.getMinPriceR(), new Price(10000, 187));
     assertTrue(Arrays.equals(operation.getReservesDeposited(), new AssetAmount[]{
-        new AssetAmount(Asset.create("ARST:GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"), "10000.0000000"),
-        new AssetAmount(Asset.create("USDC:GC5W3BH2MQRQK2H4A6LP3SXDSAAY2W2W64OWKKVNQIAOVWSAHFDEUSDC"), "187.0000000")
+        new AssetAmount(create("ARST:GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"), "10000.0000000"),
+        new AssetAmount(create("USDC:GC5W3BH2MQRQK2H4A6LP3SXDSAAY2W2W64OWKKVNQIAOVWSAHFDEUSDC"), "187.0000000")
     }));
     assertTrue(Arrays.equals(operation.getReservesMax(), new AssetAmount[]{
-        new AssetAmount(Asset.create("ARST:GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"), "10000.0000000"),
-        new AssetAmount(Asset.create("USDC:GC5W3BH2MQRQK2H4A6LP3SXDSAAY2W2W64OWKKVNQIAOVWSAHFDEUSDC"), "187.0000000")
+        new AssetAmount(create("ARST:GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"), "10000.0000000"),
+        new AssetAmount(create("USDC:GC5W3BH2MQRQK2H4A6LP3SXDSAAY2W2W64OWKKVNQIAOVWSAHFDEUSDC"), "187.0000000")
     }));
   }
 
@@ -1517,13 +1518,13 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getShares(), "1367.4794331");
     assertEquals(operation.getLiquidityPoolId().toString(), "1df1380108ca32e96650074db1f3e1e10541ab8768c9eba7ec3b6f9315f9faee");
     assertTrue(Arrays.equals(operation.getReservesMin(), new AssetAmount[]{
-        new AssetAmount(Asset.create("ARST:GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"), "10000.0000000"),
-        new AssetAmount(Asset.create("USDC:GC5W3BH2MQRQK2H4A6LP3SXDSAAY2W2W64OWKKVNQIAOVWSAHFDEUSDC"), "187.0000000")
+        new AssetAmount(create("ARST:GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"), "10000.0000000"),
+        new AssetAmount(create("USDC:GC5W3BH2MQRQK2H4A6LP3SXDSAAY2W2W64OWKKVNQIAOVWSAHFDEUSDC"), "187.0000000")
         }
     ));
     assertTrue(Arrays.equals(operation.getReservesReceived(), new AssetAmount[]{
-        new AssetAmount(Asset.create("ARST:GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"), "10000.0000000"),
-        new AssetAmount(Asset.create("USDC:GC5W3BH2MQRQK2H4A6LP3SXDSAAY2W2W64OWKKVNQIAOVWSAHFDEUSDC"), "187.0000000")
+        new AssetAmount(create("ARST:GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO"), "10000.0000000"),
+        new AssetAmount(create("USDC:GC5W3BH2MQRQK2H4A6LP3SXDSAAY2W2W64OWKKVNQIAOVWSAHFDEUSDC"), "187.0000000")
         }
     ));
   }

--- a/src/test/java/org/stellar/sdk/responses/OrderBookDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/OrderBookDeserializerTest.java
@@ -6,13 +6,15 @@ import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
 import org.stellar.sdk.KeyPair;
 
+import static org.stellar.sdk.Asset.create;
+
 public class OrderBookDeserializerTest extends TestCase {
     @Test
     public void testDeserialize() {
         OrderBookResponse orderBook = GsonSingleton.getInstance().fromJson(json, OrderBookResponse.class);
 
         assertEquals(orderBook.getBase(), new AssetTypeNative());
-        assertEquals(orderBook.getCounter(), Asset.createNonNativeAsset("DEMO", "GBAMBOOZDWZPVV52RCLJQYMQNXOBLOXWNQAY2IF2FREV2WL46DBCH3BE"));
+        assertEquals(orderBook.getCounter(), create(null,"DEMO", "GBAMBOOZDWZPVV52RCLJQYMQNXOBLOXWNQAY2IF2FREV2WL46DBCH3BE"));
 
         assertEquals(orderBook.getBids()[0].getAmount(), "31.4007644");
         assertEquals(orderBook.getBids()[0].getPrice(), "0.0024224");

--- a/src/test/java/org/stellar/sdk/responses/PathsPageDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/PathsPageDeserializerTest.java
@@ -13,6 +13,7 @@ import java.net.URISyntaxException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.stellar.sdk.ChangeTrustAsset.create;
 
 public class PathsPageDeserializerTest {
 
@@ -24,25 +25,25 @@ public class PathsPageDeserializerTest {
     assertNull(pathsPage.getNextPage(new OkHttpClient()));
 
     assertEquals(pathsPage.getRecords().get(0).getDestinationAmount(), "20.0000000");
-    Assert.assertEquals(pathsPage.getRecords().get(0).getDestinationAsset(), Asset.createNonNativeAsset("EUR", "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN"));
+    Assert.assertEquals(pathsPage.getRecords().get(0).getDestinationAsset(), create(null,"EUR", "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN"));
     assertEquals(pathsPage.getRecords().get(0).getPath().size(), 0);
     assertEquals(pathsPage.getRecords().get(0).getSourceAmount(), "30.0000000");
-    assertEquals(pathsPage.getRecords().get(0).getSourceAsset(), Asset.createNonNativeAsset("USD", "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN"));
+    assertEquals(pathsPage.getRecords().get(0).getSourceAsset(), create(null,"USD", "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN"));
 
     assertEquals(pathsPage.getRecords().get(1).getDestinationAmount(), "50.0000000");
-    assertEquals(pathsPage.getRecords().get(1).getDestinationAsset(), Asset.createNonNativeAsset("EUR", "GBFMFKDUFYYITWRQXL4775CVUV3A3WGGXNJUAP4KTXNEQ2HG7JRBITGH"));
+    assertEquals(pathsPage.getRecords().get(1).getDestinationAsset(), create(null,"EUR", "GBFMFKDUFYYITWRQXL4775CVUV3A3WGGXNJUAP4KTXNEQ2HG7JRBITGH"));
     assertEquals(pathsPage.getRecords().get(1).getPath().size(), 1);
-    assertEquals(pathsPage.getRecords().get(1).getPath().get(0), Asset.createNonNativeAsset("GBP", "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN"));
+    assertEquals(pathsPage.getRecords().get(1).getPath().get(0), create(null,"GBP", "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN"));
     assertEquals(pathsPage.getRecords().get(1).getSourceAmount(), "60.0000000");
-    assertEquals(pathsPage.getRecords().get(1).getSourceAsset(), Asset.createNonNativeAsset("USD", "GBRAOXQDNQZRDIOK64HZI4YRDTBFWNUYH3OIHQLY4VEK5AIGMQHCLGXI"));
+    assertEquals(pathsPage.getRecords().get(1).getSourceAsset(), create(null,"USD", "GBRAOXQDNQZRDIOK64HZI4YRDTBFWNUYH3OIHQLY4VEK5AIGMQHCLGXI"));
 
     assertEquals(pathsPage.getRecords().get(2).getDestinationAmount(), "200.0000000");
-    assertEquals(pathsPage.getRecords().get(2).getDestinationAsset(), Asset.createNonNativeAsset("EUR", "GBRCOBK7C7UE72PB5JCPQU3ZI45ZCEM7HKQ3KYV3YD3XB7EBOPBEDN2G"));
+    assertEquals(pathsPage.getRecords().get(2).getDestinationAsset(), create(null,"EUR", "GBRCOBK7C7UE72PB5JCPQU3ZI45ZCEM7HKQ3KYV3YD3XB7EBOPBEDN2G"));
     assertEquals(pathsPage.getRecords().get(2).getPath().size(), 2);
-    assertEquals(pathsPage.getRecords().get(2).getPath().get(0), Asset.createNonNativeAsset("GBP", "GAX7B3ZT3EOZW5POAMV4NGPPKCYUOYW2QQDIAF23JAXF72NMGRYPYOPM"));
-    assertEquals(pathsPage.getRecords().get(2).getPath().get(1), Asset.createNonNativeAsset("PLN", "GACWIA2XGDFWWN3WKPX63JTK4S2J5NDPNOIVYMZY6RVTS7LWF2VHZLV3"));
+    assertEquals(pathsPage.getRecords().get(2).getPath().get(0), create(null,"GBP", "GAX7B3ZT3EOZW5POAMV4NGPPKCYUOYW2QQDIAF23JAXF72NMGRYPYOPM"));
+    assertEquals(pathsPage.getRecords().get(2).getPath().get(1), create(null,"PLN", "GACWIA2XGDFWWN3WKPX63JTK4S2J5NDPNOIVYMZY6RVTS7LWF2VHZLV3"));
     assertEquals(pathsPage.getRecords().get(2).getSourceAmount(), "300.0000000");
-    assertEquals(pathsPage.getRecords().get(2).getSourceAsset(), Asset.createNonNativeAsset("USD", "GC7J5IHS3GABSX7AZLRINXWLHFTL3WWXLU4QX2UGSDEAIAQW2Q72U3KH"));
+    assertEquals(pathsPage.getRecords().get(2).getSourceAsset(), create(null,"USD", "GC7J5IHS3GABSX7AZLRINXWLHFTL3WWXLU4QX2UGSDEAIAQW2Q72U3KH"));
   }
 
   String json = "{\n" +

--- a/src/test/java/org/stellar/sdk/responses/PathsPageDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/PathsPageDeserializerTest.java
@@ -1,19 +1,16 @@
 package org.stellar.sdk.responses;
 
 import com.google.gson.reflect.TypeToken;
-
 import okhttp3.OkHttpClient;
 import org.junit.Assert;
 import org.junit.Test;
-import org.stellar.sdk.Asset;
-import org.stellar.sdk.KeyPair;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.stellar.sdk.ChangeTrustAsset.create;
+import static org.stellar.sdk.Asset.create;
 
 public class PathsPageDeserializerTest {
 

--- a/src/test/java/org/stellar/sdk/responses/TradesPageDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/TradesPageDeserializerTest.java
@@ -4,10 +4,10 @@ import com.google.common.base.Optional;
 import com.google.gson.reflect.TypeToken;
 import junit.framework.TestCase;
 import org.junit.Test;
-import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeNative;
 
 import static java.lang.Long.valueOf;
+import static org.stellar.sdk.Asset.create;
 
 public class TradesPageDeserializerTest extends TestCase {
     @Test
@@ -25,7 +25,7 @@ public class TradesPageDeserializerTest extends TestCase {
         assertEquals(tradesPage.getRecords().get(0).getBaseOfferId(), Optional.of(valueOf(10)));
         assertEquals(tradesPage.getRecords().get(0).getCounterOfferId(), Optional.of(valueOf(11)));
         assertEquals(tradesPage.getRecords().get(0).getBaseAsset(), new AssetTypeNative());
-        assertEquals(tradesPage.getRecords().get(0).getCounterAsset(), Asset.createNonNativeAsset("JPY", "GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM"));
+        assertEquals(tradesPage.getRecords().get(0).getCounterAsset(), create(null,"JPY", "GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM"));
         assertEquals(tradesPage.getRecords().get(0).getPrice().getNumerator(), valueOf(267));
         assertEquals(tradesPage.getRecords().get(0).getPrice().getDenominator(), valueOf(1000));
 


### PR DESCRIPTION
checked for Asset representation(native, alpha4, alpha12, pool share) consistency for any API operation/effect resource that may have possibility of holding an Asset resource which refers to liquidity pool shares via `liquidity_pool_id` and does not contain the usual non-native alpha4 or alpha12 attributes of `asset_code` and `asset_issuer`, these are the resources identified:

`
TrustlineCreatedEffectReponse
TrustlineUpdatedEffectResponse
TrustlineRemovedEffectResponse
ChangeTrustOperationResponse
`

I refactored the Asset class to provide a bit more asset-type agnostic factory methods for generating Assets which derive the type(i.e. class model), so callers do not need to have same know-how.

closes #396 