### PR TITLE
Shade kotlin dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ## Pending
 
+## 0.36.0
+
+* Fix bug in `KeyPair.fromSecretSeed(char[] seed)`. ([#447](https://github.com/stellar/java-stellar-sdk/pull/447))
+* Shade kotlin dependencies to prevent 'Duplicate class' errors. ([#448](https://github.com/stellar/java-stellar-sdk/pull/448))
+
 ## 0.35.0
 
 * Update JDK compatibility version from Java 1.6 to Java 1.8 and bump the version of few libraries ([#444](https://github.com/stellar/java-stellar-sdk/pull/444)):

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ shadowJar {
     relocate 'org.checkerframework','shadow.org.checkerframework'
     relocate 'okhttp3','shadow.okhttp3'
     relocate 'okio','shadow.okio'
+    relocate 'kotlin','shadow.kotlin'
+    relocate 'org.intellij','shadow.org.intellij'
+    relocate 'org.jetbrains','shadow.org.jetbrains'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-version = '0.35.0'
+version = '0.36.0'
 group = 'stellar'
 jar.enabled = false
 


### PR DESCRIPTION
Close https://github.com/stellar/java-stellar-sdk/issues/446

In the 0.35.0 release we upgraded the com.squareup.okhttp3:okhttp dependency from v3 to v4. Bumping that dependency pulled in a dependency on kotlin. This causes "Duplicate Class" errors when using the java stellar sdk on kotlin projects. The fix for this issue is to properly shade all the kotlin dependencies.