### PR TITLE
Bump dependencies & Remove unnecessary dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.internal.os.OperatingSystem
 
 buildscript {
-    ext.okhttpclientVersion = '4.10.0'
+    ext.okhttpclientVersion = '4.11.0'
 }
 
 plugins {
@@ -72,17 +72,15 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp-sse:${okhttpclientVersion}"
     implementation 'com.moandjiezana.toml:toml4j:0.7.2'
     // use the android version because we don't want java 8 stuff
-    implementation 'com.google.guava:guava:26.0-android'
-    implementation 'com.google.code.gson:gson:2.9.0'
-    implementation 'commons-io:commons-io:2.11.0'
+    // TODO: Do we really need to introduce guava?
+    implementation 'com.google.guava:guava:32.1.2-android'
+    implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'net.i2p.crypto:eddsa:0.3.0'
-    implementation 'org.threeten:threetenbp:1.6.0'
 
-    testImplementation 'org.mockito:mockito-core:4.6.1'
+    testImplementation 'org.mockito:mockito-core:5.5.0'
     testImplementation "com.squareup.okhttp3:mockwebserver:${okhttpclientVersion}"
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
-    testImplementation group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '4.12.1'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.10.0'
 }
 
 tasks.named('test') { task ->

--- a/src/main/java/org/stellar/sdk/Predicate.java
+++ b/src/main/java/org/stellar/sdk/Predicate.java
@@ -3,6 +3,7 @@ package org.stellar.sdk;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import java.math.BigInteger;
+import java.time.Instant;
 import java.util.List;
 import org.stellar.sdk.xdr.ClaimPredicate;
 import org.stellar.sdk.xdr.ClaimPredicateType;
@@ -11,7 +12,6 @@ import org.stellar.sdk.xdr.Int64;
 import org.stellar.sdk.xdr.TimePoint;
 import org.stellar.sdk.xdr.Uint64;
 import org.stellar.sdk.xdr.XdrUnsignedHyperInteger;
-import org.threeten.bp.Instant;
 
 public abstract class Predicate {
 

--- a/src/main/java/org/stellar/sdk/responses/PredicateDeserializer.java
+++ b/src/main/java/org/stellar/sdk/responses/PredicateDeserializer.java
@@ -3,13 +3,13 @@ package org.stellar.sdk.responses;
 import com.google.common.collect.Lists;
 import com.google.gson.*;
 import java.lang.reflect.Type;
+import java.time.Instant;
 import java.util.List;
 import org.stellar.sdk.Predicate;
 import org.stellar.sdk.xdr.Duration;
 import org.stellar.sdk.xdr.TimePoint;
 import org.stellar.sdk.xdr.Uint64;
 import org.stellar.sdk.xdr.XdrUnsignedHyperInteger;
-import org.threeten.bp.Instant;
 
 public class PredicateDeserializer implements JsonDeserializer<Predicate> {
   @Override

--- a/src/test/java/org/stellar/sdk/PredicateTest.java
+++ b/src/test/java/org/stellar/sdk/PredicateTest.java
@@ -3,8 +3,8 @@ package org.stellar.sdk;
 import static org.junit.Assert.assertEquals;
 
 import java.math.BigInteger;
+import java.time.Instant;
 import org.junit.Test;
-import org.threeten.bp.Instant;
 
 public class PredicateTest {
   @Test

--- a/src/test/java/org/stellar/sdk/StrKeyTest.java
+++ b/src/test/java/org/stellar/sdk/StrKeyTest.java
@@ -14,6 +14,7 @@ import org.stellar.sdk.xdr.MuxedAccount;
 public class StrKeyTest {
   @Test
   public void testDecodeEncode() throws IOException, FormatException {
+
     String seed = "SDJHRQF4GCMIIKAAAQ6IHY42X73FQFLHUULAPSKKD4DFDM7UXWWCRHBE";
     byte[] secret = StrKey.decodeCheck(StrKey.VersionByte.SEED, seed.toCharArray());
     char[] encoded = StrKey.encodeCheck(StrKey.VersionByte.SEED, secret);

--- a/src/test/java/org/stellar/sdk/TransactionBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/TransactionBuilderTest.java
@@ -64,13 +64,8 @@ public class TransactionBuilderTest {
     assertEquals(expectedExt, transaction.toEnvelopeXdr().getV1().getTx().getExt());
 
     // Convert transaction to binary XDR and back again to make sure correctly xdr de/serialized.
-    XdrDataInputStream is =
-        new XdrDataInputStream(
-            new ByteArrayInputStream(
-                javax.xml.bind.DatatypeConverter.parseBase64Binary(
-                    transaction.toEnvelopeXdrBase64())));
     org.stellar.sdk.xdr.TransactionEnvelope decodedTransaction =
-        org.stellar.sdk.xdr.TransactionEnvelope.decode(is);
+        org.stellar.sdk.xdr.TransactionEnvelope.fromXdrBase64(transaction.toEnvelopeXdrBase64());
     Transaction transaction2 =
         (Transaction)
             Transaction.fromEnvelopeXdr(
@@ -99,13 +94,8 @@ public class TransactionBuilderTest {
     transaction.sign(source);
 
     // Convert transaction to binary XDR and back again to make sure correctly xdr de/serialized.
-    XdrDataInputStream is =
-        new XdrDataInputStream(
-            new ByteArrayInputStream(
-                javax.xml.bind.DatatypeConverter.parseBase64Binary(
-                    transaction.toEnvelopeXdrBase64())));
     org.stellar.sdk.xdr.TransactionEnvelope decodedTransaction =
-        org.stellar.sdk.xdr.TransactionEnvelope.decode(is);
+        org.stellar.sdk.xdr.TransactionEnvelope.fromXdrBase64(transaction.toEnvelopeXdrBase64());
     Transaction transaction2 =
         (Transaction)
             Transaction.fromEnvelopeXdr(
@@ -139,13 +129,8 @@ public class TransactionBuilderTest {
 
     // Convert transaction to binary XDR and back again to make sure timebounds are correctly
     // de/serialized.
-    XdrDataInputStream is =
-        new XdrDataInputStream(
-            new ByteArrayInputStream(
-                javax.xml.bind.DatatypeConverter.parseBase64Binary(
-                    transaction.toEnvelopeXdrBase64())));
     org.stellar.sdk.xdr.TransactionEnvelope decodedTransaction =
-        org.stellar.sdk.xdr.TransactionEnvelope.decode(is);
+        org.stellar.sdk.xdr.TransactionEnvelope.fromXdrBase64(transaction.toEnvelopeXdrBase64());
 
     assertEquals(
         decodedTransaction
@@ -199,13 +184,8 @@ public class TransactionBuilderTest {
     transaction.sign(source);
 
     // Convert transaction to binary XDR and back again to make sure correctly xdr de/serialized.
-    XdrDataInputStream is =
-        new XdrDataInputStream(
-            new ByteArrayInputStream(
-                javax.xml.bind.DatatypeConverter.parseBase64Binary(
-                    transaction.toEnvelopeXdrBase64())));
     org.stellar.sdk.xdr.TransactionEnvelope decodedTransaction =
-        org.stellar.sdk.xdr.TransactionEnvelope.decode(is);
+        org.stellar.sdk.xdr.TransactionEnvelope.fromXdrBase64(transaction.toEnvelopeXdrBase64());
     Transaction transaction2 =
         (Transaction)
             Transaction.fromEnvelopeXdr(
@@ -250,13 +230,8 @@ public class TransactionBuilderTest {
     assertEquals(1337, transaction.getTimeBounds().getMaxTime().intValue());
 
     // Convert transaction to binary XDR and back again to make sure correctly xdr de/serialized.
-    XdrDataInputStream is =
-        new XdrDataInputStream(
-            new ByteArrayInputStream(
-                javax.xml.bind.DatatypeConverter.parseBase64Binary(
-                    transaction.toEnvelopeXdrBase64())));
     org.stellar.sdk.xdr.TransactionEnvelope decodedTransaction =
-        org.stellar.sdk.xdr.TransactionEnvelope.decode(is);
+        org.stellar.sdk.xdr.TransactionEnvelope.fromXdrBase64(transaction.toEnvelopeXdrBase64());
     Transaction transaction2 =
         (Transaction)
             Transaction.fromEnvelopeXdr(
@@ -313,13 +288,8 @@ public class TransactionBuilderTest {
 
     // Convert transaction to binary XDR and back again to make sure timebounds are correctly
     // de/serialized.
-    XdrDataInputStream is =
-        new XdrDataInputStream(
-            new ByteArrayInputStream(
-                javax.xml.bind.DatatypeConverter.parseBase64Binary(
-                    transaction.toEnvelopeXdrBase64())));
     org.stellar.sdk.xdr.TransactionEnvelope decodedTransaction =
-        org.stellar.sdk.xdr.TransactionEnvelope.decode(is);
+        org.stellar.sdk.xdr.TransactionEnvelope.fromXdrBase64(transaction.toEnvelopeXdrBase64());
     Transaction transaction2 =
         (Transaction)
             Transaction.fromEnvelopeXdr(
@@ -351,13 +321,8 @@ public class TransactionBuilderTest {
     assertEquals(1, transaction.getPreconditions().getLedgerBounds().getMinLedger());
     assertEquals(2, transaction.getPreconditions().getLedgerBounds().getMaxLedger());
 
-    XdrDataInputStream is =
-        new XdrDataInputStream(
-            new ByteArrayInputStream(
-                javax.xml.bind.DatatypeConverter.parseBase64Binary(
-                    transaction.toEnvelopeXdrBase64())));
     org.stellar.sdk.xdr.TransactionEnvelope decodedTransaction =
-        org.stellar.sdk.xdr.TransactionEnvelope.decode(is);
+        org.stellar.sdk.xdr.TransactionEnvelope.fromXdrBase64(transaction.toEnvelopeXdrBase64());
     Transaction transaction2 =
         (Transaction)
             Transaction.fromEnvelopeXdr(
@@ -400,13 +365,8 @@ public class TransactionBuilderTest {
     assertEquals(Long.valueOf(5), transaction.getPreconditions().getMinSeqNumber());
 
     // Convert transaction to binary XDR and back again to make sure correctly xdr de/serialized.
-    XdrDataInputStream is =
-        new XdrDataInputStream(
-            new ByteArrayInputStream(
-                javax.xml.bind.DatatypeConverter.parseBase64Binary(
-                    transaction.toEnvelopeXdrBase64())));
     org.stellar.sdk.xdr.TransactionEnvelope decodedTransaction =
-        org.stellar.sdk.xdr.TransactionEnvelope.decode(is);
+        org.stellar.sdk.xdr.TransactionEnvelope.fromXdrBase64(transaction.toEnvelopeXdrBase64());
     Transaction transaction2 =
         (Transaction)
             Transaction.fromEnvelopeXdr(
@@ -442,13 +402,8 @@ public class TransactionBuilderTest {
     assertEquals(5, transaction.getPreconditions().getMinSeqAge().intValue());
 
     // Convert transaction to binary XDR and back again to make sure correctly xdr de/serialized.
-    XdrDataInputStream is =
-        new XdrDataInputStream(
-            new ByteArrayInputStream(
-                javax.xml.bind.DatatypeConverter.parseBase64Binary(
-                    transaction.toEnvelopeXdrBase64())));
     org.stellar.sdk.xdr.TransactionEnvelope decodedTransaction =
-        org.stellar.sdk.xdr.TransactionEnvelope.decode(is);
+        org.stellar.sdk.xdr.TransactionEnvelope.fromXdrBase64(transaction.toEnvelopeXdrBase64());
     Transaction transaction2 =
         (Transaction)
             Transaction.fromEnvelopeXdr(
@@ -484,13 +439,8 @@ public class TransactionBuilderTest {
     assertEquals(5, transaction.getPreconditions().getMinSeqLedgerGap());
 
     // Convert transaction to binary XDR and back again to make sure correctly xdr de/serialized.
-    XdrDataInputStream is =
-        new XdrDataInputStream(
-            new ByteArrayInputStream(
-                javax.xml.bind.DatatypeConverter.parseBase64Binary(
-                    transaction.toEnvelopeXdrBase64())));
     org.stellar.sdk.xdr.TransactionEnvelope decodedTransaction =
-        org.stellar.sdk.xdr.TransactionEnvelope.decode(is);
+        org.stellar.sdk.xdr.TransactionEnvelope.fromXdrBase64(transaction.toEnvelopeXdrBase64());
     Transaction transaction2 =
         (Transaction)
             Transaction.fromEnvelopeXdr(
@@ -551,13 +501,8 @@ public class TransactionBuilderTest {
             .getPayload());
 
     // Convert transaction to binary XDR and back again to make sure correctly xdr de/serialized.
-    XdrDataInputStream is =
-        new XdrDataInputStream(
-            new ByteArrayInputStream(
-                javax.xml.bind.DatatypeConverter.parseBase64Binary(
-                    transaction.toEnvelopeXdrBase64())));
     org.stellar.sdk.xdr.TransactionEnvelope decodedTransaction =
-        org.stellar.sdk.xdr.TransactionEnvelope.decode(is);
+        org.stellar.sdk.xdr.TransactionEnvelope.fromXdrBase64(transaction.toEnvelopeXdrBase64());
     Transaction transaction2 =
         (Transaction)
             Transaction.fromEnvelopeXdr(


### PR DESCRIPTION
Part of #496

## Remove:
- commons-io:commons-io
- org.threeten:threetenbp
- javax.xml.bind:jaxb-api (test dep)

## Update:
- com.google.code.gson:gson (2.9.0 -> 2.10.1)
- com.squareup.okhttp3:okhttp (4.10.0 -> 4.11.0)
- com.squareup.okhttp3:okhttp-sse (4.10.0 -> 4.11.0)
- com.google.guava:guava (26.0-android -> 32.1.2-android)
- org.mockito:mockito-core (4.6.1 -> 5.5.0) (test dep)
- com.squareup.okhttp3:mockwebserver (4.10.0 -> 4.11.0) (test dep)
- junit:junit (4.12.1 -> 4.13.2) (test dep)
- org.junit.vintage:junit-vintage-engine (4.12.1 -> 5.10.0) (test dep)
