### PR TITLE
define `cursor`, `order` and `limit` in AssetsRequestBuilder object.

### DIFF
--- a/src/main/java/org/stellar/sdk/requests/AssetsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/AssetsRequestBuilder.java
@@ -39,4 +39,22 @@ public class AssetsRequestBuilder extends RequestBuilder {
   public Page<AssetResponse> execute() throws IOException, TooManyRequestsException {
     return this.execute(this.httpClient, this.buildUri());
   }
+
+  @Override
+  public AssetsRequestBuilder cursor(String token) {
+    super.cursor(token);
+    return this;
+  }
+
+  @Override
+  public AssetsRequestBuilder limit(int number) {
+    super.limit(number);
+    return this;
+  }
+
+  @Override
+  public AssetsRequestBuilder order(Order direction) {
+    super.order(direction);
+    return this;
+  }
 }


### PR DESCRIPTION
fix #371 

Sorry for creating another PR like this, please see details at https://github.com/stellar/java-stellar-sdk/pull/519#issuecomment-1707412963

Let's ignore the CI failure caused by some unformatted code. We have resolved this issue in #521.