### PR TITLE
Fixed Gradle encoding error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ version = '0.34.0'
 group = 'stellar'
 jar.enabled = false
 
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
+javadoc.options.encoding = 'UTF-8'
+
 publishing {
     publications {
         sdkLibrary(MavenPublication) { publication ->


### PR DESCRIPTION
In Windows, the Gradle build throws compile error `unmappable character for encoding Cp1252` at MemoTest.testMemoTextTooLongUtf8() and a couple of other places where `UTF-8` encoding is expected. 

This PR is to force encoding to `UTF-8`.