### PR TITLE
fix okhttp3 class loader issue on android platform

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,11 @@ shadowJar {
     duplicatesStrategy DuplicatesStrategy.EXCLUDE
     archiveClassifier.set('')
     archiveFileName.set('stellar-sdk.jar')
-    relocate 'com.','shadow.com.'
+    relocate('com.', 'shadow.com.') {
+      // okhttp hardcodes android platform class loading to this package, shadowing would attempt to rewrite the hardcode
+      // to be 'shadow.com.android.org.conscrypt' which we don't want to happen.
+      exclude 'com.android.org.conscrypt'
+    }
     relocate 'net.','shadow.net.'
     relocate 'javax.annotation', 'shadow.javax.annotation'
     relocate 'org.apache','shadow.org.apache'


### PR DESCRIPTION
I was able to replicate this problem in Android studio using emulator set at SDK version 28( android 'pie'):

The underlying issue was due to the shadowed jar, which rewrote an unintended 'com.android.org.conscrypt' hardcoded reference in the okhttp3 platform initialization which uses that as default to initialize networking from android:

https://github.com/square/okhttp/blob/parent-4.10.0/okhttp/src/main/kotlin/okhttp3/internal/platform/android/StandardAndroidSocketAdapter.kt#L61

it had a cycle when in error, trying to reference the platform instance while it was inside the platform init routine.

to avoid the problem, I tweaked the shadow config to ignore `com.android.org.conscrypt` ,which stops it from trying to rewrite any refs to that in the .class files in the shadowed jar. 

after this change, I was able to verify the fix by running the same prior failing example with `org.stellar.sdk.Server("https://horizon.stellar.com/")` and `OkHttpClient()` which now worked.


Closes #450 