### PR TITLE
payload signer signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
   * deprecated `addTimeBounds()` use `addPreconditions()` instead
   * deprecated `setTimeout()` use `addPreconditions()` instead
   * deprecated `Transaction.Builder` use TransactionBuilder instead
+* org.stellar.sdk.Transaction
+  * `getSignatures()` returns an ImmutableList of signatures, do NOT add signatures to the collection returned.
+    use `addSignature(DecoratedSignature signature)` instead.
 
 ## 0.31.0
 

--- a/src/main/java/org/stellar/sdk/AbstractTransaction.java
+++ b/src/main/java/org/stellar/sdk/AbstractTransaction.java
@@ -1,7 +1,14 @@
 package org.stellar.sdk;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
-import org.stellar.sdk.xdr.*;
+import org.stellar.sdk.xdr.DecoratedSignature;
+import org.stellar.sdk.xdr.Hash;
+import org.stellar.sdk.xdr.SignatureHint;
+import org.stellar.sdk.xdr.TransactionEnvelope;
+import org.stellar.sdk.xdr.TransactionSignaturePayload;
+import org.stellar.sdk.xdr.XdrDataInputStream;
+import org.stellar.sdk.xdr.XdrDataOutputStream;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -75,13 +82,33 @@ public abstract class AbstractTransaction {
    */
   public abstract byte[] signatureBase();
 
+  /**
+   * Gets the Network string for this transaction.
+   *
+   * @return the Network string
+   */
   public Network getNetwork() {
     return mNetwork;
   }
 
+  /**
+   * Gets read only list(immutable) of the signatures on transaction.
+   *
+   * @return immutable list of signatures
+   */
   public List<DecoratedSignature> getSignatures() {
-    return mSignatures;
+    return ImmutableList.copyOf(mSignatures);
   }
+
+  /**
+   * Adds an additional signature to the transaction's existing list of signatures.
+   *
+   * @param signature the signature to add
+   */
+  public void addSignature(DecoratedSignature signature) {
+    mSignatures.add(signature);
+  }
+
 
   public abstract TransactionEnvelope toEnvelopeXdr();
 

--- a/src/main/java/org/stellar/sdk/KeyPair.java
+++ b/src/main/java/org/stellar/sdk/KeyPair.java
@@ -272,7 +272,7 @@ public class KeyPair {
 
     //XOR the new hint with this keypair's public key hint
     for (int i = 0; i < hint.length; i++) {
-      hint[i] ^= (i < payloadSignature.getHint().getSignatureHint().length ? payloadSignature.getHint().getSignatureHint()[i] : 0);
+      hint[i] ^= payloadSignature.getHint().getSignatureHint()[i];
     }
     payloadSignature.getHint().setSignatureHint(hint);
     return payloadSignature;

--- a/src/test/java/org/stellar/sdk/KeyPairTest.java
+++ b/src/test/java/org/stellar/sdk/KeyPairTest.java
@@ -98,11 +98,7 @@ public class KeyPairTest {
 
     byte[] payload = new byte[]{1,2,3,4,5};
     DecoratedSignature sig = keypair.signPayloadDecorated(payload);
-    Assert.assertArrayEquals(sig.getHint().getSignatureHint(), new byte[]{
-            (byte)(0xFF & 252),
-            (byte)(0xFF & 65),
-            (byte)(0),
-            (byte)(0xFF & 50)});
+    Assert.assertArrayEquals(sig.getHint().getSignatureHint(), new byte[]{(byte)(0xFF & 252), 65, 0, 50});
 
   }
 
@@ -114,11 +110,6 @@ public class KeyPairTest {
     byte[] payload = new byte[]{1,2,3};
     DecoratedSignature sig = keypair.signPayloadDecorated(payload);
     // the hint could only be derived off of 3 bytes from payload
-    Assert.assertArrayEquals(sig.getHint().getSignatureHint(), new byte[]{
-            (byte)(255),
-            (byte)(0xFF & 64),
-            (byte)(0xFF & 7),
-            (byte)(0xFF & 55)});
-
+    Assert.assertArrayEquals(sig.getHint().getSignatureHint(), new byte[]{(byte)(255), 64, 7, 55});
   }
 }

--- a/src/test/java/org/stellar/sdk/KeyPairTest.java
+++ b/src/test/java/org/stellar/sdk/KeyPairTest.java
@@ -2,11 +2,15 @@ package org.stellar.sdk;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.stellar.sdk.xdr.DecoratedSignature;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class KeyPairTest {
 
@@ -85,5 +89,36 @@ public class KeyPairTest {
     } catch (RuntimeException e) {
       assertEquals("KeyPair does not contain secret key. Use KeyPair.fromSecretSeed method to create a new KeyPair with a secret key.", e.getMessage());
     }
+  }
+
+  @Test
+  public void testSignPayloadSigner() {
+    KeyPair keypair = KeyPair.fromSecretSeed(Util.hexToBytes(SEED));
+    // the hint from this keypair is [254,66,4,55]
+
+    byte[] payload = new byte[]{1,2,3,4,5};
+    DecoratedSignature sig = keypair.signPayloadDecorated(payload);
+    Assert.assertArrayEquals(sig.getHint().getSignatureHint(), new byte[]{
+            (byte)(0xFF & 252),
+            (byte)(0xFF & 65),
+            (byte)(0),
+            (byte)(0xFF & 50)});
+
+  }
+
+  @Test
+  public void testSignPayloadSignerLessThanHint() {
+    KeyPair keypair = KeyPair.fromSecretSeed(Util.hexToBytes(SEED));
+    // the hint from this keypair is [254,66,4,55]
+
+    byte[] payload = new byte[]{1,2,3};
+    DecoratedSignature sig = keypair.signPayloadDecorated(payload);
+    // the hint could only be derived off of 3 bytes from payload
+    Assert.assertArrayEquals(sig.getHint().getSignatureHint(), new byte[]{
+            (byte)(255),
+            (byte)(0xFF & 64),
+            (byte)(0xFF & 7),
+            (byte)(0xFF & 55)});
+
   }
 }

--- a/src/test/java/org/stellar/sdk/Sep10ChallengeTest.java
+++ b/src/test/java/org/stellar/sdk/Sep10ChallengeTest.java
@@ -3,6 +3,7 @@ package org.stellar.sdk;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
 import org.junit.Test;
+import org.stellar.sdk.xdr.DecoratedSignature;
 import org.stellar.sdk.xdr.EnvelopeType;
 import org.stellar.sdk.xdr.TransactionEnvelope;
 
@@ -238,7 +239,9 @@ public class Sep10ChallengeTest {
             .addPreconditions(transaction.getPreconditions())
             .build();
 
-    withMuxedClient.getSignatures().addAll(transaction.mSignatures);
+    for (DecoratedSignature signature : transaction.mSignatures) {
+      withMuxedClient.addSignature(signature);
+    }
 
     try {
       Sep10Challenge.readChallengeTransaction(


### PR DESCRIPTION
As part of CAP-40, needed to include payload signer signature generation from `KeyPair` and separate way to add pre-built signatures onto a `Transaction`.