### PR TITLE
Fix the issue where the validity of the encoded strkey is not verified in certain scenarios.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
 ## Pending
+* Fix issues where the validity of the encoded strkey is not verified in certain scenarios. ([#541](https://github.com/stellar/java-stellar-sdk/pull/541))
 
 ## 0.41.0
 * Add support for Soroban Preview 11. ([#530](https://github.com/stellar/java-stellar-sdk/pull/530))

--- a/src/main/java/org/stellar/sdk/StrKey.java
+++ b/src/main/java/org/stellar/sdk/StrKey.java
@@ -432,10 +432,8 @@ class StrKey {
   private static byte[] base32decode(byte[] data) {
     // Apache commons codec Base32 class will auto remove the illegal characters, this is
     // what we don't want, so we need to check the data before decoding
-    for (byte b : data) {
-      if (!base32Codec.isInAlphabet(b)) {
-        throw new IllegalArgumentException("Invalid Base32 character: " + (char) b);
-      }
+    if (!base32Codec.isInAlphabet(data, false)) {
+      throw new IllegalArgumentException("Invalid base32 encoded string");
     }
     return base32Codec.decode(data);
   }

--- a/src/main/java/org/stellar/sdk/StrKey.java
+++ b/src/main/java/org/stellar/sdk/StrKey.java
@@ -5,7 +5,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
-import org.apache.commons.codec.CodecPolicy;
 import org.apache.commons.codec.binary.Base32;
 import org.apache.commons.codec.binary.Base32OutputStream;
 import org.apache.commons.codec.binary.StringUtils;
@@ -25,8 +24,7 @@ class StrKey {
 
   public static final int ACCOUNT_ID_ADDRESS_LENGTH = 56;
   private static final byte[] b32Table = decodingTable();
-  private static final Base32 base32Codec =
-      new Base32(0, null, false, (byte) '=', CodecPolicy.STRICT);
+  private static final Base32 base32Codec = new Base32();
 
   public static String encodeContractId(byte[] data) {
     char[] encoded = encodeCheck(VersionByte.CONTRACT, data);

--- a/src/test/java/org/stellar/sdk/StrKeyTest.java
+++ b/src/test/java/org/stellar/sdk/StrKeyTest.java
@@ -333,7 +333,7 @@ public class StrKeyTest {
 
   @Test
   public void testEncodeToXDRMuxedAccountInvalidAddress() {
-
+    // https://github.com/stellar/go/blob/2b876cd781b6dd0c218dcdd4f300900f87b3889e/strkey/main_test.go#L86
     try {
       StrKey.encodeToXDRMuxedAccount("XBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWGTOG");
       fail();
@@ -346,6 +346,86 @@ public class StrKeyTest {
       fail();
     } catch (FormatException e) {
       assertEquals("Checksum invalid", e.getMessage());
+    }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount(
+          "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUR");
+      fail();
+    } catch (IllegalArgumentException ignored) {
+    }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZA");
+      fail();
+    } catch (IllegalArgumentException ignored) {
+    }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount("G47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVP2I");
+      fail();
+    } catch (FormatException ignored) {
+    }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount(
+          "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLKA");
+      fail();
+    } catch (IllegalArgumentException ignored) {
+    }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount(
+          "M47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ");
+      fail();
+    } catch (FormatException ignored) {
+    }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount(
+          "M47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ");
+      fail();
+    } catch (FormatException ignored) {
+    }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount(
+          "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUK");
+      fail();
+    } catch (FormatException ignored) {
+    }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount(
+          "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUO");
+      fail();
+    } catch (FormatException ignored) {
+    }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount("");
+      fail();
+    } catch (IllegalArgumentException ignored) {
+    }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount("SBCVMMCBEDB64TVJZFYJOJAERZC4YVVUOE6SYR2Y76CBTENGUSGWRRVO");
+      fail();
+    } catch (FormatException ignored) {
+    }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount(
+          "MCEO75Y6YKE53HM6N46IJYH3LK3YYFZ4QWGNUKCSSIQSH3KOAD7BEAAAAAAAAAAAPNT2W___");
+      fail();
+    } catch (IllegalArgumentException ignored) {
+    }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount(
+          "MDWZCOEQRODFCH6ISYQPWY67L3ULLWS5ISXYYL5GH43W7YFMTLB64AAAAAAAAAAAAHGLW===");
+      fail();
+    } catch (IllegalArgumentException ignored) {
     }
   }
 }

--- a/src/test/java/org/stellar/sdk/StrKeyTest.java
+++ b/src/test/java/org/stellar/sdk/StrKeyTest.java
@@ -427,5 +427,12 @@ public class StrKeyTest {
       fail();
     } catch (IllegalArgumentException ignored) {
     }
+
+    try {
+      StrKey.encodeToXDRMuxedAccount(
+          " MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK");
+      fail();
+    } catch (IllegalArgumentException ignored) {
+    }
   }
 }


### PR DESCRIPTION
We have replaced the base32 library, and their internal implementations are slightly different, which has caused a bug.

fix #540