### PR TITLE
Remove deprecated classes and methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,13 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
   | GetLatestLedgerResponse.protocolVersion | Integer | Long |
 
 * The following classes and methods have been marked as deprecated in previous releases, and now they have been removed. ([#565](https://github.com/stellar/java-stellar-sdk/pull/565))
-  * `AccountResponse.Signer#getAccountId()`
-  * `OffersRequestBuilder#forAccount(String)`
-  * `RootResponse#getGrotocolVersion()`
-  * `SetOptionsOperationResponse#getSigner()`
-  * `Transaction.Builder`
-  * `TransactionBuilder#buildTimeBounds(long, long)`
+  * `AccountResponse.Signer#getAccountId()` has been removed, use `AccountResponse.Signer#getKey()` instead.
+  * `OffersRequestBuilder#forAccount(String)` has been removed, use `OffersRequestBuilder#forSeller(String)` instead.
+  * `RootResponse#getProtocolVersion()` has been removed, use `RootResponse#getCurrentProtocolVersion()` instead.
+  * `SetOptionsOperationResponse#getSigner()` has been removed, use `SetOptionsOperationResponse#getSignerKey()` instead.
+  * `Transaction.Builder` has been removed, use `TransactionBuilder` instead.
+  * `TransactionBuilder#buildTimeBounds(long, long)` has been removed, use `TimeBounds#TimeBounds(long, long)` instead.
+  * `TransactionBuilder#addTimeBounds(TimeBounds)` has been removed, use `TransactionBuilder#addPreconditions(TransactionPreconditions)` instead.
 
 ## 0.42.0
 * Make `StrKey` public, this allows users to conveniently encode and decode Stellar keys to/from strings. ([#548](https://github.com/stellar/java-stellar-sdk/pull/548))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 ### Update
 * Support resource leeway parameter when simulating Soroban transactions. ([#561](https://github.com/stellar/java-stellar-sdk/pull/561))
+* Remove deprecated classes and methods. ([#565](https://github.com/stellar/java-stellar-sdk/pull/565))
+
 ### Breaking changes
 * The types of the following fields have changed. ([#560](https://github.com/stellar/java-stellar-sdk/pull/560))
   | field                                   | before  | now  |
@@ -13,6 +15,14 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
   | GetEventsRequest.startLedger            | String  | Long |
   | GetEventsResponse.EventInfo.ledger      | Integer | Long |
   | GetLatestLedgerResponse.protocolVersion | Integer | Long |
+
+* The following classes and methods have been marked as deprecated in previous releases, and now they have been removed. ([#565](https://github.com/stellar/java-stellar-sdk/pull/565))
+  * `AccountResponse.Signer#getAccountId()`
+  * `OffersRequestBuilder#forAccount(String)`
+  * `RootResponse#getGrotocolVersion()`
+  * `SetOptionsOperationResponse#getSigner()`
+  * `Transaction.Builder`
+  * `TransactionBuilder#buildTimeBounds(long, long)`
 
 ## 0.42.0
 * Make `StrKey` public, this allows users to conveniently encode and decode Stellar keys to/from strings. ([#548](https://github.com/stellar/java-stellar-sdk/pull/548))

--- a/src/main/java/org/stellar/sdk/Sep10Challenge.java
+++ b/src/main/java/org/stellar/sdk/Sep10Challenge.java
@@ -114,7 +114,7 @@ public class Sep10Challenge {
 
     TransactionBuilder builder =
         new TransactionBuilder(AccountConverter.enableMuxed(), sourceAccount, network)
-            .addTimeBounds(timebounds)
+            .addPreconditions(TransactionPreconditions.builder().timeBounds(timebounds).build())
             .setBaseFee(100)
             .addOperation(domainNameOperation)
             .addOperation(webAuthDomainOperation);

--- a/src/main/java/org/stellar/sdk/Transaction.java
+++ b/src/main/java/org/stellar/sdk/Transaction.java
@@ -314,25 +314,6 @@ public class Transaction extends AbstractTransaction {
   }
 
   /**
-   * Maintain backwards compatibility references to Transaction.Builder
-   *
-   * @deprecated will be removed in upcoming releases. Use <code>TransactionBuilder</code> instead.
-   * @see org.stellar.sdk.TransactionBuilder
-   */
-  public static class Builder extends TransactionBuilder {
-    public Builder(
-        AccountConverter accountConverter,
-        TransactionBuilderAccount sourceAccount,
-        Network network) {
-      super(accountConverter, sourceAccount, network);
-    }
-
-    public Builder(TransactionBuilderAccount sourceAccount, Network network) {
-      super(sourceAccount, network);
-    }
-  }
-
-  /**
    * Returns true if this transaction is a Soroban transaction.
    *
    * @return true if this transaction is a Soroban transaction.

--- a/src/main/java/org/stellar/sdk/TransactionBuilder.java
+++ b/src/main/java/org/stellar/sdk/TransactionBuilder.java
@@ -10,9 +10,6 @@ import java.util.function.Function;
 import lombok.NonNull;
 import org.stellar.sdk.TransactionPreconditions.TransactionPreconditionsBuilder;
 import org.stellar.sdk.xdr.SorobanTransactionData;
-import org.stellar.sdk.xdr.TimePoint;
-import org.stellar.sdk.xdr.Uint64;
-import org.stellar.sdk.xdr.XdrUnsignedHyperInteger;
 
 /** Builds a new Transaction object. */
 public class TransactionBuilder {
@@ -122,8 +119,6 @@ public class TransactionBuilder {
    * @param timeBounds tx can be accepted within this time bound range
    * @return Builder object so you can chain methods.
    * @see TimeBounds
-   * @deprecated this method will be removed in upcoming releases, use <code>addPreconditions()
-   *     </code> instead for more control over preconditions.
    */
   public TransactionBuilder addTimeBounds(@NonNull TimeBounds timeBounds) {
     if (preconditions.getTimeBounds() != null) {
@@ -142,7 +137,7 @@ public class TransactionBuilder {
    * setTimeout</code> does internally; if there's <code>minTime</code> set but no <code>maxTime
    * </code> it will be added). Call to <code>Builder.setTimeout</code> is required if Transaction
    * does not have <code>max_time</code> set. If you don't want to set timeout, use <code>
-   * TIMEOUT_INFINITE</code>. In general you should set <code>TIMEOUT_INFINITE</code> only in smart
+   * TIMEOUT_INFINITE</code>. In general, you should set <code>TIMEOUT_INFINITE</code> only in smart
    * contracts. Please note that Horizon may still return <code>504 Gateway Timeout</code> error,
    * even for short timeouts. In such case you need to resubmit the same transaction again without
    * making any changes to receive a status. This method is using the machine system time (UTC),
@@ -151,11 +146,7 @@ public class TransactionBuilder {
    * @param timeout Timeout in seconds.
    * @return updated Builder
    * @see TimeBounds
-   * @deprecated this method will be removed in upcoming releases, use <code>addPreconditions()
-   *     </code> with TimeBound set instead for more control over preconditions.
    */
-  // TODO: timebounds is the most commonly used precondition, I think
-  //  we can keep this function and not mark it as deprecated?
   public TransactionBuilder setTimeout(BigInteger timeout) {
     if (preconditions.getTimeBounds() != null
         && !TIMEOUT_INFINITE.equals(preconditions.getTimeBounds().getMaxTime())) {
@@ -188,8 +179,6 @@ public class TransactionBuilder {
    *
    * @param timeout Timeout in seconds.
    * @return updated Builder
-   * @deprecated this method will be removed in upcoming releases, use <code>addPreconditions()
-   *     </code> with TimeBound set instead for more control over preconditions.
    */
   public TransactionBuilder setTimeout(long timeout) {
     return setTimeout(BigInteger.valueOf(timeout));
@@ -247,14 +236,6 @@ public class TransactionBuilder {
    */
   public static Function<TransactionBuilderAccount, Long> IncrementedSequenceNumberFunc =
       TransactionBuilderAccount::getIncrementedSequenceNumber;
-
-  @Deprecated
-  public static org.stellar.sdk.xdr.TimeBounds buildTimeBounds(long minTime, long maxTime) {
-    return new org.stellar.sdk.xdr.TimeBounds.Builder()
-        .minTime(new TimePoint(new Uint64(new XdrUnsignedHyperInteger(minTime))))
-        .maxTime(new TimePoint(new Uint64(new XdrUnsignedHyperInteger(maxTime))))
-        .build();
-  }
 
   /**
    * Sets the transaction's internal Soroban transaction data (resources, footprint, etc.).

--- a/src/main/java/org/stellar/sdk/requests/OffersRequestBuilder.java
+++ b/src/main/java/org/stellar/sdk/requests/OffersRequestBuilder.java
@@ -2,7 +2,6 @@ package org.stellar.sdk.requests;
 
 import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
-import lombok.NonNull;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -45,19 +44,6 @@ public class OffersRequestBuilder extends RequestBuilder {
   public OfferResponse offer(long offerId) throws IOException {
     this.setSegments("offers", String.valueOf(offerId));
     return this.offer(this.buildUri());
-  }
-
-  /**
-   * @param account Account for which to get offers
-   * @see <a href="https://developers.stellar.org/api/resources/accounts/offers/">Offers for
-   *     Account</a>
-   * @deprecated Use {@link OffersRequestBuilder#forSeller} Builds request to <code>
-   *     GET /accounts/{account}/offers</code>
-   */
-  @Deprecated
-  public OffersRequestBuilder forAccount(@NonNull String account) {
-    this.setSegments("accounts", account, "offers");
-    return this;
   }
 
   /**

--- a/src/main/java/org/stellar/sdk/responses/AccountResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/AccountResponse.java
@@ -271,16 +271,6 @@ public class AccountResponse extends Response implements org.stellar.sdk.Transac
     @SerializedName("sponsor")
     String sponsor;
 
-    /**
-     * TODO: remove this method
-     *
-     * @deprecated Use {@link Signer#getKey()}
-     * @return
-     */
-    public String getAccountId() {
-      return key;
-    }
-
     public Optional<String> getSponsor() {
       return Optional.ofNullable(this.sponsor);
     }

--- a/src/main/java/org/stellar/sdk/responses/RootResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/RootResponse.java
@@ -30,12 +30,6 @@ public class RootResponse extends Response {
   @SerializedName("network_passphrase")
   String networkPassphrase;
 
-  /**
-   * @deprecated Will be removed in Horizon 0.17.0
-   */
-  @SerializedName("protocol_version")
-  int protocolVersion;
-
   @SerializedName("current_protocol_version")
   int currentProtocolVersion;
 

--- a/src/main/java/org/stellar/sdk/responses/operations/AllowTrustOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/AllowTrustOperationResponse.java
@@ -46,7 +46,6 @@ public class AllowTrustOperationResponse extends OperationResponse {
   @SerializedName("authorize")
   boolean authorize;
 
-  // TODO: fix, is_authorized_to_maintain_liabilities
   @SerializedName("authorize_to_maintain_liabilities")
   boolean authorizeToMaintainLiabilities;
 

--- a/src/main/java/org/stellar/sdk/responses/operations/SetOptionsOperationResponse.java
+++ b/src/main/java/org/stellar/sdk/responses/operations/SetOptionsOperationResponse.java
@@ -3,7 +3,6 @@ package org.stellar.sdk.responses.operations;
 import com.google.gson.annotations.SerializedName;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.stellar.sdk.KeyPair;
 
 /**
  * Represents SetOptions operation response.
@@ -67,13 +66,5 @@ public class SetOptionsOperationResponse extends OperationResponse {
     this.masterKeyWeight = masterKeyWeight;
     this.clearFlags = clearFlags;
     this.setFlags = setFlags;
-  }
-
-  /**
-   * @deprecated Use {@link SetOptionsOperationResponse#getSignerKey()}
-   * @return
-   */
-  public KeyPair getSigner() {
-    return KeyPair.fromAccountId(signerKey);
   }
 }

--- a/src/test/java/org/stellar/sdk/FeeBumpTransactionTest.java
+++ b/src/test/java/org/stellar/sdk/FeeBumpTransactionTest.java
@@ -24,7 +24,8 @@ public class FeeBumpTransactionTest {
                         "200")
                     .build())
             .setBaseFee(baseFee)
-            .addTimeBounds(new TimeBounds(10, 11))
+            .addPreconditions(
+                TransactionPreconditions.builder().timeBounds(new TimeBounds(10, 11)).build())
             .build();
 
     inner.sign(source);

--- a/src/test/java/org/stellar/sdk/requests/OffersRequestBuilderTest.java
+++ b/src/test/java/org/stellar/sdk/requests/OffersRequestBuilderTest.java
@@ -43,21 +43,6 @@ public class OffersRequestBuilderTest {
           + "}";
 
   @Test
-  public void testForAccount() {
-    Server server = new Server("https://horizon-testnet.stellar.org");
-    HttpUrl uri =
-        server
-            .offers()
-            .forAccount("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
-            .limit(200)
-            .order(RequestBuilder.Order.DESC)
-            .buildUri();
-    assertEquals(
-        "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H/offers?limit=200&order=desc",
-        uri.toString());
-  }
-
-  @Test
   public void testWithoutParams() {
     Server server = new Server("https://horizon-testnet.stellar.org");
     HttpUrl uri = server.offers().buildUri();

--- a/src/test/java/org/stellar/sdk/responses/AccountDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/AccountDeserializerTest.java
@@ -90,7 +90,7 @@ public class AccountDeserializerTest extends TestCase {
     assertFalse(account.getBalances()[1].getSponsor().isPresent());
 
     assertEquals(
-        account.getSigners()[0].getAccountId(),
+        account.getSigners()[0].getKey(),
         "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7");
     assertEquals(account.getSigners()[0].getWeight(), 0);
     assertEquals(account.getSigners()[0].getType(), "ed25519_public_key");

--- a/src/test/java/org/stellar/sdk/responses/OperationDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/OperationDeserializerTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.stellar.sdk.AssetAmount;
 import org.stellar.sdk.AssetTypeNative;
 import org.stellar.sdk.AssetTypePoolShare;
-import org.stellar.sdk.FormatException;
 import org.stellar.sdk.Predicate;
 import org.stellar.sdk.Price;
 import org.stellar.sdk.responses.operations.AccountMergeOperationResponse;
@@ -690,8 +689,7 @@ public class OperationDeserializerTest extends TestCase {
             GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
 
     assertEquals(
-        operation.getSigner().getAccountId(),
-        "GD3ZYXVC7C3ECD5I4E5NGPBFJJSULJ6HJI2FBHGKYFV34DSIWB4YEKJZ");
+        operation.getSignerKey(), "GD3ZYXVC7C3ECD5I4E5NGPBFJJSULJ6HJI2FBHGKYFV34DSIWB4YEKJZ");
     assertEquals(
         operation.getSignerKey(), "GD3ZYXVC7C3ECD5I4E5NGPBFJJSULJ6HJI2FBHGKYFV34DSIWB4YEKJZ");
     assertEquals(operation.getSignerWeight(), new Integer(1));
@@ -705,52 +703,6 @@ public class OperationDeserializerTest extends TestCase {
     assertEquals(operation.getMasterKeyWeight(), new Integer(4));
     assertEquals(operation.getSetFlags()[0], "auth_required_flag");
     assertEquals(operation.getClearFlags()[0], "auth_revocable_flag");
-  }
-
-  @Test
-  public void testDeserializeSetOptionsOperationWithNonEd25519Key() {
-    String json =
-        "{\n"
-            + "        \"_links\": {\n"
-            + "          \"self\": {\n"
-            + "            \"href\": \"https://horizon-testnet.stellar.org/operations/44921793093312513\"\n"
-            + "          },\n"
-            + "          \"transaction\": {\n"
-            + "            \"href\": \"https://horizon-testnet.stellar.org/transactions/d991075183f7740e1aa43700b824f2f404082632f1db9d8a54db00574f83393b\"\n"
-            + "          },\n"
-            + "          \"effects\": {\n"
-            + "            \"href\": \"https://horizon-testnet.stellar.org/operations/44921793093312513/effects\"\n"
-            + "          },\n"
-            + "          \"succeeds\": {\n"
-            + "            \"href\": \"https://horizon-testnet.stellar.org/effects?order=desc\\u0026cursor=44921793093312513\"\n"
-            + "          },\n"
-            + "          \"precedes\": {\n"
-            + "            \"href\": \"https://horizon-testnet.stellar.org/effects?order=asc\\u0026cursor=44921793093312513\"\n"
-            + "          }\n"
-            + "        },\n"
-            + "        \"id\": \"44921793093312513\",\n"
-            + "        \"paging_token\": \"44921793093312513\",\n"
-            + "        \"source_account\": \"GCWYUHCMWC2AATGAXXYZX7T45QZLTRCYNJDD3PC73NEMUXBOCO5F6T6Z\",\n"
-            + "        \"type\": \"set_options\",\n"
-            + "        \"type_i\": 5,\n"
-            + "        \"created_at\": \"2018-08-09T15:36:24Z\",\n"
-            + "        \"transaction_hash\": \"d991075183f7740e1aa43700b824f2f404082632f1db9d8a54db00574f83393b\",\n"
-            + "        \"signer_key\": \"TBGFYVCU76LJ7GZOCGR4X7DG2NV42JPG5CKRL42LA5FZOFI3U2WU7ZAL\",\n"
-            + "        \"signer_weight\": 1\n"
-            + "      }";
-
-    SetOptionsOperationResponse operation =
-        (SetOptionsOperationResponse)
-            GsonSingleton.getInstance().fromJson(json, OperationResponse.class);
-
-    try {
-      operation.getSigner();
-      fail();
-    } catch (FormatException e) {
-      assertEquals("Version byte is invalid", e.getMessage());
-    }
-    assertEquals(
-        operation.getSignerKey(), "TBGFYVCU76LJ7GZOCGR4X7DG2NV42JPG5CKRL42LA5FZOFI3U2WU7ZAL");
   }
 
   @Test

--- a/src/test/java/org/stellar/sdk/responses/RootDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/RootDeserializerTest.java
@@ -16,7 +16,6 @@ public class RootDeserializerTest extends TestCase {
     assertEquals(root.getHistoryElderLedger(), 1);
     assertEquals(root.getCoreLatestLedger(), 18369117);
     assertEquals(root.getNetworkPassphrase(), "Public Global Stellar Network ; September 2015");
-    assertEquals(root.getProtocolVersion(), 9);
     assertEquals(root.getCurrentProtocolVersion(), 10);
     assertEquals(root.getCoreSupportedProtocolVersion(), 11);
   }


### PR DESCRIPTION
The following classes and methods have been marked as deprecated in previous releases, and now they have been removed
  * `AccountResponse.Signer#getAccountId()` has been removed, use `AccountResponse.Signer#getKey()` instead.
  * `OffersRequestBuilder#forAccount(String)` has been removed, use `OffersRequestBuilder#forSeller(String)` instead.
  * `RootResponse#getProtocolVersion()` has been removed, use `RootResponse#getCurrentProtocolVersion()` instead.
  * `SetOptionsOperationResponse#getSigner()` has been removed, use `SetOptionsOperationResponse#getSignerKey()` instead.
  * `Transaction.Builder` has been removed, use `TransactionBuilder` instead.
  * `TransactionBuilder#buildTimeBounds(long, long)` has been removed, use `TimeBounds#TimeBounds(long, long)` instead.
  * `TransactionBuilder#addTimeBounds(TimeBounds)` has been removed, use `TransactionBuilder#addPreconditions(TransactionPreconditions)` instead.