### PR TITLE
Fix the deployment CI that uploads the jar to the GitHub release [2]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,14 +19,18 @@ jobs:
             - libs/stellar-sdk.jar
   deploy:
     docker:
-      - image: cibuilds/github:0.13
+      - image: cimg/go:1.17
     steps:
       - attach_workspace:
           at: ./build
       - run:
-          name: "Publish Release on GitHub"
+          name: "Install github.com/github-release/github-release"
           command: |
-            ghr -replace -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./build/libs
+            go get github.com/github-release/github-release
+      - run:
+          name: "Upload JAR to GitHub Release"
+          command: |
+            github-release upload -s ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -f ./build/libs/stellar-sdk.jar -n java-stellar-sdk.jar
 
   after_deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
       - attach_workspace:
           at: ./build
       - run:
-          name: "Install github.com/github-release/github-release"
+          name: "Install github.com/github-release/github-release v0.10.0"
           command: |
-            go get github.com/github-release/github-release
+            go get github.com/github-release/github-release@v0.10.0
       - run:
           name: "Upload JAR to GitHub Release"
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ## Pending
 
+## 0.37.2
+
+* Fix the deployment CI that uploads the jar to the GitHub release [2]. ([#453](https://github.com/stellar/java-stellar-sdk/pull/453))
+
 ## 0.37.1
 
 * Fix the deployment CI that uploads the jar to the GitHub release. ([#452](https://github.com/stellar/java-stellar-sdk/pull/452))

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-version = '0.37.1'
+version = '0.37.2'
 group = 'stellar'
 jar.enabled = false
 


### PR DESCRIPTION
### What

Fix the deployment CI that uploads the jar to the GitHub release by updating the software being used from https://github.com/tcnksm/ghr to https://github.com/github-release/github-release.

### Why

Close #449.

In an attempt to fix the deploy job, that's failing at:
https://github.com/stellar/java-stellar-sdk/blob/417a84bd760321dba1ded0db0b9a32455737424f/.circleci/config.yml#L20-L29

With the error message:
```text
Failed to upload one of assets: one of the goroutines failed: failed to upload asset: /root/project/build/libs/stellar-sdk.jar: failed to upload release asset: /root/project/build/libs/stellar-sdk.jar: Post https://uploads.github.com/repos/stellar/java-stellar-sdk/releases/73913299/assets?name=stellar-sdk.jar: http2: Transport: cannot retry err [stream error: stream ID 5; REFUSED_STREAM] after Request.Body was written; define Request.GetBody to avoid this error
```

Example of a failed deploy: [deploy (678)](https://app.circleci.com/pipelines/github/stellar/java-stellar-sdk/545/workflows/85aac5f6-5744-4716-83cd-5e0ee60032ce/jobs/678)

There was already an attempt to solve this in #452 without success.