### PR TITLE
make `StrKey` public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
 ## Pending
+* Make `StrKey` public, this allows users to conveniently encode and decode Stellar keys to/from strings. ([#548](https://github.com/stellar/java-stellar-sdk/pull/548))
 
 ## 0.41.1
 * Add `org.stellar.sdk.spi.SdkProvider`, users can implement this interface to provide their own implementation of the SDK. We provide an [Android specific implementation](https://github.com/stellar/java-stellar-sdk-android-spi), if you are integrating this SDK into an Android project, be sure to check it out. ([#543](https://github.com/stellar/java-stellar-sdk/pull/543))

--- a/src/main/java/org/stellar/sdk/AccountConverter.java
+++ b/src/main/java/org/stellar/sdk/AccountConverter.java
@@ -52,6 +52,6 @@ public class AccountConverter {
       return StrKey.encodeStellarMuxedAccount(account);
     }
 
-    return StrKey.encodeStellarAccountId(StrKey.muxedAccountToAccountId(account));
+    return StrKey.encodeEd25519PublicKey(StrKey.muxedAccountToAccountId(account));
   }
 }

--- a/src/main/java/org/stellar/sdk/Address.java
+++ b/src/main/java/org/stellar/sdk/Address.java
@@ -23,12 +23,12 @@ public class Address {
    * @param address the StrKey encoded format of Stellar public key or contract ID.
    */
   public Address(String address) {
-    if (StrKey.isValidStellarAccountId(address)) {
+    if (StrKey.isValidEd25519PublicKey(address)) {
       this.type = AddressType.ACCOUNT;
-      this.key = StrKey.decodeStellarAccountId(address);
-    } else if (StrKey.isValidContractId(address)) {
+      this.key = StrKey.decodeEd25519PublicKey(address);
+    } else if (StrKey.isValidContract(address)) {
       this.type = AddressType.CONTRACT;
-      this.key = StrKey.decodeContractId(address);
+      this.key = StrKey.decodeContract(address);
     } else {
       throw new IllegalArgumentException("Unsupported address type");
     }
@@ -41,7 +41,7 @@ public class Address {
    * @return a new {@link Address} object from the given Stellar public key.
    */
   public static Address fromAccount(byte[] accountId) {
-    return new Address(StrKey.encodeStellarAccountId(accountId));
+    return new Address(StrKey.encodeEd25519PublicKey(accountId));
   }
 
   /**
@@ -51,7 +51,7 @@ public class Address {
    * @return a new {@link Address} object from the given Stellar Contract ID.
    */
   public static Address fromContract(byte[] contractId) {
-    return new Address(StrKey.encodeContractId(contractId));
+    return new Address(StrKey.encodeContract(contractId));
   }
 
   /**
@@ -63,9 +63,9 @@ public class Address {
   public static Address fromSCAddress(SCAddress scAddress) {
     switch (scAddress.getDiscriminant()) {
       case SC_ADDRESS_TYPE_ACCOUNT:
-        return new Address(StrKey.encodeStellarAccountId(scAddress.getAccountId()));
+        return new Address(StrKey.encodeEd25519PublicKey(scAddress.getAccountId()));
       case SC_ADDRESS_TYPE_CONTRACT:
-        return new Address(StrKey.encodeContractId(scAddress.getContractId().getHash()));
+        return new Address(StrKey.encodeContract(scAddress.getContractId().getHash()));
       default:
         throw new IllegalArgumentException("Unsupported address type");
     }
@@ -142,9 +142,9 @@ public class Address {
   public String toString() {
     switch (this.type) {
       case ACCOUNT:
-        return StrKey.encodeStellarAccountId(this.key);
+        return StrKey.encodeEd25519PublicKey(this.key);
       case CONTRACT:
-        return StrKey.encodeContractId(this.key);
+        return StrKey.encodeContract(this.key);
       default:
         throw new IllegalArgumentException("Unsupported address type");
     }

--- a/src/main/java/org/stellar/sdk/AllowTrustOperation.java
+++ b/src/main/java/org/stellar/sdk/AllowTrustOperation.java
@@ -102,7 +102,7 @@ public class AllowTrustOperation extends Operation {
     private String mSourceAccount;
 
     Builder(AllowTrustOp op) {
-      trustor = StrKey.encodeStellarAccountId(op.getTrustor());
+      trustor = StrKey.encodeEd25519PublicKey(op.getTrustor());
       switch (op.getAsset().getDiscriminant()) {
         case ASSET_TYPE_CREDIT_ALPHANUM4:
           assetCode = new String(op.getAsset().getAssetCode4().getAssetCode4()).trim();

--- a/src/main/java/org/stellar/sdk/Asset.java
+++ b/src/main/java/org/stellar/sdk/Asset.java
@@ -96,12 +96,12 @@ public abstract class Asset implements Comparable<Asset> {
       case ASSET_TYPE_CREDIT_ALPHANUM4:
         String assetCode4 =
             Util.paddedByteArrayToString(xdr.getAlphaNum4().getAssetCode().getAssetCode4());
-        accountId = StrKey.encodeStellarAccountId(xdr.getAlphaNum4().getIssuer());
+        accountId = StrKey.encodeEd25519PublicKey(xdr.getAlphaNum4().getIssuer());
         return new AssetTypeCreditAlphaNum4(assetCode4, accountId);
       case ASSET_TYPE_CREDIT_ALPHANUM12:
         String assetCode12 =
             Util.paddedByteArrayToString(xdr.getAlphaNum12().getAssetCode().getAssetCode12());
-        accountId = StrKey.encodeStellarAccountId(xdr.getAlphaNum12().getIssuer());
+        accountId = StrKey.encodeEd25519PublicKey(xdr.getAlphaNum12().getIssuer());
         return new AssetTypeCreditAlphaNum12(assetCode12, accountId);
       default:
         throw new IllegalArgumentException("Unknown asset type " + xdr.getDiscriminant());

--- a/src/main/java/org/stellar/sdk/BeginSponsoringFutureReservesOperation.java
+++ b/src/main/java/org/stellar/sdk/BeginSponsoringFutureReservesOperation.java
@@ -40,7 +40,7 @@ public class BeginSponsoringFutureReservesOperation extends Operation {
      * @param op {@link BeginSponsoringFutureReservesOp}
      */
     Builder(BeginSponsoringFutureReservesOp op) {
-      sponsoredId = StrKey.encodeStellarAccountId(op.getSponsoredID());
+      sponsoredId = StrKey.encodeEd25519PublicKey(op.getSponsoredID());
     }
 
     /**

--- a/src/main/java/org/stellar/sdk/ChangeTrustAsset.java
+++ b/src/main/java/org/stellar/sdk/ChangeTrustAsset.java
@@ -89,12 +89,12 @@ public abstract class ChangeTrustAsset implements Comparable<ChangeTrustAsset> {
       case ASSET_TYPE_CREDIT_ALPHANUM4:
         String assetCode4 =
             Util.paddedByteArrayToString(xdr.getAlphaNum4().getAssetCode().getAssetCode4());
-        accountId = StrKey.encodeStellarAccountId(xdr.getAlphaNum4().getIssuer());
+        accountId = StrKey.encodeEd25519PublicKey(xdr.getAlphaNum4().getIssuer());
         return ChangeTrustAsset.create(new AssetTypeCreditAlphaNum4(assetCode4, accountId));
       case ASSET_TYPE_CREDIT_ALPHANUM12:
         String assetCode12 =
             Util.paddedByteArrayToString(xdr.getAlphaNum12().getAssetCode().getAssetCode12());
-        accountId = StrKey.encodeStellarAccountId(xdr.getAlphaNum12().getIssuer());
+        accountId = StrKey.encodeEd25519PublicKey(xdr.getAlphaNum12().getIssuer());
         return ChangeTrustAsset.create(new AssetTypeCreditAlphaNum12(assetCode12, accountId));
       case ASSET_TYPE_POOL_SHARE:
         return new LiquidityPoolShareChangeTrustAsset(

--- a/src/main/java/org/stellar/sdk/CreateAccountOperation.java
+++ b/src/main/java/org/stellar/sdk/CreateAccountOperation.java
@@ -65,7 +65,7 @@ public class CreateAccountOperation extends Operation {
      * @param op {@link CreateAccountOp}
      */
     Builder(CreateAccountOp op) {
-      destination = StrKey.encodeStellarAccountId(op.getDestination());
+      destination = StrKey.encodeEd25519PublicKey(op.getDestination());
       startingBalance = Operation.fromXdrAmount(op.getStartingBalance().getInt64().longValue());
     }
 

--- a/src/main/java/org/stellar/sdk/CreateClaimableBalanceOperation.java
+++ b/src/main/java/org/stellar/sdk/CreateClaimableBalanceOperation.java
@@ -84,7 +84,7 @@ public class CreateClaimableBalanceOperation extends Operation {
       for (org.stellar.sdk.xdr.Claimant c : op.getClaimants()) {
         claimants.add(
             new Claimant(
-                StrKey.encodeStellarAccountId(c.getV0().getDestination()),
+                StrKey.encodeEd25519PublicKey(c.getV0().getDestination()),
                 Predicate.fromXdr(c.getV0().getPredicate())));
       }
     }

--- a/src/main/java/org/stellar/sdk/KeyPair.java
+++ b/src/main/java/org/stellar/sdk/KeyPair.java
@@ -70,7 +70,7 @@ public class KeyPair {
    * @return {@link KeyPair}
    */
   public static KeyPair fromSecretSeed(char[] seed) {
-    byte[] decoded = StrKey.decodeStellarSecretSeed(seed);
+    byte[] decoded = StrKey.decodeEd25519SecretSeed(seed);
     KeyPair keypair = fromSecretSeed(decoded);
     return keypair;
   }
@@ -87,7 +87,7 @@ public class KeyPair {
    */
   public static KeyPair fromSecretSeed(String seed) {
     char[] charSeed = seed.toCharArray();
-    byte[] decoded = StrKey.decodeStellarSecretSeed(charSeed);
+    byte[] decoded = StrKey.decodeEd25519SecretSeed(charSeed);
     KeyPair keypair = fromSecretSeed(decoded);
     Arrays.fill(charSeed, ' ');
     return keypair;
@@ -113,7 +113,7 @@ public class KeyPair {
    * @return {@link KeyPair}
    */
   public static KeyPair fromAccountId(String accountId) {
-    byte[] decoded = StrKey.decodeStellarAccountId(accountId);
+    byte[] decoded = StrKey.decodeEd25519PublicKey(accountId);
     return fromPublicKey(decoded);
   }
 
@@ -163,12 +163,12 @@ public class KeyPair {
 
   /** Returns the human readable account ID encoded in strkey. */
   public String getAccountId() {
-    return StrKey.encodeStellarAccountId(mPublicKey.getAbyte());
+    return StrKey.encodeEd25519PublicKey(mPublicKey.getAbyte());
   }
 
   /** Returns the human readable secret seed encoded in strkey. */
   public char[] getSecretSeed() {
-    return StrKey.encodeStellarSecretSeed(mPrivateKey.getSeed());
+    return StrKey.encodeEd25519SecretSeed(mPrivateKey.getSeed());
   }
 
   public byte[] getPublicKey() {

--- a/src/main/java/org/stellar/sdk/RevokeAccountSponsorshipOperation.java
+++ b/src/main/java/org/stellar/sdk/RevokeAccountSponsorshipOperation.java
@@ -45,7 +45,7 @@ public class RevokeAccountSponsorshipOperation extends Operation {
      * @param op {@link RevokeSponsorshipOp}
      */
     Builder(RevokeSponsorshipOp op) {
-      accountId = StrKey.encodeStellarAccountId(op.getLedgerKey().getAccount().getAccountID());
+      accountId = StrKey.encodeEd25519PublicKey(op.getLedgerKey().getAccount().getAccountID());
     }
 
     /**

--- a/src/main/java/org/stellar/sdk/RevokeDataSponsorshipOperation.java
+++ b/src/main/java/org/stellar/sdk/RevokeDataSponsorshipOperation.java
@@ -56,7 +56,7 @@ public class RevokeDataSponsorshipOperation extends Operation {
      * @param op {@link RevokeSponsorshipOp}
      */
     Builder(RevokeSponsorshipOp op) {
-      accountId = StrKey.encodeStellarAccountId(op.getLedgerKey().getData().getAccountID());
+      accountId = StrKey.encodeEd25519PublicKey(op.getLedgerKey().getData().getAccountID());
       dataName = op.getLedgerKey().getData().getDataName().getString64().toString();
     }
 

--- a/src/main/java/org/stellar/sdk/RevokeOfferSponsorshipOperation.java
+++ b/src/main/java/org/stellar/sdk/RevokeOfferSponsorshipOperation.java
@@ -57,7 +57,7 @@ public class RevokeOfferSponsorshipOperation extends Operation {
      */
     Builder(RevokeSponsorshipOp op) {
       offerId = op.getLedgerKey().getOffer().getOfferID().getInt64();
-      seller = StrKey.encodeStellarAccountId(op.getLedgerKey().getOffer().getSellerID());
+      seller = StrKey.encodeEd25519PublicKey(op.getLedgerKey().getOffer().getSellerID());
     }
 
     /**

--- a/src/main/java/org/stellar/sdk/RevokeSignerSponsorshipOperation.java
+++ b/src/main/java/org/stellar/sdk/RevokeSignerSponsorshipOperation.java
@@ -52,7 +52,7 @@ public class RevokeSignerSponsorshipOperation extends Operation {
      * @param op {@link RevokeSponsorshipOp}
      */
     Builder(RevokeSponsorshipOp op) {
-      accountId = StrKey.encodeStellarAccountId(op.getSigner().getAccountID());
+      accountId = StrKey.encodeEd25519PublicKey(op.getSigner().getAccountID());
       signer = op.getSigner().getSignerKey();
     }
 

--- a/src/main/java/org/stellar/sdk/RevokeTrustlineSponsorshipOperation.java
+++ b/src/main/java/org/stellar/sdk/RevokeTrustlineSponsorshipOperation.java
@@ -54,7 +54,7 @@ public class RevokeTrustlineSponsorshipOperation extends Operation {
      * @param op {@link RevokeSponsorshipOp}
      */
     Builder(RevokeSponsorshipOp op) {
-      accountId = StrKey.encodeStellarAccountId(op.getLedgerKey().getTrustLine().getAccountID());
+      accountId = StrKey.encodeEd25519PublicKey(op.getLedgerKey().getTrustLine().getAccountID());
       asset = TrustLineAsset.fromXdr(op.getLedgerKey().getTrustLine().getAsset());
     }
 

--- a/src/main/java/org/stellar/sdk/SetOptionsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetOptionsOperation.java
@@ -199,7 +199,7 @@ public class SetOptionsOperation extends Operation {
 
     Builder(SetOptionsOp op) {
       if (op.getInflationDest() != null) {
-        inflationDestination = StrKey.encodeStellarAccountId(op.getInflationDest());
+        inflationDestination = StrKey.encodeEd25519PublicKey(op.getInflationDest());
       }
       if (op.getClearFlags() != null) {
         clearFlags = op.getClearFlags().getUint32().getNumber().intValue();

--- a/src/main/java/org/stellar/sdk/SetTrustlineFlagsOperation.java
+++ b/src/main/java/org/stellar/sdk/SetTrustlineFlagsOperation.java
@@ -87,7 +87,7 @@ public class SetTrustlineFlagsOperation extends Operation {
     private String mSourceAccount;
 
     Builder(SetTrustLineFlagsOp op) {
-      trustor = StrKey.encodeStellarAccountId(op.getTrustor());
+      trustor = StrKey.encodeEd25519PublicKey(op.getTrustor());
       asset = Util.assertNonNativeAsset(Asset.fromXdr(op.getAsset()));
       clearFlags = flagSetFromInt(op.getClearFlags().getUint32().getNumber().intValue());
       setFlags = flagSetFromInt(op.getSetFlags().getUint32().getNumber().intValue());

--- a/src/main/java/org/stellar/sdk/StrKey.java
+++ b/src/main/java/org/stellar/sdk/StrKey.java
@@ -183,7 +183,7 @@ public class StrKey {
    * @param accountID data to encode
    * @return "G..." representation of the key
    */
-  public static String encodeEd25519PublicKey(AccountID accountID) {
+  static String encodeEd25519PublicKey(AccountID accountID) {
     char[] encoded =
         encodeCheck(VersionByte.ACCOUNT_ID, accountID.getAccountID().getEd25519().getUint256());
     return String.valueOf(encoded);

--- a/src/main/java/org/stellar/sdk/Transaction.java
+++ b/src/main/java/org/stellar/sdk/Transaction.java
@@ -258,7 +258,7 @@ public class Transaction extends AbstractTransaction {
     Transaction transaction =
         new Transaction(
             accountConverter,
-            StrKey.encodeStellarAccountId(envelope.getTx().getSourceAccountEd25519().getUint256()),
+            StrKey.encodeEd25519PublicKey(envelope.getTx().getSourceAccountEd25519().getUint256()),
             mFee,
             mSequenceNumber,
             mOperations,

--- a/src/main/java/org/stellar/sdk/TrustLineAsset.java
+++ b/src/main/java/org/stellar/sdk/TrustLineAsset.java
@@ -106,12 +106,12 @@ public abstract class TrustLineAsset implements Comparable<TrustLineAsset> {
       case ASSET_TYPE_CREDIT_ALPHANUM4:
         String assetCode4 =
             Util.paddedByteArrayToString(xdr.getAlphaNum4().getAssetCode().getAssetCode4());
-        accountId = StrKey.encodeStellarAccountId(xdr.getAlphaNum4().getIssuer());
+        accountId = StrKey.encodeEd25519PublicKey(xdr.getAlphaNum4().getIssuer());
         return TrustLineAsset.create(new AssetTypeCreditAlphaNum4(assetCode4, accountId));
       case ASSET_TYPE_CREDIT_ALPHANUM12:
         String assetCode12 =
             Util.paddedByteArrayToString(xdr.getAlphaNum12().getAssetCode().getAssetCode12());
-        accountId = StrKey.encodeStellarAccountId(xdr.getAlphaNum12().getIssuer());
+        accountId = StrKey.encodeEd25519PublicKey(xdr.getAlphaNum12().getIssuer());
         return TrustLineAsset.create(new AssetTypeCreditAlphaNum12(assetCode12, accountId));
       case ASSET_TYPE_POOL_SHARE:
         return new LiquidityPoolShareTrustLineAsset(

--- a/src/test/java/org/stellar/sdk/AddressTest.java
+++ b/src/test/java/org/stellar/sdk/AddressTest.java
@@ -54,7 +54,7 @@ public class AddressTest {
   @Test
   public void testFromAccountByte() {
     String accountId = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ";
-    byte[] accountIdBytes = StrKey.decodeStellarAccountId(accountId);
+    byte[] accountIdBytes = StrKey.decodeEd25519PublicKey(accountId);
     Address address = Address.fromAccount(accountIdBytes);
     assertEquals(address.toString(), accountId);
     assertEquals(address.getAddressType(), Address.AddressType.ACCOUNT);
@@ -63,7 +63,7 @@ public class AddressTest {
   @Test
   public void testFromContractByte() {
     String contractId = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA";
-    byte[] contractIdBytes = StrKey.decodeContractId(contractId);
+    byte[] contractIdBytes = StrKey.decodeContract(contractId);
     Address address = Address.fromContract(contractIdBytes);
     assertEquals(address.toString(), contractId);
     assertEquals(address.getAddressType(), Address.AddressType.CONTRACT);

--- a/src/test/java/org/stellar/sdk/SetOptionsOperationTest.java
+++ b/src/test/java/org/stellar/sdk/SetOptionsOperationTest.java
@@ -19,7 +19,7 @@ public class SetOptionsOperationTest {
         Util.hexToBytes(
             "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20".toUpperCase());
     SignedPayloadSigner signedPayloadSigner =
-        new SignedPayloadSigner(StrKey.decodeStellarAccountId(payloadSignerStrKey), payload);
+        new SignedPayloadSigner(StrKey.decodeEd25519PublicKey(payloadSignerStrKey), payload);
     SignerKey signerKey = Signer.signedPayload(signedPayloadSigner);
 
     builder.setSigner(signerKey, 1);

--- a/src/test/java/org/stellar/sdk/SignedPayloadSignerTest.java
+++ b/src/test/java/org/stellar/sdk/SignedPayloadSignerTest.java
@@ -25,7 +25,7 @@ public class SignedPayloadSignerTest {
             "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2001"
                 .toUpperCase());
     try {
-      new SignedPayloadSigner(StrKey.decodeStellarAccountId(accountStrKey), payload);
+      new SignedPayloadSigner(StrKey.decodeEd25519PublicKey(accountStrKey), payload);
       fail("should not create a payload signer if payload > max length");
     } catch (IllegalArgumentException ignored) {
     }

--- a/src/test/java/org/stellar/sdk/SignerTest.java
+++ b/src/test/java/org/stellar/sdk/SignerTest.java
@@ -16,7 +16,7 @@ public class SignerTest {
         Util.hexToBytes(
             "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20".toUpperCase());
     SignedPayloadSigner signedPayloadSigner =
-        new SignedPayloadSigner(StrKey.decodeStellarAccountId(accountStrKey), payload);
+        new SignedPayloadSigner(StrKey.decodeEd25519PublicKey(accountStrKey), payload);
     SignerKey signerKey = Signer.signedPayload(signedPayloadSigner);
 
     assertArrayEquals(signerKey.getEd25519SignedPayload().getPayload(), payload);

--- a/src/test/java/org/stellar/sdk/StrKeyTest.java
+++ b/src/test/java/org/stellar/sdk/StrKeyTest.java
@@ -145,7 +145,7 @@ public class StrKeyTest {
             "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20".toUpperCase());
     SignedPayloadSigner signedPayloadSigner =
         new SignedPayloadSigner(
-            StrKey.decodeStellarAccountId(
+            StrKey.decodeEd25519PublicKey(
                 "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"),
             payload);
     String encoded = StrKey.encodeSignedPayload(signedPayloadSigner);
@@ -158,7 +158,7 @@ public class StrKeyTest {
         Util.hexToBytes("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d".toUpperCase());
     signedPayloadSigner =
         new SignedPayloadSigner(
-            StrKey.decodeStellarAccountId(
+            StrKey.decodeEd25519PublicKey(
                 "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"),
             payload);
     encoded = StrKey.encodeSignedPayload(signedPayloadSigner);
@@ -241,8 +241,8 @@ public class StrKeyTest {
             0xfc, 0x7f, 0xe8, 0x9a);
 
     String encoded = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA";
-    assertEquals(encoded, StrKey.encodeContractId(data));
-    assertArrayEquals(data, StrKey.decodeContractId(encoded));
+    assertEquals(encoded, StrKey.encodeContract(data));
+    assertArrayEquals(data, StrKey.decodeContract(encoded));
   }
 
   @Test
@@ -288,13 +288,13 @@ public class StrKeyTest {
             173, 151, 52, 164, 162, 251, 13, 122, 3, 252, 127, 232, 154);
     AccountID account = StrKey.encodeToXDRAccountId(address);
     assertArrayEquals(ed25519, account.getAccountID().getEd25519().getUint256());
-    assertEquals(address, StrKey.encodeStellarAccountId(account));
+    assertEquals(address, StrKey.encodeEd25519PublicKey(account));
 
     MuxedAccount muxedAccount = StrKey.encodeToXDRMuxedAccount(address);
     assertEquals(CryptoKeyType.KEY_TYPE_ED25519, muxedAccount.getDiscriminant());
     assertArrayEquals(ed25519, muxedAccount.getEd25519().getUint256());
     assertEquals(
-        address, StrKey.encodeStellarAccountId(StrKey.muxedAccountToAccountId(muxedAccount)));
+        address, StrKey.encodeEd25519PublicKey(StrKey.muxedAccountToAccountId(muxedAccount)));
   }
 
   @Test
@@ -434,5 +434,234 @@ public class StrKeyTest {
       fail();
     } catch (IllegalArgumentException ignored) {
     }
+  }
+
+  @Test
+  public void testEncodeAndDecodeEd25519PublicKey() {
+    byte[] rawData = {
+      (byte) 0x52,
+      (byte) 0x23,
+      (byte) 0xd1,
+      (byte) 0x59,
+      (byte) 0x64,
+      (byte) 0xcb,
+      (byte) 0x25,
+      (byte) 0xb9,
+      (byte) 0x8d,
+      (byte) 0x17,
+      (byte) 0xdf,
+      (byte) 0xc9,
+      (byte) 0xcb,
+      (byte) 0x95,
+      (byte) 0x4a,
+      (byte) 0x43,
+      (byte) 0x31,
+      (byte) 0x61,
+      (byte) 0x7b,
+      (byte) 0xba,
+      (byte) 0xa4,
+      (byte) 0xe5,
+      (byte) 0xdc,
+      (byte) 0x14,
+      (byte) 0x4c,
+      (byte) 0x87,
+      (byte) 0xdf,
+      (byte) 0xb,
+      (byte) 0x8b,
+      (byte) 0x3b,
+      (byte) 0x47,
+      (byte) 0xd9
+    };
+    String strKey = "GBJCHUKZMTFSLOMNC7P4TS4VJJBTCYL3XKSOLXAUJSD56C4LHND5TWUC";
+    assertEquals(strKey, StrKey.encodeEd25519PublicKey(rawData));
+    assertArrayEquals(rawData, StrKey.decodeEd25519PublicKey(strKey));
+  }
+
+  @Test
+  public void testEncodeAndDecodeEd25519SecretSeed() {
+    byte[] rawData = {
+      (byte) 0x7d,
+      (byte) 0xd6,
+      (byte) 0x1c,
+      (byte) 0xa0,
+      (byte) 0xd6,
+      (byte) 0x77,
+      (byte) 0xcd,
+      (byte) 0xe,
+      (byte) 0xfc,
+      (byte) 0x2b,
+      (byte) 0x54,
+      (byte) 0x73,
+      (byte) 0xe9,
+      (byte) 0x42,
+      (byte) 0x6c,
+      (byte) 0x7a,
+      (byte) 0x98,
+      (byte) 0xb3,
+      (byte) 0xe6,
+      (byte) 0x45,
+      (byte) 0x67,
+      (byte) 0x68,
+      (byte) 0x2d,
+      (byte) 0x46,
+      (byte) 0xee,
+      (byte) 0x7c,
+      (byte) 0xbd,
+      (byte) 0x80,
+      (byte) 0x7,
+      (byte) 0xe5,
+      (byte) 0x32,
+      (byte) 0xbc
+    };
+    String strKey = "SB65MHFA2Z342DX4FNKHH2KCNR5JRM7GIVTWQLKG5Z6L3AAH4UZLZV4E";
+    assertEquals(strKey, String.valueOf(StrKey.encodeEd25519SecretSeed(rawData)));
+    assertArrayEquals(rawData, StrKey.decodeEd25519SecretSeed(strKey.toCharArray()));
+  }
+
+  @Test
+  public void testEncodeAndDecodePreAuthTx() {
+    byte[] rawData = {
+      (byte) 0x7d,
+      (byte) 0xd6,
+      (byte) 0x1c,
+      (byte) 0xa0,
+      (byte) 0xd6,
+      (byte) 0x77,
+      (byte) 0xcd,
+      (byte) 0xe,
+      (byte) 0xfc,
+      (byte) 0x2b,
+      (byte) 0x54,
+      (byte) 0x73,
+      (byte) 0xe9,
+      (byte) 0x42,
+      (byte) 0x6c,
+      (byte) 0x7a,
+      (byte) 0x98,
+      (byte) 0xb3,
+      (byte) 0xe6,
+      (byte) 0x45,
+      (byte) 0x67,
+      (byte) 0x68,
+      (byte) 0x2d,
+      (byte) 0x46,
+      (byte) 0xee,
+      (byte) 0x7c,
+      (byte) 0xbd,
+      (byte) 0x80,
+      (byte) 0x7,
+      (byte) 0xe5,
+      (byte) 0x32,
+      (byte) 0xbc
+    };
+    String strKey = "TB65MHFA2Z342DX4FNKHH2KCNR5JRM7GIVTWQLKG5Z6L3AAH4UZLZM5K";
+    assertEquals(strKey, StrKey.encodePreAuthTx(rawData));
+    assertArrayEquals(rawData, StrKey.decodePreAuthTx(strKey));
+  }
+
+  @Test
+  public void testEncodeAndDecodeSha256Hash() {
+    byte[] rawData = {
+      (byte) 0x7d,
+      (byte) 0xd6,
+      (byte) 0x1c,
+      (byte) 0xa0,
+      (byte) 0xd6,
+      (byte) 0x77,
+      (byte) 0xcd,
+      (byte) 0xe,
+      (byte) 0xfc,
+      (byte) 0x2b,
+      (byte) 0x54,
+      (byte) 0x73,
+      (byte) 0xe9,
+      (byte) 0x42,
+      (byte) 0x6c,
+      (byte) 0x7a,
+      (byte) 0x98,
+      (byte) 0xb3,
+      (byte) 0xe6,
+      (byte) 0x45,
+      (byte) 0x67,
+      (byte) 0x68,
+      (byte) 0x2d,
+      (byte) 0x46,
+      (byte) 0xee,
+      (byte) 0x7c,
+      (byte) 0xbd,
+      (byte) 0x80,
+      (byte) 0x7,
+      (byte) 0xe5,
+      (byte) 0x32,
+      (byte) 0xbc
+    };
+    String strKey = "XB65MHFA2Z342DX4FNKHH2KCNR5JRM7GIVTWQLKG5Z6L3AAH4UZLYIYT";
+    assertEquals(strKey, StrKey.encodeSha256Hash(rawData));
+    assertArrayEquals(rawData, StrKey.decodeSha256Hash(strKey));
+  }
+
+  @Test
+  public void testEncodeAndDecodeSignedPayload() {
+    AccountID accountID =
+        KeyPair.fromAccountId("GBJCHUKZMTFSLOMNC7P4TS4VJJBTCYL3XKSOLXAUJSD56C4LHND5TWUC")
+            .getXdrAccountId();
+    byte[] payload = {
+      (byte) 0xd5,
+      (byte) 0xf1,
+      (byte) 0x3d,
+      (byte) 0xbd,
+      (byte) 0x95,
+      (byte) 0x5e,
+      (byte) 0x99,
+      (byte) 0xf9,
+      (byte) 0xd
+    };
+    SignedPayloadSigner signedPayloadSigner = new SignedPayloadSigner(accountID, payload);
+    String expected =
+        "PBJCHUKZMTFSLOMNC7P4TS4VJJBTCYL3XKSOLXAUJSD56C4LHND5SAAAAAE5L4J5XWKV5GPZBUAAAAAYQ4";
+    assertEquals(expected, StrKey.encodeSignedPayload(signedPayloadSigner));
+    assertArrayEquals(payload, StrKey.decodeSignedPayload(expected).getPayload());
+    assertEquals(accountID, StrKey.decodeSignedPayload(expected).getSignerAccountId());
+  }
+
+  @Test
+  public void testEncodeAndDecodeContract() {
+    byte[] rawData = {
+      (byte) 0x7d,
+      (byte) 0xd6,
+      (byte) 0x1c,
+      (byte) 0xa0,
+      (byte) 0xd6,
+      (byte) 0x77,
+      (byte) 0xcd,
+      (byte) 0xe,
+      (byte) 0xfc,
+      (byte) 0x2b,
+      (byte) 0x54,
+      (byte) 0x73,
+      (byte) 0xe9,
+      (byte) 0x42,
+      (byte) 0x6c,
+      (byte) 0x7a,
+      (byte) 0x98,
+      (byte) 0xb3,
+      (byte) 0xe6,
+      (byte) 0x45,
+      (byte) 0x67,
+      (byte) 0x68,
+      (byte) 0x2d,
+      (byte) 0x46,
+      (byte) 0xee,
+      (byte) 0x7c,
+      (byte) 0xbd,
+      (byte) 0x80,
+      (byte) 0x7,
+      (byte) 0xe5,
+      (byte) 0x32,
+      (byte) 0xbc
+    };
+    String strKey = "CB65MHFA2Z342DX4FNKHH2KCNR5JRM7GIVTWQLKG5Z6L3AAH4UZLZVKC";
+    assertEquals(strKey, StrKey.encodeContract(rawData));
+    assertArrayEquals(rawData, StrKey.decodeContract(strKey));
   }
 }

--- a/src/test/java/org/stellar/sdk/TransactionBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/TransactionBuilderTest.java
@@ -470,7 +470,7 @@ public class TransactionBuilderTest {
             .ed25519SignedPayload(
                 new SignerKey.SignerKeyEd25519SignedPayload.Builder()
                     .payload(payload)
-                    .ed25519(new Uint256(StrKey.decodeStellarAccountId(accountStrKey)))
+                    .ed25519(new Uint256(StrKey.decodeEd25519PublicKey(accountStrKey)))
                     .build())
             .build();
 

--- a/src/test/java/org/stellar/sdk/TransactionPreconditionsTest.java
+++ b/src/test/java/org/stellar/sdk/TransactionPreconditionsTest.java
@@ -113,7 +113,7 @@ public class TransactionPreconditionsTest {
                     .payload(payload)
                     .ed25519(
                         new Uint256(
-                            StrKey.decodeStellarAccountId(
+                            StrKey.decodeEd25519PublicKey(
                                 "GDW6AUTBXTOC7FIKUO5BOO3OGLK4SF7ZPOBLMQHMZDI45J2Z6VXRB5NR")))
                     .build())
             .build();


### PR DESCRIPTION
Closes #318 

In Soroban, we have many scenarios that require converting strkey into raw data. Making strkey public helps users handle it conveniently.

We will prudently make the following methods public:
- encodeEd25519PublicKey
- decodeEd25519PublicKey
- encodeEd25519SecretSeed
- decodeEd25519SecretSeed
- encodePreAuthTx
- decodePreAuthTx
- encodeSha256Hash
- decodeSha256Hash
- encodeSignedPayload
- decodeSignedPayload
- encodeContract
- decodeContract

In addition, we have modified the names of some functions to be consistent with other SDKs. Since StrKey was not previously public, there will be no destructive updates.
