### PR TITLE
fix AccountResponse().getAsset() NullPointerException

### DIFF
--- a/src/main/java/org/stellar/sdk/responses/AccountResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/AccountResponse.java
@@ -238,7 +238,11 @@ public class AccountResponse extends Response implements org.stellar.sdk.Transac
     }
 
     public Optional<Asset> getAsset() {
-      return Optional.of(create(assetType, assetCode, assetIssuer, liquidityPoolID.toString()));
+      if (liquidityPoolID != null) {
+        return Optional.of(create(assetType, assetCode, assetIssuer, liquidityPoolID.toString()));
+      } else {
+        return Optional.of(create(assetType, assetCode, assetIssuer));
+      }
     }
 
     public String getAssetType() {

--- a/src/test/java/org/stellar/sdk/responses/AccountDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/AccountDeserializerTest.java
@@ -4,6 +4,9 @@ import com.google.common.base.Optional;
 import junit.framework.TestCase;
 
 import org.junit.Test;
+import org.stellar.sdk.Asset;
+import org.stellar.sdk.AssetTypeCreditAlphaNum4;
+import org.stellar.sdk.AssetTypeNative;
 
 import java.util.Arrays;
 
@@ -15,6 +18,7 @@ public class AccountDeserializerTest extends TestCase {
     assertEquals(account.getBalances()[0].getAssetType(), "credit_alphanum4");
     assertEquals(account.getBalances()[0].getAssetCode(), Optional.of("ABC"));
     assertEquals(account.getBalances()[0].getAssetIssuer(), Optional.of("GCRA6COW27CY5MTKIA7POQ2326C5ABYCXODBN4TFF5VL4FMBRHOT3YHU"));
+    assertEquals(account.getBalances()[0].getAsset(), Optional.of(new AssetTypeCreditAlphaNum4("ABC", "GCRA6COW27CY5MTKIA7POQ2326C5ABYCXODBN4TFF5VL4FMBRHOT3YHU")));
     assertEquals(account.getBalances()[0].getBalance(), "1001.0000000");
     assertEquals(account.getBalances()[0].getLimit(), "12000.4775807");
     assertEquals(account.getBalances()[0].getBuyingLiabilities(), Optional.of("100.1234567"));
@@ -23,6 +27,7 @@ public class AccountDeserializerTest extends TestCase {
     assertEquals(account.getBalances()[0].getAuthorizedToMaintainLiabilities(), Boolean.TRUE);
 
     assertEquals(account.getBalances()[1].getAssetType(), "native");
+    assertEquals(account.getBalances()[1].getAsset(), Optional.of(new AssetTypeNative()));
     assertEquals(account.getBalances()[1].getBalance(), "20.0000300");
     assertEquals(account.getBalances()[1].getBuyingLiabilities(), Optional.of("5.1234567"));
     assertEquals(account.getBalances()[1].getSellingLiabilities(), Optional.of("1.7654321"));
@@ -50,6 +55,7 @@ public class AccountDeserializerTest extends TestCase {
     assertEquals(account.getBalances()[0].getAssetType(), "credit_alphanum4");
     assertEquals(account.getBalances()[0].getAssetCode(), Optional.of("ABC"));
     assertEquals(account.getBalances()[0].getAssetIssuer(), Optional.of("GCRA6COW27CY5MTKIA7POQ2326C5ABYCXODBN4TFF5VL4FMBRHOT3YHU"));
+    assertEquals(account.getBalances()[0].getAsset(), Optional.of(new AssetTypeCreditAlphaNum4("ABC", "GCRA6COW27CY5MTKIA7POQ2326C5ABYCXODBN4TFF5VL4FMBRHOT3YHU")));
     assertEquals(account.getBalances()[0].getBalance(), "1001.0000000");
     assertEquals(account.getBalances()[0].getLimit(), "12000.4775807");
     assertEquals(account.getBalances()[0].getBuyingLiabilities(), Optional.of("100.1234567"));
@@ -57,6 +63,7 @@ public class AccountDeserializerTest extends TestCase {
     assertFalse(account.getBalances()[0].getSponsor().isPresent());
 
     assertEquals(account.getBalances()[1].getAssetType(), "native");
+    assertEquals(account.getBalances()[1].getAsset(), Optional.of(new AssetTypeNative()));
     assertEquals(account.getBalances()[1].getBalance(), "20.0000300");
     assertEquals(account.getBalances()[1].getBuyingLiabilities(), Optional.of("5.1234567"));
     assertEquals(account.getBalances()[1].getSellingLiabilities(), Optional.of("1.7654321"));
@@ -104,12 +111,14 @@ public class AccountDeserializerTest extends TestCase {
     assertEquals(account.getBalances()[0].getAssetType(), "credit_alphanum4");
     assertEquals(account.getBalances()[0].getAssetCode(), Optional.of("ABC"));
     assertEquals(account.getBalances()[0].getAssetIssuer(), Optional.of("GCRA6COW27CY5MTKIA7POQ2326C5ABYCXODBN4TFF5VL4FMBRHOT3YHU"));
+    assertEquals(account.getBalances()[0].getAsset(), Optional.of(new AssetTypeCreditAlphaNum4("ABC", "GCRA6COW27CY5MTKIA7POQ2326C5ABYCXODBN4TFF5VL4FMBRHOT3YHU")));
     assertEquals(account.getBalances()[0].getBalance(), "1001.0000000");
     assertEquals(account.getBalances()[0].getLimit(), "12000.4775807");
     assertEquals(account.getBalances()[0].getBuyingLiabilities(), Optional.absent());
     assertEquals(account.getBalances()[0].getSellingLiabilities(), Optional.absent());
 
     assertEquals(account.getBalances()[1].getAssetType(), "native");
+    assertEquals(account.getBalances()[1].getAsset(), Optional.of(new AssetTypeNative()));
     assertEquals(account.getBalances()[1].getBalance(), "20.0000300");
     assertEquals(account.getBalances()[1].getBuyingLiabilities(), Optional.absent());
     assertEquals(account.getBalances()[1].getSellingLiabilities(), Optional.absent());


### PR DESCRIPTION
resolves #405 

Checks `liquidityPoolID` to see if it is `null`, and calls a constructor that doesn't include the `liquidityPoolID` parameter if so.