### PR TITLE
Fix KeyPair.fromSecretSeet on char array

### DIFF
--- a/src/main/java/org/stellar/sdk/KeyPair.java
+++ b/src/main/java/org/stellar/sdk/KeyPair.java
@@ -73,7 +73,6 @@ public class KeyPair {
   public static KeyPair fromSecretSeed(char[] seed) {
     byte[] decoded = StrKey.decodeStellarSecretSeed(seed);
     KeyPair keypair = fromSecretSeed(decoded);
-    Arrays.fill(decoded, (byte) 0);
     return keypair;
   }
 

--- a/src/test/java/org/stellar/sdk/KeyPairTest.java
+++ b/src/test/java/org/stellar/sdk/KeyPairTest.java
@@ -7,14 +7,22 @@ import org.stellar.sdk.xdr.DecoratedSignature;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class KeyPairTest {
 
   private static final String SEED = "1123740522f11bfef6b3671f51e159ccf589ccf8965262dd5f97d1721d383dd4";
+
+  @Test
+  public void testFromSecretSeedCharArray() {
+    KeyPair original = KeyPair.fromSecretSeed("SDMMJC2BSGESMFQ53MF3WECMCQGJVRY3TJ45J7PYZ53GZZ36NDDDWEDM");
+
+    char[] seed = original.getSecretSeed();
+    KeyPair newPair = KeyPair.fromSecretSeed(seed);
+
+    assertArrayEquals(original.getSecretSeed(), newPair.getSecretSeed());
+    assertEquals(original.getAccountId(), newPair.getAccountId());
+  }
 
   @Test
   public void testInvalidPublicKey() {


### PR DESCRIPTION
close https://github.com/stellar/java-stellar-sdk/issues/445

`fromSecretSeed(char[] seed)` decodes the seed into a byte array which is eventually passed into EdDSAPrivateKeySpec (defined in a library). EdDSAPrivateKeySpec stores a reference to the byte array in the class definition. So when we clear out the byte array using `Arrays.fill(decoded, (byte) 0);` it will actually affect EdDSAPrivateKeySpec. Consequently, `getSecretSeed()` will end up returning the private key corresponding to all zeros instead of the seed. 