### PR TITLE
Use JDK 11 for CI builds & Bump version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ## Pending
 
+## 0.41.0-beta.1
+* Use JDK 11 for CI builds. ([#511](https://github.com/stellar/java-stellar-sdk/issues/511))
+
 ## 0.41.0-beta.0
 * Add support for Soroban Preview 10. ([#490](https://github.com/stellar/java-stellar-sdk/issues/490))
 * Correct the data type of certain fields to store the expected design values. ([#497](https://github.com/stellar/java-stellar-sdk/pull/497))

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ spotless {
 
 
 sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-version = '0.41.0-beta.0'
+version = '0.41.0-beta.1'
 group = 'stellar'
 jar.enabled = false
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,7 @@
+jdk:
+  - openjdk11
+
+before_install:
+  - sdk install java 11.0.23-open
+  - sdk use java 11.0.23-open
+


### PR DESCRIPTION
Closes #510 

https://jitpack.io/docs/BUILDING/#java-version

@tamirms we need to release a new version.