### PR TITLE
Improve the reliability of `SSEStream`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
   - The `InvokeHostFunctionOperation.createTokenContractOperationBuilder` is now `InvokeHostFunctionOperation.createStellarAssetContractOperationBuilder`.
   - `SorobanDataBuilder.setRefundableFee` is now `setResourceFee`.
   - The RPC endpoint structure has changed, check [#552](https://github.com/stellar/java-stellar-sdk/issues/552) for more details.
-* Improve the reliability of `SSEStream`. Now, it will restart when necessary, and you can get its status through `SSEStream.isStopped()` and `SSEStream.isClosed()`. ([#555](https://github.com/stellar/java-stellar-sdk/pull/555))
+* Improve the reliability of `SSEStream`. Now, it will restart when necessary. ([#555](https://github.com/stellar/java-stellar-sdk/pull/555))
 
 ## 0.41.1
 * Add `org.stellar.sdk.spi.SdkProvider`, users can implement this interface to provide their own implementation of the SDK. We provide an [Android specific implementation](https://github.com/stellar/java-stellar-sdk-android-spi), if you are integrating this SDK into an Android project, be sure to check it out. ([#543](https://github.com/stellar/java-stellar-sdk/pull/543))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
   - The `InvokeHostFunctionOperation.createTokenContractOperationBuilder` is now `InvokeHostFunctionOperation.createStellarAssetContractOperationBuilder`.
   - `SorobanDataBuilder.setRefundableFee` is now `setResourceFee`.
   - The RPC endpoint structure has changed, check [#552](https://github.com/stellar/java-stellar-sdk/issues/552) for more details.
+* Improve the reliability of `SSEStream`. Now, it will restart when necessary, and you can get its status through `SSEStream.isStopped()` and `SSEStream.isClosed()`. ([#555](https://github.com/stellar/java-stellar-sdk/pull/555))
 
 ## 0.41.1
 * Add `org.stellar.sdk.spi.SdkProvider`, users can implement this interface to provide their own implementation of the SDK. We provide an [Android specific implementation](https://github.com/stellar/java-stellar-sdk-android-spi), if you are integrating this SDK into an Android project, be sure to check it out. ([#543](https://github.com/stellar/java-stellar-sdk/pull/543))

--- a/src/main/java/org/stellar/sdk/requests/AccountsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/AccountsRequestBuilder.java
@@ -176,11 +176,19 @@ public class AccountsRequestBuilder extends RequestBuilder {
    * @see <a href="https://developers.stellar.org/api/introduction/response-format/"
    *     target="_blank">Response Format documentation</a>
    * @param listener {@link EventListener} implementation with {@link AccountResponse} type
+   * @param reconnectTimeout Custom stream connection timeout in ms
    * @return EventSource object, so you can <code>close()</code> connection when not needed anymore
    */
-  public SSEStream<AccountResponse> stream(final EventListener<AccountResponse> listener) {
+  public SSEStream<AccountResponse> stream(
+      final EventListener<AccountResponse> listener, long reconnectTimeout) {
+    return SSEStream.create(httpClient, this, AccountResponse.class, listener, reconnectTimeout);
+  }
 
-    return SSEStream.create(httpClient, this, AccountResponse.class, listener);
+  /**
+   * An overloaded version of {@link #stream(EventListener, long)} with default reconnect timeout.
+   */
+  public SSEStream<AccountResponse> stream(final EventListener<AccountResponse> listener) {
+    return stream(listener, SSEStream.DEFAULT_RECONNECT_TIMEOUT);
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/requests/EffectsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/EffectsRequestBuilder.java
@@ -117,10 +117,19 @@ public class EffectsRequestBuilder extends RequestBuilder {
    * @see <a href="https://developers.stellar.org/api/introduction/response-format/"
    *     target="_blank">Response Format documentation</a>
    * @param listener {@link EventListener} implementation with {@link EffectResponse} type
+   * @param reconnectTimeout Custom stream connection timeout in ms
    * @return EventSource object, so you can <code>close()</code> connection when not needed anymore
    */
+  public SSEStream<EffectResponse> stream(
+      final EventListener<EffectResponse> listener, long reconnectTimeout) {
+    return SSEStream.create(httpClient, this, EffectResponse.class, listener, reconnectTimeout);
+  }
+
+  /**
+   * An overloaded version of {@link #stream(EventListener, long)} with default reconnect timeout.
+   */
   public SSEStream<EffectResponse> stream(final EventListener<EffectResponse> listener) {
-    return SSEStream.create(httpClient, this, EffectResponse.class, listener);
+    return stream(listener, SSEStream.DEFAULT_RECONNECT_TIMEOUT);
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/requests/LedgersRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/LedgersRequestBuilder.java
@@ -72,10 +72,19 @@ public class LedgersRequestBuilder extends RequestBuilder {
    * @see <a href="https://developers.stellar.org/api/introduction/response-format/"
    *     target="_blank">Response Format documentation</a>
    * @param listener {@link EventListener} implementation with {@link LedgerResponse} type
+   * @param reconnectTimeout Custom stream connection timeout in ms
    * @return EventSource object, so you can <code>close()</code> connection when not needed anymore
    */
+  public SSEStream<LedgerResponse> stream(
+      final EventListener<LedgerResponse> listener, long reconnectTimeout) {
+    return SSEStream.create(httpClient, this, LedgerResponse.class, listener, reconnectTimeout);
+  }
+
+  /**
+   * An overloaded version of {@link #stream(EventListener, long)} with default reconnect timeout.
+   */
   public SSEStream<LedgerResponse> stream(final EventListener<LedgerResponse> listener) {
-    return SSEStream.create(httpClient, this, LedgerResponse.class, listener);
+    return stream(listener, SSEStream.DEFAULT_RECONNECT_TIMEOUT);
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/requests/LiquidityPoolsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/LiquidityPoolsRequestBuilder.java
@@ -7,8 +7,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.stellar.sdk.LiquidityPoolID;
-import org.stellar.sdk.responses.LiquidityPoolResponse;
-import org.stellar.sdk.responses.Page;
+import org.stellar.sdk.responses.*;
 
 /** Builds requests connected to liquidity pools. */
 public class LiquidityPoolsRequestBuilder extends RequestBuilder {
@@ -116,12 +115,21 @@ public class LiquidityPoolsRequestBuilder extends RequestBuilder {
    * @see <a href="https://developers.stellar.org/api/introduction/response-format/"
    *     target="_blank">Response Format documentation</a>
    * @param listener {@link EventListener} implementation with {@link LiquidityPoolResponse} type
+   * @param reconnectTimeout Custom stream connection timeout in ms
    * @return EventSource object, so you can <code>close()</code> connection when not needed anymore
    */
   public SSEStream<LiquidityPoolResponse> stream(
-      final EventListener<LiquidityPoolResponse> listener) {
+      final EventListener<LiquidityPoolResponse> listener, long reconnectTimeout) {
+    return SSEStream.create(
+        httpClient, this, LiquidityPoolResponse.class, listener, reconnectTimeout);
+  }
 
-    return SSEStream.create(httpClient, this, LiquidityPoolResponse.class, listener);
+  /**
+   * An overloaded version of {@link #stream(EventListener, long)} with default reconnect timeout.
+   */
+  public SSEStream<LiquidityPoolResponse> stream(
+      final EventListener<LiquidityPoolResponse> listener) {
+    return stream(listener, SSEStream.DEFAULT_RECONNECT_TIMEOUT);
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/requests/LiquidityPoolsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/LiquidityPoolsRequestBuilder.java
@@ -7,7 +7,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.stellar.sdk.LiquidityPoolID;
-import org.stellar.sdk.responses.*;
+import org.stellar.sdk.responses.LiquidityPoolResponse;
+import org.stellar.sdk.responses.Page;
 
 /** Builds requests connected to liquidity pools. */
 public class LiquidityPoolsRequestBuilder extends RequestBuilder {
@@ -38,10 +39,10 @@ public class LiquidityPoolsRequestBuilder extends RequestBuilder {
   /**
    * Requests <code>GET /liquidity_pools/{liquidity_pool_id}</code>
    *
-   * @see <a href="https://developers.stellar.org/api/resources/liquiditypools/single/">Liquidity
-   *     Pool Details</a>
    * @param liquidityPoolID Liquidity Pool to fetch
    * @throws IOException
+   * @see <a href="https://developers.stellar.org/api/resources/liquiditypools/single/">Liquidity
+   *     Pool Details</a>
    */
   public LiquidityPoolResponse liquidityPool(String liquidityPoolID) throws IOException {
     this.setSegments("liquidity_pools", liquidityPoolID);
@@ -51,10 +52,10 @@ public class LiquidityPoolsRequestBuilder extends RequestBuilder {
   /**
    * Requests <code>GET /liquidity_pools/{liquidity_pool_id}</code>
    *
-   * @see <a href="https://developers.stellar.org/api/resources/liquiditypools/single/">Liquidity
-   *     Pool Details</a>
    * @param liquidityPoolID Liquidity Pool to fetch
    * @throws IOException
+   * @see <a href="https://developers.stellar.org/api/resources/liquiditypools/single/">Liquidity
+   *     Pool Details</a>
    */
   public LiquidityPoolResponse liquidityPool(LiquidityPoolID liquidityPoolID) throws IOException {
     return this.liquidityPool(liquidityPoolID.toString());
@@ -111,12 +112,12 @@ public class LiquidityPoolsRequestBuilder extends RequestBuilder {
    * streaming mode using Server-Sent Events. This mode will keep the connection to horizon open and
    * horizon will continue to return responses as ledgers close.
    *
-   * @see <a href="http://www.w3.org/TR/eventsource/" target="_blank">Server-Sent Events</a>
-   * @see <a href="https://developers.stellar.org/api/introduction/response-format/"
-   *     target="_blank">Response Format documentation</a>
    * @param listener {@link EventListener} implementation with {@link LiquidityPoolResponse} type
    * @param reconnectTimeout Custom stream connection timeout in ms
    * @return EventSource object, so you can <code>close()</code> connection when not needed anymore
+   * @see <a href="http://www.w3.org/TR/eventsource/" target="_blank">Server-Sent Events</a>
+   * @see <a href="https://developers.stellar.org/api/introduction/response-format/"
+   *     target="_blank">Response Format documentation</a>
    */
   public SSEStream<LiquidityPoolResponse> stream(
       final EventListener<LiquidityPoolResponse> listener, long reconnectTimeout) {

--- a/src/main/java/org/stellar/sdk/requests/OffersRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/OffersRequestBuilder.java
@@ -135,10 +135,19 @@ public class OffersRequestBuilder extends RequestBuilder {
    * @see <a href="https://developers.stellar.org/api/introduction/response-format/"
    *     target="_blank">Response Format documentation</a>
    * @param listener {@link EventListener} implementation with {@link OfferResponse} type
+   * @param reconnectTimeout Custom stream connection timeout in ms
    * @return EventSource object, so you can <code>close()</code> connection when not needed anymore
    */
+  public SSEStream<OfferResponse> stream(
+      final EventListener<OfferResponse> listener, long reconnectTimeout) {
+    return SSEStream.create(httpClient, this, OfferResponse.class, listener, reconnectTimeout);
+  }
+
+  /**
+   * An overloaded version of {@link #stream(EventListener, long)} with default reconnect timeout.
+   */
   public SSEStream<OfferResponse> stream(final EventListener<OfferResponse> listener) {
-    return SSEStream.create(httpClient, this, OfferResponse.class, listener);
+    return stream(listener, SSEStream.DEFAULT_RECONNECT_TIMEOUT);
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/requests/OperationsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/OperationsRequestBuilder.java
@@ -190,10 +190,19 @@ public class OperationsRequestBuilder extends RequestBuilder {
    * @see <a href="https://developers.stellar.org/api/introduction/response-format/"
    *     target="_blank">Response Format documentation</a>
    * @param listener {@link OperationResponse} implementation with {@link OperationResponse} type
+   * @param reconnectTimeout Custom stream connection timeout in ms
    * @return EventSource object, so you can <code>close()</code> connection when not needed anymore
    */
+  public SSEStream<OperationResponse> stream(
+      final EventListener<OperationResponse> listener, long reconnectTimeout) {
+    return SSEStream.create(httpClient, this, OperationResponse.class, listener, reconnectTimeout);
+  }
+
+  /**
+   * An overloaded version of {@link #stream(EventListener, long)} with default reconnect timeout.
+   */
   public SSEStream<OperationResponse> stream(final EventListener<OperationResponse> listener) {
-    return SSEStream.create(httpClient, this, OperationResponse.class, listener);
+    return stream(listener, SSEStream.DEFAULT_RECONNECT_TIMEOUT);
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/requests/OrderBookRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/OrderBookRequestBuilder.java
@@ -57,10 +57,19 @@ public class OrderBookRequestBuilder extends RequestBuilder {
    * @see <a href="https://developers.stellar.org/api/introduction/response-format/"
    *     target="_blank">Response Format documentation</a>
    * @param listener {@link OrderBookResponse} implementation with {@link OrderBookResponse} type
+   * @param reconnectTimeout Custom stream connection timeout in ms
    * @return EventSource object, so you can <code>close()</code> connection when not needed anymore
    */
+  public SSEStream<OrderBookResponse> stream(
+      final EventListener<OrderBookResponse> listener, long reconnectTimeout) {
+    return SSEStream.create(httpClient, this, OrderBookResponse.class, listener, reconnectTimeout);
+  }
+
+  /**
+   * An overloaded version of {@link #stream(EventListener, long)} with default reconnect timeout.
+   */
   public SSEStream<OrderBookResponse> stream(final EventListener<OrderBookResponse> listener) {
-    return SSEStream.create(httpClient, this, OrderBookResponse.class, listener);
+    return stream(listener, SSEStream.DEFAULT_RECONNECT_TIMEOUT);
   }
 
   public OrderBookResponse execute() throws IOException, TooManyRequestsException {

--- a/src/main/java/org/stellar/sdk/requests/PaymentsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/PaymentsRequestBuilder.java
@@ -110,10 +110,19 @@ public class PaymentsRequestBuilder extends RequestBuilder {
    * @see <a href="https://developers.stellar.org/api/introduction/response-format/"
    *     target="_blank">Response Format documentation</a>
    * @param listener {@link EventListener} implementation with {@link OperationResponse} type
+   * @param reconnectTimeout Custom stream connection timeout in ms
    * @return EventSource object, so you can <code>close()</code> connection when not needed anymore
    */
+  public SSEStream<OperationResponse> stream(
+      final EventListener<OperationResponse> listener, long reconnectTimeout) {
+    return SSEStream.create(httpClient, this, OperationResponse.class, listener, reconnectTimeout);
+  }
+
+  /**
+   * An overloaded version of {@link #stream(EventListener, long)} with default reconnect timeout.
+   */
   public SSEStream<OperationResponse> stream(final EventListener<OperationResponse> listener) {
-    return SSEStream.create(httpClient, this, OperationResponse.class, listener);
+    return stream(listener, SSEStream.DEFAULT_RECONNECT_TIMEOUT);
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/requests/SSEStream.java
+++ b/src/main/java/org/stellar/sdk/requests/SSEStream.java
@@ -270,14 +270,4 @@ public class SSEStream<T extends org.stellar.sdk.responses.Response> implements 
       listener.onEvent(event);
     }
   }
-
-  /**
-   * Check if the stream is stopped. Current implementation does not allow to restart the stream if
-   * it was stopped.
-   *
-   * @return true if the stream is stopped.
-   */
-  public boolean isStopped() {
-    return isStopped.get();
-  }
 }

--- a/src/main/java/org/stellar/sdk/requests/SSEStream.java
+++ b/src/main/java/org/stellar/sdk/requests/SSEStream.java
@@ -102,6 +102,7 @@ public class SSEStream<T extends org.stellar.sdk.responses.Response> implements 
 
     // Start a timer to check if the client has not received any event for a long time.
     // If so, we will close the connection and restart it.
+    latestEventTime.set(System.currentTimeMillis());
     clientTimeoutTimer.scheduleAtFixedRate(
         () -> {
           if (System.currentTimeMillis() - latestEventTime.get() > reconnectTimeout) {

--- a/src/main/java/org/stellar/sdk/requests/SSEStream.java
+++ b/src/main/java/org/stellar/sdk/requests/SSEStream.java
@@ -280,14 +280,4 @@ public class SSEStream<T extends org.stellar.sdk.responses.Response> implements 
   public boolean isStopped() {
     return isStopped.get();
   }
-
-  /**
-   * Check if the stream is closed. Current implementation will try to restart the stream if it was
-   * closed.
-   *
-   * @return true if the stream is closed.
-   */
-  public boolean isClosed() {
-    return serverSideClosed.get() || clientSideClosed.get();
-  }
 }

--- a/src/main/java/org/stellar/sdk/requests/SSEStream.java
+++ b/src/main/java/org/stellar/sdk/requests/SSEStream.java
@@ -105,7 +105,7 @@ public class SSEStream<T extends org.stellar.sdk.responses.Response> implements 
     clientTimeoutTimer.scheduleAtFixedRate(
         () -> {
           if (System.currentTimeMillis() - latestEventTime.get() > reconnectTimeout) {
-            this.latestEventTime.set(System.currentTimeMillis());
+            latestEventTime.set(System.currentTimeMillis());
             clientSideClosed.set(true);
           }
         },

--- a/src/main/java/org/stellar/sdk/requests/TradesRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/TradesRequestBuilder.java
@@ -133,9 +133,18 @@ public class TradesRequestBuilder extends RequestBuilder {
    * @see <a href="https://developers.stellar.org/api/introduction/response-format/"
    *     target="_blank">Response Format documentation</a>
    * @param listener {@link EventListener} implementation with {@link TradeResponse} type
+   * @param reconnectTimeout Custom stream connection timeout in ms
    * @return EventSource object, so you can <code>close()</code> connection when not needed anymore
    */
+  public SSEStream<TradeResponse> stream(
+      final EventListener<TradeResponse> listener, long reconnectTimeout) {
+    return SSEStream.create(httpClient, this, TradeResponse.class, listener, reconnectTimeout);
+  }
+
+  /**
+   * An overloaded version of {@link #stream(EventListener, long)} with default reconnect timeout.
+   */
   public SSEStream<TradeResponse> stream(final EventListener<TradeResponse> listener) {
-    return SSEStream.create(httpClient, this, TradeResponse.class, listener);
+    return stream(listener, SSEStream.DEFAULT_RECONNECT_TIMEOUT);
   }
 }

--- a/src/main/java/org/stellar/sdk/requests/TransactionsRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/TransactionsRequestBuilder.java
@@ -149,10 +149,20 @@ public class TransactionsRequestBuilder extends RequestBuilder {
    * @see <a href="https://developers.stellar.org/api/introduction/response-format/"
    *     target="_blank">Response Format documentation</a>
    * @param listener {@link EventListener} implementation with {@link TransactionResponse} type
+   * @param reconnectTimeout Custom stream connection timeout in ms
    * @return EventSource object, so you can <code>close()</code> connection when not needed anymore
    */
+  public SSEStream<TransactionResponse> stream(
+      final EventListener<TransactionResponse> listener, long reconnectTimeout) {
+    return SSEStream.create(
+        httpClient, this, TransactionResponse.class, listener, reconnectTimeout);
+  }
+
+  /**
+   * An overloaded version of {@link #stream(EventListener, long)} with default reconnect timeout.
+   */
   public SSEStream<TransactionResponse> stream(final EventListener<TransactionResponse> listener) {
-    return SSEStream.create(httpClient, this, TransactionResponse.class, listener);
+    return stream(listener, SSEStream.DEFAULT_RECONNECT_TIMEOUT);
   }
 
   /**

--- a/src/test/java/org/stellar/sdk/StreamingSmokeTest.java
+++ b/src/test/java/org/stellar/sdk/StreamingSmokeTest.java
@@ -35,10 +35,8 @@ public class StreamingSmokeTest {
       } catch (InterruptedException e) {
         e.printStackTrace();
       }
-      Assert.assertFalse(manager.isStopped());
 
       manager.close();
-      Assert.assertTrue(manager.isStopped());
 
       int eventCount = events.get();
       Assert.assertTrue(eventCount > 0);

--- a/src/test/java/org/stellar/sdk/StreamingSmokeTest.java
+++ b/src/test/java/org/stellar/sdk/StreamingSmokeTest.java
@@ -7,22 +7,22 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.stellar.sdk.requests.EventListener;
 import org.stellar.sdk.requests.SSEStream;
-import org.stellar.sdk.responses.TradeResponse;
+import org.stellar.sdk.responses.LedgerResponse;
 
 public class StreamingSmokeTest {
 
   @Test
   @Ignore // lets not run this by default for now
-  public void shouldStreamPaymentsFromTestNet() {
+  public void shouldStreamLedgersFromTestNet() {
     final AtomicInteger events = new AtomicInteger();
     Server server = new Server("https://horizon-testnet.stellar.org/");
-    SSEStream<TradeResponse> manager = null;
+    SSEStream<LedgerResponse> manager = null;
     try {
       manager =
-          server.trades().limit(100).stream(
-              new EventListener<TradeResponse>() {
+          server.ledgers().limit(100).stream(
+              new EventListener<LedgerResponse>() {
                 @Override
-                public void onEvent(TradeResponse r) {
+                public void onEvent(LedgerResponse r) {
                   events.incrementAndGet();
                 }
 
@@ -35,7 +35,12 @@ public class StreamingSmokeTest {
       } catch (InterruptedException e) {
         e.printStackTrace();
       }
+      Assert.assertFalse(manager.isStopped());
+      Assert.assertFalse(manager.isClosed());
+
       manager.close();
+      Assert.assertTrue(manager.isStopped());
+
       int eventCount = events.get();
       Assert.assertTrue(eventCount > 0);
 

--- a/src/test/java/org/stellar/sdk/StreamingSmokeTest.java
+++ b/src/test/java/org/stellar/sdk/StreamingSmokeTest.java
@@ -36,7 +36,6 @@ public class StreamingSmokeTest {
         e.printStackTrace();
       }
       Assert.assertFalse(manager.isStopped());
-      Assert.assertFalse(manager.isClosed());
 
       manager.close();
       Assert.assertTrue(manager.isStopped());


### PR DESCRIPTION
fix #463, fix #432, fix #210.

Restart SSE to improve reliability if no new messages are received within the timeout period.