### PR TITLE
Support muxed accounts by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 ### Breaking changes
 * org.stellar.sdk.Asset.createNonNativeAsset() is now private. ([#398](https://github.com/stellar/java-stellar-sdk/pull/398)).
 * org.stellar.sdk.responses.effects.TrustlineCUDResponse, removed non-default public constructor, it wasn't needed. ([#398](https://github.com/stellar/java-stellar-sdk/pull/398)).
+* Muxed accounts are now supported by default. Previously we added opt in support for muxed accounts. But now we are changing the default behavior so that muxed accounts are rendered using their 'M' address encoding ([#399](https://github.com/stellar/java-stellar-sdk/pull/399)).
 
 ## 0.30.0
 

--- a/src/main/java/org/stellar/sdk/AbstractTransaction.java
+++ b/src/main/java/org/stellar/sdk/AbstractTransaction.java
@@ -126,7 +126,7 @@ public abstract class AbstractTransaction {
    * @return
    */
   public static AbstractTransaction fromEnvelopeXdr(TransactionEnvelope envelope, Network network) {
-    return fromEnvelopeXdr(AccountConverter.disableMuxed(), envelope, network);
+    return fromEnvelopeXdr(AccountConverter.enableMuxed(), envelope, network);
   }
 
   /**
@@ -150,7 +150,7 @@ public abstract class AbstractTransaction {
    * @throws IOException
    */
   public static AbstractTransaction fromEnvelopeXdr(String envelope, Network network) throws IOException {
-    return fromEnvelopeXdr(AccountConverter.disableMuxed(), envelope, network);
+    return fromEnvelopeXdr(AccountConverter.enableMuxed(), envelope, network);
   }
 
   public static byte[] getTransactionSignatureBase(TransactionSignaturePayload.TransactionSignaturePayloadTaggedTransaction taggedTransaction,

--- a/src/main/java/org/stellar/sdk/FeeBumpTransaction.java
+++ b/src/main/java/org/stellar/sdk/FeeBumpTransaction.java
@@ -49,7 +49,7 @@ public class FeeBumpTransaction extends AbstractTransaction {
   }
 
   public static FeeBumpTransaction fromFeeBumpTransactionEnvelope(FeeBumpTransactionEnvelope envelope, Network network) {
-    return fromFeeBumpTransactionEnvelope(AccountConverter.disableMuxed(), envelope, network);
+    return fromFeeBumpTransactionEnvelope(AccountConverter.enableMuxed(), envelope, network);
   }
 
     private org.stellar.sdk.xdr.FeeBumpTransaction toXdr() {
@@ -140,7 +140,7 @@ public class FeeBumpTransaction extends AbstractTransaction {
      * @param inner The inner transaction which will be fee bumped.
      */
     public Builder(Transaction inner) {
-      this(AccountConverter.disableMuxed(), inner);
+      this(AccountConverter.enableMuxed(), inner);
     }
 
     public FeeBumpTransaction.Builder setBaseFee(long baseFee) {

--- a/src/main/java/org/stellar/sdk/Operation.java
+++ b/src/main/java/org/stellar/sdk/Operation.java
@@ -47,7 +47,7 @@ public abstract class Operation {
    * Generates Operation XDR object.
    */
   public org.stellar.sdk.xdr.Operation toXdr() {
-    return toXdr(AccountConverter.disableMuxed());
+    return toXdr(AccountConverter.enableMuxed());
   }
 
   /**
@@ -70,7 +70,7 @@ public abstract class Operation {
    * Returns base64-encoded Operation XDR object.
    */
   public String toXdrBase64() {
-    return toXdrBase64(AccountConverter.disableMuxed());
+    return toXdrBase64(AccountConverter.enableMuxed());
   }
 
 
@@ -199,7 +199,7 @@ public abstract class Operation {
    * @param xdr XDR object
    */
   public static Operation fromXdr(org.stellar.sdk.xdr.Operation xdr) {
-    return fromXdr(AccountConverter.disableMuxed(), xdr);
+    return fromXdr(AccountConverter.enableMuxed(), xdr);
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/Sep10Challenge.java
+++ b/src/main/java/org/stellar/sdk/Sep10Challenge.java
@@ -88,7 +88,7 @@ public class Sep10Challenge {
         .setSourceAccount(sourceAccount.getAccountId())
         .build();
 
-    Transaction.Builder builder = new Transaction.Builder(AccountConverter.disableMuxed(), sourceAccount, network)
+    Transaction.Builder builder = new Transaction.Builder(AccountConverter.enableMuxed(), sourceAccount, network)
         .addTimeBounds(timebounds)
         .setBaseFee(100)
         .addOperation(domainNameOperation)
@@ -137,7 +137,7 @@ public class Sep10Challenge {
     }
 
     // decode the received input as a base64-urlencoded XDR representation of Stellar transaction envelope
-    AbstractTransaction parsed = Transaction.fromEnvelopeXdr(AccountConverter.disableMuxed(), challengeXdr, network);
+    AbstractTransaction parsed = Transaction.fromEnvelopeXdr(AccountConverter.enableMuxed(), challengeXdr, network);
     if (!(parsed instanceof Transaction)) {
       throw new InvalidSep10ChallengeException("Transaction cannot be a fee bump transaction");
     }

--- a/src/main/java/org/stellar/sdk/Transaction.java
+++ b/src/main/java/org/stellar/sdk/Transaction.java
@@ -145,7 +145,7 @@ public class Transaction extends AbstractTransaction {
     // operations
     org.stellar.sdk.xdr.Operation[] operations = new org.stellar.sdk.xdr.Operation[mOperations.length];
     for (int i = 0; i < mOperations.length; i++) {
-      operations[i] = mOperations[i].toXdr(AccountConverter.disableMuxed());
+      operations[i] = mOperations[i].toXdr(AccountConverter.enableMuxed());
     }
     // ext
     TransactionV0.TransactionV0Ext ext = new TransactionV0.TransactionV0Ext();
@@ -223,7 +223,7 @@ public class Transaction extends AbstractTransaction {
   }
 
   public static Transaction fromV0EnvelopeXdr(TransactionV0Envelope envelope, Network network) {
-    return fromV0EnvelopeXdr(AccountConverter.disableMuxed(), envelope, network);
+    return fromV0EnvelopeXdr(AccountConverter.enableMuxed(), envelope, network);
   }
 
   public static Transaction fromV1EnvelopeXdr(AccountConverter accountConverter, TransactionV1Envelope envelope, Network network) {
@@ -254,7 +254,7 @@ public class Transaction extends AbstractTransaction {
   }
 
   public static Transaction fromV1EnvelopeXdr(TransactionV1Envelope envelope, Network network) {
-    return fromV1EnvelopeXdr(AccountConverter.disableMuxed(), envelope, network);
+    return fromV1EnvelopeXdr(AccountConverter.enableMuxed(), envelope, network);
   }
 
     /**
@@ -320,7 +320,7 @@ public class Transaction extends AbstractTransaction {
      * will be incremented.
      */
     public Builder(TransactionBuilderAccount sourceAccount, Network network) {
-      this(AccountConverter.disableMuxed(), sourceAccount, network);
+      this(AccountConverter.enableMuxed(), sourceAccount, network);
     }
     
     public int getOperationsCount() {

--- a/src/test/java/org/stellar/sdk/OperationTest.java
+++ b/src/test/java/org/stellar/sdk/OperationTest.java
@@ -90,9 +90,9 @@ public class OperationTest {
         assertEquals(destination, parsedOperation.getDestination());
         assertEquals(source, parsedOperation.getSourceAccount());
 
-        parsedOperation = (PaymentOperation) Operation.fromXdr(AccountConverter.disableMuxed(), xdr);
-        assertEquals("GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3", parsedOperation.getDestination());
-        assertEquals("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ", parsedOperation.getSourceAccount());
+        parsedOperation = (PaymentOperation) Operation.fromXdr(AccountConverter.enableMuxed(), xdr);
+        assertEquals("MDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKAAAAAAMV7V2XYGQO", parsedOperation.getDestination());
+        assertEquals("MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK", parsedOperation.getSourceAccount());
     }
 
     @Test
@@ -200,9 +200,9 @@ public class OperationTest {
         assertEquals(destination, parsedOperation.getDestination());
         assertEquals(source, parsedOperation.getSourceAccount());
 
-        parsedOperation = (PathPaymentStrictReceiveOperation) Operation.fromXdr(AccountConverter.disableMuxed(), xdr);
-        assertEquals("GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3", parsedOperation.getDestination());
-        assertEquals("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ", parsedOperation.getSourceAccount());
+        parsedOperation = (PathPaymentStrictReceiveOperation) Operation.fromXdr(AccountConverter.enableMuxed(), xdr);
+        assertEquals("MDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKAAAAAAMV7V2XYGQO", parsedOperation.getDestination());
+        assertEquals("MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK", parsedOperation.getSourceAccount());
     }
 
     @Test
@@ -316,9 +316,9 @@ public class OperationTest {
         assertEquals(destination, parsedOperation.getDestination());
         assertEquals(source, parsedOperation.getSourceAccount());
 
-        parsedOperation = (PathPaymentStrictSendOperation) Operation.fromXdr(AccountConverter.disableMuxed(), xdr);
-        assertEquals("GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3", parsedOperation.getDestination());
-        assertEquals("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ", parsedOperation.getSourceAccount());
+        parsedOperation = (PathPaymentStrictSendOperation) Operation.fromXdr(AccountConverter.enableMuxed(), xdr);
+        assertEquals("MDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKAAAAAAMV7V2XYGQO", parsedOperation.getDestination());
+        assertEquals("MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK", parsedOperation.getSourceAccount());
     }
 
     @Test
@@ -729,9 +729,9 @@ public class OperationTest {
         assertEquals(destination, parsedOperation.getDestination());
         assertEquals(source, parsedOperation.getSourceAccount());
 
-        parsedOperation = (AccountMergeOperation) Operation.fromXdr(AccountConverter.disableMuxed(), xdr);
-        assertEquals("GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3", parsedOperation.getDestination());
-        assertEquals("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ", parsedOperation.getSourceAccount());
+        parsedOperation = (AccountMergeOperation) Operation.fromXdr(AccountConverter.enableMuxed(), xdr);
+        assertEquals("MDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKAAAAAAMV7V2XYGQO", parsedOperation.getDestination());
+        assertEquals("MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK", parsedOperation.getSourceAccount());
     }
 
     @Test
@@ -1044,9 +1044,9 @@ public class OperationTest {
         assertEquals(from, parsedOperation.getFrom());
         assertEquals(source, parsedOperation.getSourceAccount());
 
-        parsedOperation = (ClawbackOperation) Operation.fromXdr(AccountConverter.disableMuxed(), xdr);
-        assertEquals("GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3", parsedOperation.getFrom());
-        assertEquals("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ", parsedOperation.getSourceAccount());
+        parsedOperation = (ClawbackOperation) Operation.fromXdr(AccountConverter.enableMuxed(), xdr);
+        assertEquals("MDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKAAAAAAMV7V2XYGQO", parsedOperation.getFrom());
+        assertEquals("MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK", parsedOperation.getSourceAccount());
     }
 
     @Test
@@ -1064,9 +1064,9 @@ public class OperationTest {
         assertEquals(from, parsedOperation.getFrom());
         assertEquals(source, parsedOperation.getSourceAccount());
 
-        parsedOperation = (ClawbackOperation) Operation.fromXdr(AccountConverter.disableMuxed(), xdr);
+        parsedOperation = (ClawbackOperation) Operation.fromXdr(AccountConverter.enableMuxed(), xdr);
         assertEquals(from, parsedOperation.getFrom());
-        assertEquals("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ", parsedOperation.getSourceAccount());
+        assertEquals("MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK", parsedOperation.getSourceAccount());
     }
 
     @Test


### PR DESCRIPTION
Previously, in https://github.com/stellar/java-stellar-sdk/pull/348 we added opt in support for muxed.
But, by default, we rendered muxed accounts in their non muxed encoding.
We are now changing the default behavior so that muxed accounts are rendered using ther 'M' address encoding.

Fixes https://github.com/stellar/java-stellar-sdk/issues/397