### PR TITLE
Generate separate stellar-sdk-javadoc.jar release artifact

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -77,9 +77,9 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
-      - name: Generate JavaDoc Jar
+      - name: Generate javadocJar
         run: ./gradlew javadocJar
-      - name: Persist Documentation
+      - name: Persist javadocJar
         uses: actions/upload-artifact@v3
         with:
           name: javadoc_jar

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -66,6 +66,25 @@ jobs:
           name: javadoc
           path: javadoc
 
+  javadoc_jar:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - name: Generate JavaDoc Jar
+        run: ./gradlew javadocJar
+      - name: Persist Documentation
+        uses: actions/upload-artifact@v3
+        with:
+          name: javadoc_jar
+          path: build/libs/stellar-sdk-javadoc.jar
+
   android-test:
     needs: shadow_jar
     runs-on: macos-latest
@@ -116,6 +135,11 @@ jobs:
         with:
           name: javadoc
           path: javadoc
+      - name: Download javadocJar
+        uses: actions/download-artifact@v2
+        with:
+          name: javadoc_jar
+          path: javadoc_jar
       - name: Archive Documentation
         run: tar -czf stellar-sdk-javadoc.tar.gz javadoc
       - name: Upload artifacts to GitHub Release
@@ -123,6 +147,7 @@ jobs:
         with:
           files: |
             jar/stellar-sdk.jar
+            javadoc_jar/stellar-sdk-javadoc.jar
             stellar-sdk-javadoc.tar.gz
       - name: Upload Documentation to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -121,7 +121,7 @@ jobs:
           profile: 'pixel_2'
 
   deploy:
-    needs: [ javadoc, shadow_jar ]  # TODO: add android-test when it is stable.
+    needs: [ javadoc, shadow_jar, javadoc_jar ]  # TODO: add android-test when it is stable.
     permissions:
       contents: write
     if: github.event_name == 'release' && github.event.action == 'created'

--- a/build.gradle
+++ b/build.gradle
@@ -33,13 +33,6 @@ compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
 
-publishing {
-    publications {
-        sdkLibrary(MavenPublication) { publication ->
-            project.shadow.component(publication)
-        }
-    }
-}
 
 shadowJar {
     manifest {
@@ -114,4 +107,22 @@ tasks.javadoc {
     options.setSplitIndex(true)
     options.setMemberLevel(JavadocMemberLevel.PUBLIC)
     options.setEncoding('UTF-8')
+}
+
+tasks.register('javadocJar', Jar) {
+    dependsOn javadoc
+    archiveClassifier.set('javadoc')
+    from javadoc.destinationDir
+    archiveFileName.set('stellar-sdk-javadoc.jar')
+}
+
+publishing {
+    publications {
+        sdkLibrary(MavenPublication) { publication ->
+            project.shadow.component(publication)
+        }
+        javadocPublication(MavenPublication) { publication ->
+            artifact tasks.javadocJar
+        }
+    }
 }


### PR DESCRIPTION
Closes #454

Note:
IDEA users need to enable the automatic download document function.
See https://intellij-support.jetbrains.com/hc/en-us/community/posts/206834305-Automatically-download-sources-documentation-from-maven-working-great
<img width="972" alt="image" src="https://github.com/stellar/java-stellar-sdk/assets/2368403/14c40387-f474-4b9b-91b2-f15173a73efb">

<img width="965" alt="image" src="https://github.com/stellar/java-stellar-sdk/assets/2368403/3976a32e-6744-4c80-a671-325c16f1d9e9">
