### PR TITLE
Prepare 0.41.0-beta.2 for release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ## Pending
 
+## 0.41.0-beta.2
+* Migrate from CircleCI to GitHub Actions. ([#512](https://github.com/stellar/java-stellar-sdk/pull/512))
+
 ## 0.41.0-beta.1
 * Use JDK 11 for CI builds. ([#511](https://github.com/stellar/java-stellar-sdk/issues/511))
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ spotless {
 
 
 sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-version = '0.41.0-beta.1'
+version = '0.41.0-beta.2'
 group = 'stellar'
 jar.enabled = false
 


### PR DESCRIPTION
Let's release a new version **on the soroban branch** after merging #512 and this PR to address a series of issues related to the release.