### PR TITLE
bugfix: make `Sep10Challenge.verifyTransactionSignatures` resilient against account IDs that are not compliant with ed25519

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 ## Pending
 
 ## 0.34.1
-* Fix the `Sep10Challenge.verifyChallengeTransactionThreshold` flow so it can handle/ignore signers that are not ed25519 compliant. ([#440](https://github.com/stellar/java-stellar-sdk/pull/440))
+
+* Fix the `Sep10Challenge.verifyTransactionSignatures` method to handle/ignore signers that are not ed25519 compliant. ([#440](https://github.com/stellar/java-stellar-sdk/pull/440))
 
 ## 0.34.0
 * Add memo to `Sep10Challenge.newChallenge()` and `Sep10Challenge.readChallengeTransaction`. ([#435](https://github.com/stellar/java-stellar-sdk/pull/435))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ## Pending
 
+## 0.34.1
+* Fix the `Sep10Challenge.verifyChallengeTransactionThreshold` flow so it can handle/ignore signers that are not ed25519 compliant. ([#440](https://github.com/stellar/java-stellar-sdk/pull/440))
+
 ## 0.34.0
 * Add memo to `Sep10Challenge.newChallenge()` and `Sep10Challenge.readChallengeTransaction`. ([#435](https://github.com/stellar/java-stellar-sdk/pull/435))
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 sourceCompatibility = 1.6
-version = '0.34.0'
+version = '0.34.1'
 group = 'stellar'
 jar.enabled = false
 

--- a/src/main/java/org/stellar/sdk/Sep10Challenge.java
+++ b/src/main/java/org/stellar/sdk/Sep10Challenge.java
@@ -552,7 +552,14 @@ public class Sep10Challenge {
     }
 
     for (String signer : signers) {
-      KeyPair keyPair = KeyPair.fromAccountId(signer);
+      KeyPair keyPair;
+      try {
+        keyPair = KeyPair.fromAccountId(signer);
+      } catch (RuntimeException e) {
+        System.out.printf("Couldn't parse the signer \"%s\" as a valid Public Key.", signer);
+        e.printStackTrace();
+        continue;
+      }
       SignatureHint hint = keyPair.getSignatureHint();
 
       for (Signature signature : signatures.get(hint)) {

--- a/src/main/java/org/stellar/sdk/Sep10Challenge.java
+++ b/src/main/java/org/stellar/sdk/Sep10Challenge.java
@@ -556,8 +556,6 @@ public class Sep10Challenge {
       try {
         keyPair = KeyPair.fromAccountId(signer);
       } catch (RuntimeException e) {
-        System.out.printf("Couldn't parse the signer \"%s\" as a valid Public Key.", signer);
-        e.printStackTrace();
         continue;
       }
       SignatureHint hint = keyPair.getSignatureHint();

--- a/src/test/java/org/stellar/sdk/Sep10ChallengeTest.java
+++ b/src/test/java/org/stellar/sdk/Sep10ChallengeTest.java
@@ -1609,12 +1609,10 @@ public class Sep10ChallengeTest {
   }
 
   @Test
-  public void testVerifyChallengeTransactionThresholdValidServerAndMultipleClientKeyMeetingThresholdSomeUnusedAndOneNotEd25519Compliant() throws IOException, InvalidSep10ChallengeException {
+  public void testVerifyChallengeTransactionWithAccountIdNonCompliantWithEd25519() throws IOException, InvalidSep10ChallengeException {
     Network network = Network.TESTNET;
     KeyPair server = KeyPair.random();
     KeyPair masterClient = KeyPair.random();
-    KeyPair signerClient1 = KeyPair.random();
-    KeyPair signerClient2 = KeyPair.random();
     long now = System.currentTimeMillis() / 1000L;
     long end = now + 300;
     TimeBounds timeBounds = new TimeBounds(now, end);
@@ -1631,18 +1629,15 @@ public class Sep10ChallengeTest {
     );
 
     transaction.sign(masterClient);
-    transaction.sign(signerClient1);
 
     Set<Sep10Challenge.Signer> signers = new HashSet<Sep10Challenge.Signer>(Arrays.asList(
-        new Sep10Challenge.Signer(masterClient.getAccountId(), 1),
-        new Sep10Challenge.Signer(signerClient1.getAccountId(), 2),
-        new Sep10Challenge.Signer(signerClient2.getAccountId(), 4),
+        new Sep10Challenge.Signer(masterClient.getAccountId(), 2),
         new Sep10Challenge.Signer("GA2T6GR7VXXXBETTERSAFETHANSORRYXXXPROTECTEDBYLOBSTRVAULT", 1)
     ));
 
-    int threshold = 3;
+    int threshold = 2;
     Set<String> signersFound = Sep10Challenge.verifyChallengeTransactionThreshold(transaction.toEnvelopeXdrBase64(), server.getAccountId(), network, domainName, webAuthDomain, threshold, signers);
-    assertEquals(new HashSet<String>(Arrays.asList(masterClient.getAccountId(), signerClient1.getAccountId())), signersFound);
+    assertEquals(new HashSet<String>(Collections.singletonList(masterClient.getAccountId())), signersFound);
   }
 
   @Test

--- a/src/test/java/org/stellar/sdk/Sep10ChallengeTest.java
+++ b/src/test/java/org/stellar/sdk/Sep10ChallengeTest.java
@@ -69,7 +69,7 @@ public class Sep10ChallengeTest {
   }
 
   @Test
-  public void testNewChallengeRejectsMuxedClientAccount() throws InvalidSep10ChallengeException {
+  public void testNewChallengeRejectsMuxedClientAccount() {
     try {
       KeyPair server = KeyPair.random();
 
@@ -1601,6 +1601,43 @@ public class Sep10ChallengeTest {
         new Sep10Challenge.Signer(masterClient.getAccountId(), 1),
         new Sep10Challenge.Signer(signerClient1.getAccountId(), 2),
         new Sep10Challenge.Signer(signerClient2.getAccountId(), 4)
+    ));
+
+    int threshold = 3;
+    Set<String> signersFound = Sep10Challenge.verifyChallengeTransactionThreshold(transaction.toEnvelopeXdrBase64(), server.getAccountId(), network, domainName, webAuthDomain, threshold, signers);
+    assertEquals(new HashSet<String>(Arrays.asList(masterClient.getAccountId(), signerClient1.getAccountId())), signersFound);
+  }
+
+  @Test
+  public void testVerifyChallengeTransactionThresholdValidServerAndMultipleClientKeyMeetingThresholdSomeUnusedAndOneNotEd25519Compliant() throws IOException, InvalidSep10ChallengeException {
+    Network network = Network.TESTNET;
+    KeyPair server = KeyPair.random();
+    KeyPair masterClient = KeyPair.random();
+    KeyPair signerClient1 = KeyPair.random();
+    KeyPair signerClient2 = KeyPair.random();
+    long now = System.currentTimeMillis() / 1000L;
+    long end = now + 300;
+    TimeBounds timeBounds = new TimeBounds(now, end);
+    String domainName = "example.com";
+    String webAuthDomain = "example.com";
+
+    Transaction transaction = Sep10Challenge.newChallenge(
+        server,
+        network,
+        masterClient.getAccountId(),
+        domainName,
+        webAuthDomain,
+        timeBounds
+    );
+
+    transaction.sign(masterClient);
+    transaction.sign(signerClient1);
+
+    Set<Sep10Challenge.Signer> signers = new HashSet<Sep10Challenge.Signer>(Arrays.asList(
+        new Sep10Challenge.Signer(masterClient.getAccountId(), 1),
+        new Sep10Challenge.Signer(signerClient1.getAccountId(), 2),
+        new Sep10Challenge.Signer(signerClient2.getAccountId(), 4),
+        new Sep10Challenge.Signer("GA2T6GR7VXXXBETTERSAFETHANSORRYXXXPROTECTEDBYLOBSTRVAULT", 1)
     ));
 
     int threshold = 3;


### PR DESCRIPTION
### What
Make `Sep10Challenge.verifyTransactionSignatures` resilient against account IDs that are not compliant with ed25519. If a non-compliant account was provided in the list of signers, this account is simply ignored.

Accounts whose ID is not a valid ed25519 public key won't have a signing key, so they can't have signed the challenge transaction.

After the `Sep10Challenge.verifyTransactionSignatures` method finds the intersection between `account IDs that signed the transaction` ∩ `signers provided in the list`, it will return to the caller and the number of accounts and their weight will be verified accordingly.

### Why

Close #439.