### PR TITLE
Fix the deployment CI that uploads the jar to the GitHub release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             - libs/stellar-sdk.jar
   deploy:
     docker:
-      - image: cibuilds/github:0.10
+      - image: cibuilds/github:0.13
     steps:
       - attach_workspace:
           at: ./build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ## Pending
 
+## 0.37.1
+
+* Fix the deployment CI that uploads the jar to the GitHub release. ([#452](https://github.com/stellar/java-stellar-sdk/pull/452))
+
 ## 0.37.0
 
 * Fix missing `auth_clawback_enabled` field in AccountResponse class. ([#449](https://github.com/stellar/java-stellar-sdk/pull/449))

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-version = '0.37.0'
+version = '0.37.1'
 group = 'stellar'
 jar.enabled = false
 


### PR DESCRIPTION
### What

Fix the deployment CI that uploads the jar to the GitHub release by updating the image version of cibuilds/github from `0.10` to `0.13`.

### Why

Close #449.

In an attempt to fix the deploy job, that's failing at:
https://github.com/stellar/java-stellar-sdk/blob/b2a93410a39f7b39f4dbb8e462214ae119a3996b/.circleci/config.yml#L20-L29

With the error message:
```text
Failed to upload one of assets: one of the goroutines failed: failed to upload asset: /root/project/build/libs/stellar-sdk.jar: failed to upload release asset: /root/project/build/libs/stellar-sdk.jar: stat /root/project/build/libs/stellar-sdk.jar: use of closed file
```

Example of a failed deploy: [deploy (669)](https://app.circleci.com/pipelines/github/stellar/java-stellar-sdk/539/workflows/de14000a-07fe-481c-8707-787d3f58bd48/jobs/669/steps)

This error seems to have been fixed at https://github.com/tcnksm/ghr/pull/99 and released in version `0.11.0`. Also referenced in https://github.com/tcnksm/ghr/issues/90.